### PR TITLE
Add custom input directory flags to v2d_bundlesdf 

### DIFF
--- a/reconstruction/modules/v2d_bundlesdf/README.md
+++ b/reconstruction/modules/v2d_bundlesdf/README.md
@@ -1,0 +1,82 @@
+# v2d_bundlesdf
+
+BundleSDF SDF training and texture baking from pre-computed poses, depth, and masks.
+
+## Usage
+
+Run from `reconstruction/`:
+
+```bash
+python modules/v2d_bundlesdf/docker/run_reconstruct.py \
+  --output_path data/outputs/bundlesdf/my_object \
+  --weights_dir data/weights
+```
+
+By default, `output_path` must contain:
+
+```
+output_path/
+├── keyframes.yml       # camera poses (YAML)
+├── left/               # RGB images
+├── depth/              # depth maps (one per keyframe)
+├── masks/              # object masks (one per keyframe)
+└── calibration.json    # camera intrinsics (optional)
+```
+
+### Custom input directories
+
+Use these flags to point directly to existing directories/files instead of
+relying on the default folder structure:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--images_dir` | `<output_path>/left/` | RGB images directory |
+| `--depth_dir` | `<output_path>/depth/` | Depth maps directory |
+| `--masks_dir` | `<output_path>/masks/` | Object masks directory |
+| `--poses_file` | `<output_path>/keyframes.yml` | Camera poses YAML file |
+| `--intrinsics_file` | `<output_path>/calibration.json` | Camera intrinsics JSON file |
+
+Example:
+
+```bash
+python modules/v2d_bundlesdf/docker/run_reconstruct.py \
+  --output_path  data/outputs/bundlesdf/my_object \
+  --weights_dir  data/weights \
+  --images_dir   /data/raw/my_object/images \
+  --depth_dir    /data/raw/my_object/depth \
+  --masks_dir    /data/raw/my_object/masks \
+  --poses_file   /data/raw/my_object/keyframes.yml \
+  --intrinsics_file /data/raw/my_object/calibration.json
+```
+
+When custom paths are provided, symlinks are created inside `output_path` pointing
+to those locations so BundleSDF can find them without copying data.
+
+### Other flags
+
+| Flag | Description |
+|------|-------------|
+| `--config` | NeRF/SDF config YAML (uses container default if omitted) |
+| `--bbox_str` | Bounding box `x1,y1,x2,y2` (informational only) |
+| `--skip-texture` | Skip texture baking; produce untextured mesh only |
+| `--skip-sdf` | Skip SDF training; reuse existing `model_latest.pth` |
+| `--gpu_id` | GPU index to use |
+| `--dev` | Mount local modules for development |
+
+## Outputs
+
+Results are written to `output_path/`:
+
+| File | Description |
+|------|-------------|
+| `textured_mesh.obj` | Final textured mesh (+ `.mtl`, `_0.png` atlas) |
+| `mesh_cleaned.obj` | Untextured SDF mesh |
+| `model_latest.pth` | Saved SDF model (reusable with `--skip-sdf`) |
+| `run_time.yaml` | Timing breakdown |
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `tools/visualize_reconstruction_standalone.py` | Visualize camera trajectory and point cloud |
+| `tools/fuse_depth_to_pointcloud.py` | Fuse depth maps into a point cloud |

--- a/reconstruction/modules/v2d_bundlesdf/docker/run_reconstruct.py
+++ b/reconstruction/modules/v2d_bundlesdf/docker/run_reconstruct.py
@@ -1,11 +1,15 @@
 """
 Run BundleSDF SDF training and texture baking with pre-computed depth and masks.
 
-Expects the output directory to already contain:
+By default, expects the output directory to already contain:
   - keyframes.yml   (pre-computed camera poses)
   - left/           (RGB images)
   - depth/          (depth maps — one per keyframe)
   - masks/          (object masks — one per keyframe)
+
+Custom input paths can be supplied directly via optional arguments to avoid
+relying on a specific folder structure:
+  --images_dir, --depth_dir, --masks_dir, --poses_file, --intrinsics_file
 
 Outputs:
   <output_path>/textured_mesh.obj  — final textured mesh
@@ -30,10 +34,25 @@ def run_reconstruct(
     skip_sdf: bool = False,
     gpu_id: int = None,
     dev: bool = False,
+    images_dir: str = None,
+    depth_dir: str = None,
+    masks_dir: str = None,
+    poses_file: str = None,
+    intrinsics_file: str = None,
 ) -> None:
     inputs = {"weights_dir": weights_dir}
     if config:
         inputs["config"] = config
+    if images_dir:
+        inputs["images_dir"] = images_dir
+    if depth_dir:
+        inputs["depth_dir"] = depth_dir
+    if masks_dir:
+        inputs["masks_dir"] = masks_dir
+    if poses_file:
+        inputs["poses_file"] = poses_file
+    if intrinsics_file:
+        inputs["intrinsics_file"] = intrinsics_file
 
     extra = {}
     if bbox_str:
@@ -62,14 +81,19 @@ def run_reconstruct(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run BundleSDF SDF training and texture baking")
-    parser.add_argument("--output_path",     required=True, help="Directory containing keyframes.yml, left/, depth/, masks/")
-    parser.add_argument("--weights_dir",     required=True, help="Root weights directory (roma/ subdirs)")
-    parser.add_argument("--config",          default=None,  help="NeRF config YAML path (host-side)")
-    parser.add_argument("--bbox_str",        default=None,  help="Bounding box 'x1,y1,x2,y2' (informational only)")
-    parser.add_argument("--skip-texture",    action="store_true", help="Skip texture baking")
-    parser.add_argument("--skip-sdf",        action="store_true", help="Skip SDF training; reuse existing model_latest.pth")
-    parser.add_argument("--gpu_id",          type=int, default=None)
-    parser.add_argument("--dev",             action="store_true", help="Mount local modules for development")
+    parser.add_argument("--output_path",      required=True, help="Output directory for mesh results")
+    parser.add_argument("--weights_dir",      required=True, help="Root weights directory (roma/ subdirs)")
+    parser.add_argument("--config",           default=None,  help="NeRF config YAML path (host-side)")
+    parser.add_argument("--bbox_str",         default=None,  help="Bounding box 'x1,y1,x2,y2' (informational only)")
+    parser.add_argument("--skip-texture",     action="store_true", help="Skip texture baking")
+    parser.add_argument("--skip-sdf",         action="store_true", help="Skip SDF training; reuse existing model_latest.pth")
+    parser.add_argument("--gpu_id",           type=int, default=None)
+    parser.add_argument("--dev",              action="store_true", help="Mount local modules for development")
+    parser.add_argument("--images_dir",       default=None, help="RGB images directory (default: <output_path>/left/)")
+    parser.add_argument("--depth_dir",        default=None, help="Depth maps directory (default: <output_path>/depth/)")
+    parser.add_argument("--masks_dir",        default=None, help="Object masks directory (default: <output_path>/masks/)")
+    parser.add_argument("--poses_file",       default=None, help="Camera poses YAML file (default: <output_path>/keyframes.yml)")
+    parser.add_argument("--intrinsics_file",  default=None, help="Camera intrinsics JSON file (default: <output_path>/calibration.json)")
     args = parser.parse_args()
     run_reconstruct(
         output_path=args.output_path,
@@ -80,4 +104,9 @@ if __name__ == "__main__":
         skip_sdf=args.skip_sdf,
         gpu_id=args.gpu_id,
         dev=args.dev,
+        images_dir=args.images_dir,
+        depth_dir=args.depth_dir,
+        masks_dir=args.masks_dir,
+        poses_file=args.poses_file,
+        intrinsics_file=args.intrinsics_file,
     )

--- a/reconstruction/modules/v2d_bundlesdf/lib/reconstruct.py
+++ b/reconstruction/modules/v2d_bundlesdf/lib/reconstruct.py
@@ -2,13 +2,14 @@
 """
 Run BundleSDF reconstruction with pre-computed camera poses.
 
-Expects the output directory to already contain:
-  - keyframes.yml  (pre-computed camera poses)
-  - left/          (RGB images)
-  - depth/         (depth maps — one per keyframe)
-  - masks/         (object masks — one per keyframe)
+Expects the output directory to already contain (or have custom paths supplied):
+  - keyframes.yml  (pre-computed camera poses)    override with --poses_file
+  - left/          (RGB images)                   override with --images_dir
+  - depth/         (depth maps — one per keyframe) override with --depth_dir
+  - masks/         (object masks — one per keyframe) override with --masks_dir
+  - calibration.json (camera intrinsics)          override with --intrinsics_file
 
-Outputs written to the same directory:
+Outputs written to output_path:
   - mesh_cleaned.obj    untextured SDF mesh
   - textured_mesh.obj   textured mesh (+ .mtl, _0.png atlas)
   - model_latest.pth    saved SDF model
@@ -17,6 +18,16 @@ Usage:
   python reconstruct.py \\
     --output_path /path/to/recon_dir \\
     --weights_dir /path/to/weights
+
+  # With custom input directories:
+  python reconstruct.py \\
+    --output_path /path/to/recon_dir \\
+    --weights_dir /path/to/weights \\
+    --images_dir /path/to/images \\
+    --depth_dir /path/to/depth \\
+    --masks_dir /path/to/masks \\
+    --poses_file /path/to/keyframes.yml \\
+    --intrinsics_file /path/to/calibration.json
 """
 
 import argparse
@@ -127,6 +138,53 @@ def _subsample_keyframes_for_texture(
         yaml.dump({k: keyframes[k] for k in selected}, f)
 
 
+def setup_input_dirs(
+    output_path: Path,
+    images_dir: str = None,
+    depth_dir: str = None,
+    masks_dir: str = None,
+    poses_file: str = None,
+    intrinsics_file: str = None,
+) -> None:
+    """Symlink custom input dirs/files into the expected output_path structure."""
+    import shutil
+
+    def _link(src: str, dst: Path, is_dir: bool) -> None:
+        if src is None:
+            return
+        # Resolve src — if it raises OSError (e.g. symlink loop caused by
+        # Docker mounting the same host directory at two container paths),
+        # the data is already accessible at dst, so skip.
+        try:
+            src_path = Path(src).resolve(strict=True)
+        except OSError:
+            if dst.is_symlink():
+                dst.unlink()  # remove the looping symlink so validate_inputs sees real data
+            return
+        # Skip if dst is already the same filesystem object as src.
+        if dst.exists() or dst.is_symlink():
+            try:
+                if os.path.samefile(dst, src_path):
+                    return
+            except (OSError, ValueError):
+                pass
+            # Only remove symlinks — never delete real directories/files.
+            if dst.is_symlink():
+                dst.unlink()
+            else:
+                raise FileExistsError(
+                    f"Cannot create symlink at {dst}: a real file/directory already exists. "
+                    f"Remove it manually or do not pass --{'images_dir' if is_dir else 'poses_file'}."
+                )
+        dst.symlink_to(src_path)
+
+    _link(images_dir,      output_path / "left",           is_dir=True)
+    _link(depth_dir,       output_path / "depth",          is_dir=True)
+    _link(masks_dir,       output_path / "masks",          is_dir=True)
+    _link(poses_file,      output_path / "keyframes.yml",  is_dir=False)
+    _link(intrinsics_file, output_path / "calibration.json", is_dir=False)
+
+
 def validate_inputs(output_path: Path) -> None:
     """Validate that the output directory has required pre-computed inputs."""
     if not output_path.exists():
@@ -154,7 +212,7 @@ def main():
         description="BundleSDF reconstruction with pre-computed poses, depth, and masks",
     )
     parser.add_argument("--output_path", "--output-path", dest="output_path", required=True,
-                        help="Directory containing keyframes.yml, left/, depth/, masks/")
+                        help="Output directory for mesh results")
     parser.add_argument("--config", default=_DEFAULT_CONFIG,
                         help=f"NeRF/SDF config YAML (default: {_DEFAULT_CONFIG})")
     parser.add_argument("--weights_dir", default=None,
@@ -165,6 +223,16 @@ def main():
                         help="Skip texture baking (faster; produces untextured mesh only)")
     parser.add_argument("--skip-sdf", action="store_true",
                         help="Skip SDF training; reuse existing model_latest.pth and run texture baking only")
+    parser.add_argument("--images_dir", default=None,
+                        help="Directory of RGB images (default: <output_path>/left/)")
+    parser.add_argument("--depth_dir", default=None,
+                        help="Directory of depth maps (default: <output_path>/depth/)")
+    parser.add_argument("--masks_dir", default=None,
+                        help="Directory of object masks (default: <output_path>/masks/)")
+    parser.add_argument("--poses_file", default=None,
+                        help="Camera poses YAML file (default: <output_path>/keyframes.yml)")
+    parser.add_argument("--intrinsics_file", default=None,
+                        help="Camera intrinsics JSON file (default: <output_path>/calibration.json)")
     parser.add_argument("--verbose", "-v", action="store_true")
     args = parser.parse_args()
 
@@ -176,6 +244,15 @@ def main():
 
     try:
         output_path = Path(args.output_path)
+        output_path.mkdir(parents=True, exist_ok=True)
+        setup_input_dirs(
+            output_path,
+            images_dir=args.images_dir,
+            depth_dir=args.depth_dir,
+            masks_dir=args.masks_dir,
+            poses_file=args.poses_file,
+            intrinsics_file=args.intrinsics_file,
+        )
         validate_inputs(output_path)
 
         config = {}

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/README.md
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/README.md
@@ -33,8 +33,7 @@ Run on the included example data (from `reconstruction/`):
 python modules/v2d_hoi_object_reconstruction/docker/run_reconstruction.py \
   --mapping_data_dir modules/v2d_hoi_object_reconstruction/assets/basketball_example \
   --job_dir          data/outputs/hoi_recon/basketball_example \
-  --prompt           "basketball" \
-  --config           modules/v2d_hoi_object_reconstruction/lib/data/configs/theseus_optimizer_hawk.yaml
+  --prompt           "basketball"
 ```
 
 Or on your own data:


### PR DESCRIPTION
- Add `--images_dir`, `--depth_dir`, `--masks_dir`, `--poses_file`, `--intrinsics_file` optional flags to `v2d_bundlesdf`, allowing users to specify input paths directly instead of relying on a fixed folder structure under `output_path`                                                  
- Fix incorrect `--config` path in `v2d_hoi_object_reconstruction` Quick Start example         
- Add `v2d_bundlesdf/README.md` documenting standalone usage and new flags 