### PR TITLE
Add v2d_ego_hand_reconstruction module

### DIFF
--- a/reconstruction/modules/v2d_ego_hand_reconstruction/.gitignore
+++ b/reconstruction/modules/v2d_ego_hand_reconstruction/.gitignore
@@ -1,0 +1,5 @@
+*
+!.gitignore
+!sync.sh
+!README.md
+

--- a/reconstruction/modules/v2d_ego_hand_reconstruction/README.md
+++ b/reconstruction/modules/v2d_ego_hand_reconstruction/README.md
@@ -1,0 +1,16 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Egocentric Hand Reconstruction
+
+Automated pipeline for 4D hand and camera pose reconstruction from egocentric videos. Integrates ViPE and Dyn-HaMR in containerized environments.
+
+Get the vendored sources:
+
+```bash
+./sync.sh
+```
+
+Then follow the quick start guide in [`doc/quickstart.md`](doc/quickstart.md).

--- a/reconstruction/modules/v2d_ego_hand_reconstruction/sync.sh
+++ b/reconstruction/modules/v2d_ego_hand_reconstruction/sync.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO="https://github.com/NVIDIA/IsaacTeleop.git"
-BRANCH="ego4robo/0.0.1"
+BRANCH="main"
 DIR="src/postprocessing/egocentric_hand_reconstruction"
 
 echo "Syncing $DIR from $REPO ($BRANCH)..."

--- a/reconstruction/modules/v2d_ego_hand_reconstruction/sync.sh
+++ b/reconstruction/modules/v2d_ego_hand_reconstruction/sync.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="https://github.com/NVIDIA/IsaacTeleop.git"
+BRANCH="ego4robo/0.0.1"
+DIR="src/postprocessing/egocentric_hand_reconstruction"
+
+echo "Syncing $DIR from $REPO ($BRANCH)..."
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+git clone --filter=blob:none --sparse --branch "$BRANCH" --depth 1 "$REPO" "$tmp"
+cd "$tmp"
+git sparse-checkout set "$DIR"
+cd - > /dev/null
+
+cp -r "$tmp/$DIR/." "$SCRIPT_DIR/"
+
+echo "Done. Files synced to $SCRIPT_DIR/"


### PR DESCRIPTION
1.Use `sync.sh` to port the code from https://github.com/NVIDIA/IsaacTeleop.git branch `main`.
   - After running the script, the directory structure is like this:
<img width="369" height="381" alt="Screenshot 2026-04-06 at 3 16 27 PM" src="https://github.com/user-attachments/assets/dec71096-8f53-43e3-b63c-9368aeb39f06" />

2.Then it support build docker images dynhamr and vipe and run the reconstruction pipeline locally with a video using run_reconstruction.sh

  - The docker images are built with following commands
```
./reconstruction/modules/v2d_ego_hand_reconstruction/docker/dynhamr.sh build
./reconstruction/modules/v2d_ego_hand_reconstruction/docker/vipe.sh build
```
  - The reconstruction can be executed with the following command
```
./reconstruction/modules/v2d_ego_hand_reconstruction/scripts/run_reconstruction.sh path/to/your_video.mp4
```
   - The resulting directory structure is as follow
 
<img width="1003" height="791" alt="Screenshot 2026-04-06 at 3 35 36 PM" src="https://github.com/user-attachments/assets/0e945119-4545-4300-8761-2afbfbce4efb" />
