### PR TITLE
fix(bundlesdf/stage1_detect): zfar clipping fix + stage1 plateau detection improvements

### DIFF
--- a/reconstruction/modules/v2d_bundlesdf/docker/Dockerfile
+++ b/reconstruction/modules/v2d_bundlesdf/docker/Dockerfile
@@ -161,6 +161,35 @@ RUN git clone \
         https://github.com/NVIDIA/3DObjectReconstruction.git \
         /workspace/3d-object-reconstruction
 
+# Fix upstream bug in 3d-object-reconstruction:
+#   zfar dynamic computation to prevent mesh clipping during texture baking
+#   (default far*sc_factor is too small when cameras are far from the origin)
+RUN python3 - <<'EOF'
+import pathlib
+
+f = pathlib.Path("/workspace/3d-object-reconstruction/src/nvidia/objectreconstruction/networks/nerf_runner.py")
+src = f.read_text()
+
+old = "    renderer = ModelRendererOffscreen([], cam_K=K, H=Height, W=Width, zfar=far*sc_factor)"
+new = (
+    "    # Compute zfar from actual camera distances to avoid clipping the mesh.\n"
+    "    # The default far*sc_factor is often too small when cameras are far from the origin\n"
+    "    # in normalized space (e.g. far=1.0, sc_factor=1.56 -> zfar=1.56, but cameras may\n"
+    "    # sit at distance >1.9 from the mesh center).\n"
+    "    cam_dists = np.linalg.norm(poses[:, :3, 3], axis=-1)\n"
+    "    computed_zfar = max(far * sc_factor, float(cam_dists.max()) * 2.0)\n"
+    "    logger.info(f\"Texture baking zfar: {computed_zfar:.3f} \"\n"
+    "                f\"(far={far}, sc_factor={sc_factor:.3f}, max_cam_dist={cam_dists.max():.3f})\")\n"
+    "\n"
+    "    renderer = ModelRendererOffscreen([], cam_K=K, H=Height, W=Width, zfar=computed_zfar)"
+)
+assert old in src, "zfar anchor not found in nerf_runner.py"
+src = src.replace(old, new, 1)
+
+f.write_text(src)
+print("nerf_runner.py patched successfully")
+EOF
+
 # Install Python dependencies from repo requirements
 RUN pip3 install --no-cache-dir packaging setuptools wheel
 RUN pip3 install --no-cache-dir -r /workspace/3d-object-reconstruction/src/requirements.txt

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/detect_stage1_end.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/detect_stage1_end.py
@@ -450,7 +450,7 @@ def main():
             })
         )
         print(f"result.json written with stage1_end_frame=null — pipeline will stop.")
-        sys.exit(1)
+        sys.exit(0)  # exit 0: script ran correctly; the data has no detectable plateau
 
 
 if __name__ == '__main__':

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/detect_stage1_end.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/detect_stage1_end.py
@@ -8,22 +8,34 @@ Algorithm:
   3. Project positions onto the fitted plane, find centroid (≈ object center).
   4. Compute per-frame azimuthal angle of camera around centroid in the plane.
   5. Unwrap to cumulative angle; smooth with a rolling window.
-  6. Compute local slope (angular velocity); detect a sustained drop in slope
-     (the transition period where the person stops and rotates the object).
-  7. Stage-1 end = start of the first sustained low-slope plateau.
+  6. Compute local slope (angular velocity); find the longest sustained low-slope
+     plateau across the entire sequence (the transition period where the person
+     stops and rotates the object).
+  7. Stage-1 end = frame just before the longest plateau starts (backed off by
+     buffer_deg for safety).
+
+  If no qualifying plateau is found the script exits with code 1 and writes
+  result.json with stage1_end_frame=null.  The pipeline should treat this as a
+  fatal error and stop with a clear message rather than continuing with an
+  incorrect split point.
 
 Usage:
   python detect_stage1_end.py \\
       --sfm_keyframes /data/hoi_obj_recon/<job>/sfm/keyframes/frames_meta.json \\
       --frames_meta   /data/hoi_obj_recon/<job>/frames_meta.json \\
-      [--smooth_window 15]        rolling window for slope smoothing (keyframes)
-      [--slope_drop_frac 0.35]   slope fraction of median below which = plateau
-      [--min_plateau_len 5]      min consecutive keyframes below threshold
+      [--smooth_window 15]         rolling window for slope smoothing (keyframes)
+      [--slope_drop_frac 0.35]    slope fraction of median below which = plateau
+      [--min_plateau_len 5]       min consecutive keyframes below threshold
+      [--tail_exclude_frac 0.15]  ignore plateaus starting in last X% of sequence
+      [--buffer_deg 10]           back off this many degrees before plateau start
       [--output_dir /tmp/stage1_debug]
+
+  --max_angle_deg is accepted but ignored (deprecated).
 """
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -94,44 +106,58 @@ def sliding_window_slope(angles_deg, window):
 
 # ── Plateau detection ──────────────────────────────────────────────────────────
 
-def detect_plateau(slopes, angles_deg, median_slope, drop_frac, min_len,
-                   max_angle=350.0):
+def detect_longest_plateau(slopes, median_slope, drop_frac, min_len,
+                           tail_exclude_frac=0.15):
     """
-    Find the start of the first sustained low-slope period within the
-    search window (cumulative angle <= max_angle).
+    Find the longest sustained low-slope period across the entire sequence,
+    ignoring any plateau whose start falls in the last tail_exclude_frac of
+    the sequence (to avoid picking up end-of-scan pauses after Stage 2).
 
-    Primary: first run of >= min_len frames with slope < median*drop_frac.
-    Fallback: frame with the global minimum slope in the search window
-              (used when no hard threshold is crossed — gradual transitions).
+    A "low-slope" frame satisfies: abs(slope) < abs(median_slope) * drop_frac.
+    Only runs of >= min_len consecutive low-slope frames are considered.
 
-    Returns (plateau_idx, method_str).
+    Returns (plateau_start_idx, plateau_len, method_str):
+      plateau_start_idx — keyframe index of the first frame of the longest plateau
+      plateau_len       — number of consecutive low-slope frames in that plateau
+      method_str        — 'longest_plateau' if found, 'no_plateau' otherwise
+
+    If no qualifying plateau is found, returns (None, 0, 'no_plateau').
+    The caller should treat 'no_plateau' as a fatal error: it means the scan
+    does not have a detectable Stage-1 → Stage-2 transition and cannot be
+    processed by this pipeline without manual --stage1_end_frame specification.
     """
-    threshold = abs(median_slope) * drop_frac
+    N = len(slopes)
+    threshold  = abs(median_slope) * drop_frac
+    tail_start = int(N * (1.0 - tail_exclude_frac))
+
+    best_start = None
+    best_len   = 0
+
     run_start = None
     run_len   = 0
-    window_indices = []
 
-    for i in range(len(slopes)):
-        if abs(angles_deg[i]) > max_angle:
-            break
-        window_indices.append(i)
+    for i in range(N):
         if abs(slopes[i]) < threshold:
             if run_start is None:
                 run_start = i
             run_len += 1
-            if run_len >= min_len:
-                return run_start, 'threshold'
         else:
+            if run_start is not None and run_len >= min_len:
+                if run_start < tail_start and run_len > best_len:
+                    best_start = run_start
+                    best_len   = run_len
             run_start = None
             run_len   = 0
 
-    # Fallback: minimum |slope| in search window (closest to zero angular velocity)
-    if window_indices:
-        win = np.array(window_indices)
-        win_slopes = slopes[win]
-        best = win[np.argmin(np.abs(win_slopes))]
-        return best, 'min_slope_fallback'
-    return None, None
+    # Handle a plateau that extends to the very end of the sequence
+    if run_start is not None and run_len >= min_len:
+        if run_start < tail_start and run_len > best_len:
+            best_start = run_start
+            best_len   = run_len
+
+    if best_start is not None:
+        return best_start, best_len, 'longest_plateau'
+    return None, 0, 'no_plateau'
 
 
 # ── Main ───────────────────────────────────────────────────────────────────────
@@ -140,18 +166,24 @@ def main():
     parser = argparse.ArgumentParser(description="Detect Stage-1 end from CuSFM trajectory slope change")
     parser.add_argument('--sfm_keyframes', required=True)
     parser.add_argument('--frames_meta',   required=True)
-    parser.add_argument('--smooth_window',    type=int,   default=15,
+    parser.add_argument('--smooth_window',      type=int,   default=15,
                         help='Rolling window (keyframes) for slope smoothing (default: 15)')
-    parser.add_argument('--slope_drop_frac',  type=float, default=0.35,
+    parser.add_argument('--slope_drop_frac',    type=float, default=0.35,
                         help='Slope below median*frac triggers plateau (default: 0.35)')
-    parser.add_argument('--min_plateau_len',  type=int,   default=5,
+    parser.add_argument('--min_plateau_len',    type=int,   default=5,
                         help='Min consecutive low-slope keyframes for plateau (default: 5)')
-    parser.add_argument('--max_angle_deg',    type=float, default=350.0,
-                        help='Stop searching for plateau after this cumulative angle (default: 350°)')
-    parser.add_argument('--buffer_deg',       type=float, default=10.0,
-                        help='Back off by this many degrees before the detected transition (default: 10°)')
+    parser.add_argument('--tail_exclude_frac',  type=float, default=0.15,
+                        help='Ignore plateaus starting in last X fraction of sequence (default: 0.15)')
+    parser.add_argument('--buffer_deg',         type=float, default=10.0,
+                        help='Back off by this many degrees before the plateau start (default: 10°)')
+    parser.add_argument('--max_angle_deg',      type=float, default=None,
+                        help='[DEPRECATED — ignored] Previously limited the search window.')
     parser.add_argument('--output_dir', default='/tmp/stage1_debug')
     args = parser.parse_args()
+
+    if args.max_angle_deg is not None:
+        print(f"WARNING: --max_angle_deg is deprecated and will be ignored. "
+              f"The search now covers the full sequence.")
 
     out_dir = Path(args.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -221,30 +253,60 @@ def main():
     print(f"Plateau threshold:              < {median_slope * args.slope_drop_frac:.3f} °/keyframe  "
           f"({args.slope_drop_frac*100:.0f}% of median)")
 
-    # ── Detect first sustained low-slope plateau ──────────────────────────────
-    plateau_idx, method = detect_plateau(slopes_smooth, angles_deg, median_slope,
-                                         args.slope_drop_frac, args.min_plateau_len,
-                                         max_angle=args.max_angle_deg)
+    # ── Detect longest sustained low-slope plateau (full sequence) ───────────
+    plateau_idx, plateau_len, method = detect_longest_plateau(
+        slopes_smooth, median_slope,
+        args.slope_drop_frac, args.min_plateau_len,
+        tail_exclude_frac=args.tail_exclude_frac,
+    )
 
     if plateau_idx is not None:
-        # Apply angle buffer: back off to min(max_angle_deg, detected_angle - buffer_deg)
-        target_angle = min(args.max_angle_deg, angles_deg[plateau_idx] - args.buffer_deg)
-        buffered_idx = plateau_idx
-        for i in range(plateau_idx, -1, -1):
-            if angles_deg[i] <= target_angle:
-                buffered_idx = i
-                break
+        # Apply angle buffer: back off toward 0 by buffer_deg from the plateau start.
+        # Works correctly for both positive (CCW) and negative (CW) cumulative angles.
+        transition_angle = angles_deg[plateau_idx]
+        if transition_angle >= 0:
+            target_angle = transition_angle - args.buffer_deg
+            buffered_idx = plateau_idx
+            for i in range(plateau_idx, -1, -1):
+                if angles_deg[i] <= target_angle:
+                    buffered_idx = i
+                    break
+        else:
+            target_angle = transition_angle + args.buffer_deg  # less negative → closer to 0
+            buffered_idx = plateau_idx
+            for i in range(plateau_idx, -1, -1):
+                if angles_deg[i] >= target_angle:
+                    buffered_idx = i
+                    break
         stage1_end_seq = seq_indices[buffered_idx]
         print(f"\n*** Stage-1 end detected ({method}) ***")
-        print(f"  Transition keyframe index:    {plateau_idx}  (seq={seq_indices[plateau_idx]}, angle={angles_deg[plateau_idx]:.1f}°)")
-        print(f"  Buffer:                       -{args.buffer_deg:.0f}° → target angle {target_angle:.1f}°")
+        print(f"  Plateau start keyframe index: {plateau_idx}  (seq={seq_indices[plateau_idx]}, angle={transition_angle:.1f}°)")
+        print(f"  Plateau length:               {plateau_len} keyframes")
+        print(f"  Buffer:                       {args.buffer_deg:.0f}° toward 0 → target angle {target_angle:.1f}°")
         print(f"  Buffered keyframe index:      {buffered_idx}  (seq={stage1_end_seq}, angle={angles_deg[buffered_idx]:.1f}°)")
-        print(f"  Slope at transition: {slopes_smooth[plateau_idx]:.3f} °/keyframe  (median: {median_slope:.3f})")
+        print(f"  Slope at plateau start:       {slopes_smooth[plateau_idx]:.3f} °/keyframe  (median: {median_slope:.3f})")
     else:
-        buffered_idx = None
+        buffered_idx   = None
         stage1_end_seq = None
-        method = None
-        print("\nStage-1 end NOT detected")
+        target_angle   = None
+        print(
+            f"\n{'='*60}\n"
+            f"WARNING: Stage-1 end could NOT be detected.\n"
+            f"  No sustained low-slope plateau (>= {args.min_plateau_len} keyframes, "
+            f"slope < {args.slope_drop_frac*100:.0f}% of median) was found in the\n"
+            f"  trajectory (excluding the last {args.tail_exclude_frac*100:.0f}% of frames).\n"
+            f"\n"
+            f"  Likely causes:\n"
+            f"    • The scan has no clear Stage-1 → Stage-2 transition pause.\n"
+            f"    • The object was not manually repositioned between the two scan stages.\n"
+            f"    • CuSFM may have failed to reconstruct the transition segment.\n"
+            f"\n"
+            f"  Action required:\n"
+            f"    Inspect the debug plots in {out_dir}/ and either:\n"
+            f"      a) Re-collect the data following the two-stage scan protocol, or\n"
+            f"      b) Specify --stage1_end_frame <frame> manually.\n"
+            f"{'='*60}"
+        )
 
     # ── Plot 1: 3D camera positions + fitted plane ────────────────────────────
     from mpl_toolkits.mplot3d import Axes3D  # noqa
@@ -261,7 +323,7 @@ def main():
     ax.scatter(*centroid_3d, color='red', s=80, zorder=5, label='centroid')
     if plateau_idx is not None:
         ax.scatter(*positions[plateau_idx], color='red', s=100, marker='^', zorder=6,
-                   label=f'transition seq={seq_indices[plateau_idx]} [{method}]')
+                   label=f'plateau start seq={seq_indices[plateau_idx]} [{method}]')
         ax.scatter(*positions[buffered_idx], color='orange', s=150, marker='*', zorder=7,
                    label=f'stage1 end seq={stage1_end_seq} (-{args.buffer_deg:.0f}°)')
     ax.set_xlabel('X'); ax.set_ylabel('Y'); ax.set_zlabel('Z')
@@ -281,7 +343,7 @@ def main():
     if plateau_idx is not None:
         ax.scatter(pts_c[plateau_idx, 0], pts_c[plateau_idx, 1],
                    color='red', s=100, marker='^', zorder=6,
-                   label=f'transition seq={seq_indices[plateau_idx]} [{method}]')
+                   label=f'plateau start seq={seq_indices[plateau_idx]} [{method}]')
         ax.scatter(pts_c[buffered_idx, 0], pts_c[buffered_idx, 1],
                    color='orange', s=200, marker='*', zorder=7,
                    label=f'stage1 end seq={stage1_end_seq} (-{args.buffer_deg:.0f}°)')
@@ -300,7 +362,7 @@ def main():
     ax.plot(seq_indices, angles_deg, 'b-', lw=1.5, label='cumulative angle')
     if plateau_idx is not None:
         ax.axvline(seq_indices[plateau_idx], color='red', lw=1.5, ls='--',
-                   label=f'transition (seq={seq_indices[plateau_idx]}, {angles_deg[plateau_idx]:.1f}°)')
+                   label=f'plateau start (seq={seq_indices[plateau_idx]}, {angles_deg[plateau_idx]:.1f}°, len={plateau_len}kf)')
         ax.axhline(target_angle, color='orange', lw=1.5, ls=':',
                    label=f'buffer target ({target_angle:.1f}°)')
         ax.axvline(stage1_end_seq, color='orange', lw=2,
@@ -319,21 +381,25 @@ def main():
     ax.plot(seq_indices, slopes_smooth, color='blue', lw=1.8, label=f'slope (sliding window, w={W})')
     ax.axhline(thr_line,  color='green', ls='--', lw=1.5,
                label=f'plateau threshold ({args.slope_drop_frac*100:.0f}% of median = {thr_line:.2f}°/kf)')
+    ax.axhline(-thr_line, color='green', ls='--', lw=1.5)   # mirror for CW scans
     ax.axhline(median_slope, color='gray', ls=':', lw=1, label=f'median slope ({median_slope:.2f}°/kf)')
     ax.axhline(0, color='k', lw=0.5)
-    # Shade the search window [min_angle, max_angle] on the angle axis
-    in_window = np.abs(angles_deg) <= args.max_angle_deg
-    if in_window.any():
-        win_seq = seq_indices[in_window]
-        ax.axvspan(win_seq[0], win_seq[-1], alpha=0.08, color='green',
-                   label=f'search window (0°–{args.max_angle_deg:.0f}°)')
+    # Shade the tail-exclusion zone
+    tail_start_seq = seq_indices[int(N * (1.0 - args.tail_exclude_frac))]
+    ax.axvspan(tail_start_seq, seq_indices[-1], alpha=0.08, color='red',
+               label=f'tail exclusion (last {args.tail_exclude_frac*100:.0f}%)')
     if plateau_idx is not None:
+        # Shade the detected longest plateau
+        plateau_end_idx = min(plateau_idx + plateau_len - 1, N - 1)
+        ax.axvspan(seq_indices[plateau_idx], seq_indices[plateau_end_idx],
+                   alpha=0.15, color='cyan',
+                   label=f'longest plateau ({plateau_len} kf)')
         ax.axvline(seq_indices[plateau_idx], color='red', lw=1.5, ls='--',
-                   label=f'transition (seq={seq_indices[plateau_idx]})')
+                   label=f'plateau start (seq={seq_indices[plateau_idx]})')
         ax.axvline(stage1_end_seq, color='orange', lw=2,
                    label=f'stage1 end (seq={stage1_end_seq}, -{args.buffer_deg:.0f}°)')
     ax.set_xlabel('seq_idx'); ax.set_ylabel('Angular velocity (°/keyframe)')
-    ax.set_title(f'Slope of cumulative angle  [smooth_window={W}, drop_frac={args.slope_drop_frac}, min_len={args.min_plateau_len}]')
+    ax.set_title(f'Slope of cumulative angle  [smooth_window={W}, drop_frac={args.slope_drop_frac}, min_len={args.min_plateau_len}, tail_excl={args.tail_exclude_frac}]')
     ax.legend(fontsize=8); ax.grid(True, alpha=0.3)
     fig.tight_layout()
     fig.savefig(out_dir / '4_slope.png', dpi=120)
@@ -345,7 +411,7 @@ def main():
     ax.plot(seq_indices, np.rad2deg(angles_raw), 'g-', lw=1.2, label='raw angle (atan2)')
     if plateau_idx is not None:
         ax.axvline(seq_indices[plateau_idx], color='red', lw=1.5, ls='--',
-                   label=f'transition (seq={seq_indices[plateau_idx]})')
+                   label=f'plateau start (seq={seq_indices[plateau_idx]})')
         ax.axvline(stage1_end_seq, color='orange', lw=2,
                    label=f'stage1 end (seq={stage1_end_seq}, -{args.buffer_deg:.0f}°)')
     ax.set_xlabel('seq_idx'); ax.set_ylabel('Angle (°)')
@@ -358,10 +424,33 @@ def main():
 
     print(f"\nAll plots saved to {out_dir}/")
     if stage1_end_seq is not None:
-        print(f"\nSuggested --stage1_end_frame: {stage1_end_seq}  (transition at seq={seq_indices[plateau_idx]}, buffer={args.buffer_deg:.0f}°)")
+        print(f"\nSuggested --stage1_end_frame: {stage1_end_seq}"
+              f"  (plateau start seq={seq_indices[plateau_idx]}, len={plateau_len} kf,"
+              f" buffer={args.buffer_deg:.0f}°)")
         (out_dir / "result.json").write_text(
-            json.dumps({"stage1_end_frame": int(stage1_end_seq)})
+            json.dumps({
+                "stage1_end_frame": int(stage1_end_seq),
+                "plateau_start_seq": int(seq_indices[plateau_idx]),
+                "plateau_len_keyframes": int(plateau_len),
+                "method": method,
+            })
         )
+    else:
+        # Write a result.json with null so the pipeline can emit a clear error
+        # message rather than a generic "file not found" failure.
+        (out_dir / "result.json").write_text(
+            json.dumps({
+                "stage1_end_frame": None,
+                "method": "no_plateau",
+                "reason": (
+                    "No sustained low-slope plateau found. "
+                    "The scan may lack a Stage-1 to Stage-2 transition. "
+                    "Use --stage1_end_frame to specify manually."
+                ),
+            })
+        )
+        print(f"result.json written with stage1_end_frame=null — pipeline will stop.")
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/detect_stage1_end.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/detect_stage1_end.py
@@ -107,53 +107,83 @@ def sliding_window_slope(angles_deg, window):
 # ── Plateau detection ──────────────────────────────────────────────────────────
 
 def detect_longest_plateau(slopes, median_slope, drop_frac, min_len,
-                           tail_exclude_frac=0.15):
+                           tail_exclude_frac=0.15, qualify_frac=0.65,
+                           spread_frac=1.5):
     """
-    Find the longest sustained low-slope period across the entire sequence,
-    ignoring any plateau whose start falls in the last tail_exclude_frac of
-    the sequence (to avoid picking up end-of-scan pauses after Stage 2).
+    Find the longest contiguous region where the rolling-mean absolute slope
+    (window = min_len frames) is significantly lower than the active-scanning
+    median slope.  This is the transition pause where the person stops moving
+    and rotates the object between Stage 1 and Stage 2.
 
-    A "low-slope" frame satisfies: abs(slope) < abs(median_slope) * drop_frac.
-    Only runs of >= min_len consecutive low-slope frames are considered.
+    Algorithm:
+      1. Compute rolling-mean of |slope| over min_len frames → window_mean[i].
+      2. Find the global minimum of window_mean (before the tail exclusion zone).
+         This is the "quietest" part of the scan.
+      3. Qualify check: min_wm must be < median * qualify_frac (default 0.65).
+         Scans with no real transition have no deep minimum and fail here.
+      4. Adaptive threshold = max(min_wm * spread_frac, |median| * drop_frac).
+         • For a clean, crisp pause  : spread term is tiny → strict drop_frac wins.
+         • For a noisy / partial pause: spread term gives a threshold relative to
+           the actual minimum, catching the whole neighbourhood even when the
+           camera never fully stops.
+      5. Find the longest contiguous run of positions below this threshold
+         (start must be before tail_start).
 
     Returns (plateau_start_idx, plateau_len, method_str):
       plateau_start_idx — keyframe index of the first frame of the longest plateau
-      plateau_len       — number of consecutive low-slope frames in that plateau
+      plateau_len       — length of the plateau in frames
       method_str        — 'longest_plateau' if found, 'no_plateau' otherwise
-
-    If no qualifying plateau is found, returns (None, 0, 'no_plateau').
-    The caller should treat 'no_plateau' as a fatal error: it means the scan
-    does not have a detectable Stage-1 → Stage-2 transition and cannot be
-    processed by this pipeline without manual --stage1_end_frame specification.
     """
     N = len(slopes)
-    threshold  = abs(median_slope) * drop_frac
+    if N < min_len:
+        return None, 0, 'no_plateau'
+
     tail_start = int(N * (1.0 - tail_exclude_frac))
 
-    best_start = None
-    best_len   = 0
+    abs_slopes  = np.abs(slopes)
+    cumsum      = np.concatenate([[0.0], np.cumsum(abs_slopes)])
+    window_mean = (cumsum[min_len:] - cumsum[:-min_len]) / min_len  # length N-min_len+1
 
-    run_start = None
-    run_len   = 0
+    # Step 2: global minimum before tail
+    search_end = min(tail_start, len(window_mean))
+    if search_end <= 0:
+        return None, 0, 'no_plateau'
+    i_min  = int(np.argmin(window_mean[:search_end]))
+    min_wm = window_mean[i_min]
 
-    for i in range(N):
-        if abs(slopes[i]) < threshold:
-            if run_start is None:
-                run_start = i
-            run_len += 1
+    # Step 3: qualify check — the minimum must be a meaningful slowdown
+    abs_median = abs(median_slope)
+    if min_wm >= abs_median * qualify_frac:
+        return None, 0, 'no_plateau'
+
+    # Step 4: adaptive threshold
+    threshold = max(min_wm * spread_frac, abs_median * drop_frac)
+
+    # Step 5: longest contiguous qualifying run (start < tail_start)
+    best_start    = None
+    best_len      = 0
+    run_start_pos = None
+    run_len_pos   = 0
+
+    for i in range(min(len(window_mean), tail_start)):
+        if window_mean[i] < threshold:
+            if run_start_pos is None:
+                run_start_pos = i
+            run_len_pos += 1
         else:
-            if run_start is not None and run_len >= min_len:
-                if run_start < tail_start and run_len > best_len:
-                    best_start = run_start
-                    best_len   = run_len
-            run_start = None
-            run_len   = 0
+            if run_start_pos is not None:
+                actual_len = run_len_pos + min_len - 1
+                if actual_len > best_len:
+                    best_start = run_start_pos
+                    best_len   = actual_len
+            run_start_pos = None
+            run_len_pos   = 0
 
-    # Handle a plateau that extends to the very end of the sequence
-    if run_start is not None and run_len >= min_len:
-        if run_start < tail_start and run_len > best_len:
-            best_start = run_start
-            best_len   = run_len
+    if run_start_pos is not None:
+        actual_len = run_len_pos + min_len - 1
+        if actual_len > best_len:
+            best_start = run_start_pos
+            best_len   = actual_len
 
     if best_start is not None:
         return best_start, best_len, 'longest_plateau'
@@ -250,8 +280,10 @@ def main():
     lo, hi       = int(0.2 * N), int(0.8 * N)
     median_slope  = np.median(slopes_smooth[lo:hi])
     print(f"Median slope (active scanning): {median_slope:.3f} °/keyframe")
-    print(f"Plateau threshold:              < {median_slope * args.slope_drop_frac:.3f} °/keyframe  "
+    print(f"Strict drop threshold:          < {median_slope * args.slope_drop_frac:.3f} °/keyframe  "
           f"({args.slope_drop_frac*100:.0f}% of median)")
+    print(f"Qualify threshold:              global min must be < {median_slope * 0.65:.3f} °/keyframe  "
+          f"(65% of median)")
 
     # ── Detect longest sustained low-slope plateau (full sequence) ───────────
     plateau_idx, plateau_len, method = detect_longest_plateau(
@@ -376,11 +408,19 @@ def main():
     print(f"Saved: {out_dir}/3_cumulative_angle.png")
 
     # ── Plot 4: Slope (raw + smoothed) + threshold ────────────────────────────
-    thr_line = abs(median_slope) * args.slope_drop_frac
+    strict_thr = abs(median_slope) * args.slope_drop_frac
+    # Recompute the adaptive threshold used by detect_longest_plateau for display
+    abs_slopes_disp = np.abs(slopes_smooth)
+    cumsum_disp = np.concatenate([[0.0], np.cumsum(abs_slopes_disp)])
+    wm_disp = (cumsum_disp[args.min_plateau_len:] - cumsum_disp[:-args.min_plateau_len]) / args.min_plateau_len
+    tail_s = int(N * (1.0 - args.tail_exclude_frac))
+    min_wm_disp = float(np.min(wm_disp[:min(tail_s, len(wm_disp))]))
+    adapt_thr = max(min_wm_disp * 1.5, strict_thr)
+    thr_line = adapt_thr
     fig, ax = plt.subplots(figsize=(12, 4))
     ax.plot(seq_indices, slopes_smooth, color='blue', lw=1.8, label=f'slope (sliding window, w={W})')
     ax.axhline(thr_line,  color='green', ls='--', lw=1.5,
-               label=f'plateau threshold ({args.slope_drop_frac*100:.0f}% of median = {thr_line:.2f}°/kf)')
+               label=f'adaptive threshold ({thr_line:.2f}°/kf = max(min×1.5, {strict_thr:.2f}))')
     ax.axhline(-thr_line, color='green', ls='--', lw=1.5)   # mirror for CW scans
     ax.axhline(median_slope, color='gray', ls=':', lw=1, label=f'median slope ({median_slope:.2f}°/kf)')
     ax.axhline(0, color='k', lw=0.5)


### PR DESCRIPTION
## Summary
  - fix(stage1_detect): find longest plateau across full sequence instead of first within 350°
  - fix(stage1_detect): exit 0 on no-plateau instead of exit 1
  - fix(stage1_detect): use adaptive threshold based on global minimum slope
  - fix(bundlesdf): patch nerf_runner.py zfar at Docker build time to prevent mesh clipping during texture baking