### PR TITLE
Add SAM3D pipeline mode

### DIFF
--- a/reconstruction/modules/v2d_bundlesdf/lib/data/configs/hoi_pipeline.yaml
+++ b/reconstruction/modules/v2d_bundlesdf/lib/data/configs/hoi_pipeline.yaml
@@ -1,0 +1,26 @@
+# HOI Object Reconstruction — Pipeline Configuration
+#
+# Controls the orchestration-level behaviour of each pipeline step.
+# For NeRF/SDF/texture neural rendering settings, see theseus_optimizer_hawk.yaml.
+
+stage1_detect:
+  buffer_deg: 10.0          # angle buffer (°) before the detected Stage-1 transition
+
+sfm:
+  config_set: backpack       # CuSFM config preset (backpack | av | isaac | rgbd)
+  num_threads: 1             # CPU threads for CuSFM feature matching
+
+grounding_dino:
+  box_threshold: 0.3         # confidence threshold for object bbox detection
+
+depth:
+  num_workers: 2             # parallel FoundationStereo depth workers
+
+foundationpose:
+  reference_frame: 0         # frame index used as FoundationPose registration reference
+  weights_dir: null          # path to FP weights; null = data/weights/foundationpose
+
+texture_bake:
+  min_keyframe_translation: 0.0   # min camera translation (m) between selected keyframes; 0 = keep all
+  min_keyframe_rotation_deg: 5.0  # min camera rotation (°) between selected keyframes; 0 = keep all
+  min_keyframes: 30               # minimum keyframes after subsampling (uniform padding if needed)

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/README.md
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/README.md
@@ -1,79 +1,118 @@
 # v2d_hoi_object_reconstruction
 
-End-to-end textured 3D mesh reconstruction from hand-object interaction video using a **two-stage scan** (object stationary → rotated → stationary).
+End-to-end textured 3D mesh reconstruction from hand-object interaction video.
 
-## Prerequisites
+Two reconstruction modes:
+- **BundleSDF** (default) — two-stage scan (stationary → rotated → stationary) → full textured NeRF mesh
+- **SAM3D** — select representative frames → per-frame single-image 3D → silhouette-based scale estimation
 
-1. **Install host packages** (from `reconstruction/`):
-   ```bash
-   ./scripts/install_pacakages.sh
-   ```
+---
 
-2. **Build all required containers**:
-   ```bash
-   ./scripts/build_containers.sh
-   ```
+## Data Collection
 
-3. **Download model weights**:
-   ```bash
-   python -m v2d.sam2.docker.run_download_weights --output_dir data/weights/sam2
-   python -m v2d.grounding_dino.docker.run_download_weights --output_dir data/weights/grounding_dino
-   python modules/v2d_foundation_stereo/docker/run_download_weights.py \
-     --output_dir data/weights/foundationstereo
-   python modules/v2d_foundation_pose/docker/run_download_weights.py \
-     --output_dir data/weights/foundationpose
-   python modules/v2d_bundlesdf/docker/run_download_weights.py --output_dir data/weights
-   ```
+_Coming soon._
 
-## Quick Start
+---
 
-Run on the included example data (from `reconstruction/`):
+## Environment Setup
+
+### 1. Install host packages (from `reconstruction/`)
 
 ```bash
-python modules/v2d_hoi_object_reconstruction/docker/run_reconstruction.py \
-  --mapping_data_dir modules/v2d_hoi_object_reconstruction/assets/basketball_example \
-  --job_dir          data/outputs/hoi_recon/basketball_example \
-  --prompt           "basketball"
+./scripts/install_pacakages.sh
 ```
 
-Or on your own data:
+### 2. Build all required containers
+
+```bash
+./scripts/build_containers.sh
+```
+
+### 3. Download model weights
+
+```bash
+# Shared (both modes)
+python -m v2d.sam2.docker.run_download_weights --output_dir data/weights/sam2
+python -m v2d.grounding_dino.docker.run_download_weights --output_dir data/weights/grounding_dino
+
+# BundleSDF mode
+python modules/v2d_foundation_stereo/docker/run_download_weights.py \
+  --output_dir data/weights/foundationstereo
+python modules/v2d_foundation_pose/docker/run_download_weights.py \
+  --output_dir data/weights/foundationpose
+python modules/v2d_bundlesdf/docker/run_download_weights.py --output_dir data/weights
+
+# SAM3D mode
+python modules/v2d_sam3d/docker/run_download_weights.py --output_dir data/weights/sam3d
+# (optional: FoundationStereo for depth-assisted scale estimation)
+python modules/v2d_foundation_stereo/docker/run_download_weights.py \
+  --output_dir data/weights/foundationstereo
+```
+
+---
+
+## BundleSDF Pipeline
+
+Two-stage scan: object stationary → rotated 360° → stationary again.
+
+### Quick Start
 
 ```bash
 python modules/v2d_hoi_object_reconstruction/docker/run_reconstruction.py \
   --mapping_data_dir data/hoi_obj_recon/raw_data/<job> \
-  --job_dir          data/hoi_obj_recon/jobs/<job> \
+  --job_dir          data/outputs/hoi_recon/<job> \
   --prompt           "basketball"
 ```
 
-Results are written to `<job_dir>/`:
-- `merged_recon/textured_mesh.obj` — final textured mesh (+ `.mtl`, `_0.png`)
-- `stage1_recon/textured_mesh.obj` — Stage-1 mesh (bottom missing)
-
-## Pipeline
+### Pipeline Steps
 
 ```
 mapping_data_dir  (images + frames_meta.json)
     ↓
-CuSFM  →  sfm/keyframes/frames_meta.json  (camera poses)
+1.  prepare_FP_folder   → job_dir/left/, right/, calibration.json, video.mp4
     ↓
-Stage-1 auto-detect  →  stage1_end_frame  (transition from stationary to rotation)
+2.  CuSFM               → sfm/keyframes/frames_meta.json  (camera poses)
     ↓
-Grounding DINO  →  object bounding box
-FoundationStereo  →  depth/  (all frames, parallel workers)
-SAM2  →  masks/  (reference frame only)
+2b. Stage-1 auto-detect → stage1_detect_debug/result.json  (transition frame)
     ↓
-Stage-1 NeRF  →  stage1_recon/textured_mesh.obj
+3.  Grounding DINO      → grounding_dino_bboxes.json
+4a. FoundationStereo    → depth/  (all frames, parallel workers)
+4b. SAM2                → masks/  (all frames, from reference frame)
     ↓
-FoundationPose tracking  →  poses/  (all frames)
+5.  Stage-1 setup       → stage1_recon/  (SfM keyframes + depth symlinks)
+6.  BundleSDF NeRF      → stage1_recon/textured_mesh.obj
+7.  Center mesh         → mesh_input.obj
     ↓
-World poses + Stage-2 setup  →  merged_recon/  (both stages aligned)
+8.  FoundationPose      → poses/  (tracking with Stage-1 mesh)
+8b. FP render           → fp_render/render.mp4
     ↓
-Full NeRF  →  merged_recon/textured_mesh.obj
+9.  World poses         → poses_world.json  (T_world_from_obj + stage detection)
+10. Merged setup        → merged_recon/  (both stages aligned)
+11. BundleSDF NeRF      → merged_recon/textured_mesh.obj
     ↓
-FoundationPose tracking (final)  →  poses_final/  (all frames, final mesh)
+12. FoundationPose      → poses_final/  (tracking with final mesh)
+13. FP render           → fp_render_final/render.mp4
 ```
 
-## Skip Flags
+### Results
+
+- `merged_recon/textured_mesh.obj` — final textured mesh (+ `.mtl`, `_0.png`)
+- `stage1_recon/textured_mesh.obj` — Stage-1 mesh (bottom missing)
+
+### Key Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--stage1_end_frame N` | auto | Override Stage-1 end (sequential frame index) |
+| `--stage1_end_timestamp NS` | auto | Override Stage-1 end (nanosecond timestamp) |
+| `--stage1_buffer_deg DEG` | 10.0 | Angle buffer before detected transition |
+| `--config PATH` | bundlesdf default | NeRF/SDF config YAML |
+| `--pipeline_config PATH` | `lib/data/configs/hoi_pipeline.yaml` | Pipeline config YAML |
+| `--reference_frame N` | 0 | SAM2/FP reference frame |
+| `--num_depth_workers N` | 2 | Parallel FoundationStereo workers |
+| `--fp_weights_dir PATH` | `data/weights/foundationpose` | FoundationPose weights |
+
+### Skip Flags (BundleSDF)
 
 Resume from any checkpoint by skipping completed steps:
 
@@ -84,63 +123,167 @@ Resume from any checkpoint by skipping completed steps:
 --skip_final_fp_tracking  --skip_final_fp_render
 ```
 
-## Configuration
+### Configuration
 
-Two config files control the pipeline:
-
-### Pipeline config — `lib/data/configs/hoi_pipeline.yaml`
-
-Orchestration-level settings (override with `--pipeline_config`):
+**Pipeline config** — `lib/data/configs/hoi_pipeline.yaml` (override with `--pipeline_config`):
 
 | Section | Parameter | Default | Description |
 |---------|-----------|---------|-------------|
 | `stage1_detect` | `buffer_deg` | 10.0 | Angle buffer (°) before detected Stage-1 transition |
 | `sfm` | `config_set` | `backpack` | CuSFM preset (`backpack` \| `av` \| `isaac` \| `rgbd`) |
 | `depth` | `num_workers` | 2 | Parallel FoundationStereo depth workers |
-| `foundationpose` | `reference_frame` | 0 | Frame used as FoundationPose registration reference |
+| `foundationpose` | `reference_frame` | 0 | FP registration reference frame |
 | `foundationpose` | `weights_dir` | `null` | FP weights path; `null` = `data/weights/foundationpose` |
-### NeRF/SDF config — `modules/v2d_bundlesdf/lib/data/configs/theseus_optimizer_hawk.yaml`
 
-Neural rendering settings (override with `--config`). Camera intrinsics are filled in automatically from `<job_dir>/calibration.json`.
+**NeRF/SDF config** — `modules/v2d_bundlesdf/lib/data/configs/theseus_optimizer_hawk.yaml` (override with `--config`):
 
 | Section | Parameter | Default | Description |
 |---------|-----------|---------|-------------|
-| `camera_config` | `step` | 4 | CuSFM keyframe subsampling for SDF training (BundleSDF default; 1 = all keyframes) |
+| `camera_config` | `step` | 4 | CuSFM keyframe subsampling for SDF training |
 | `nerf` | `n_step` | 3000 | SDF training steps |
-| `nerf` | `trunc` | 0.01 | TSDF truncation distance (normalized space). Larger = fewer holes in underobserved regions |
-| `nerf` | `mesh_resolution` | 0.005 | Voxel size for mesh extraction (normalized space). Should be ≤ `trunc` |
+| `nerf` | `trunc` | 0.01 | TSDF truncation distance (normalized). Larger = fewer holes |
+| `nerf` | `mesh_resolution` | 0.005 | Voxel size for mesh extraction. Must be ≤ `trunc` |
 | `texture_bake` | `texture_res` | 2048 | Output texture atlas resolution |
-| `texture_bake` | `downscale` | 1.0 | Image downscale for texture baking (increase to speed up) |
+| `texture_bake` | `downscale` | 1.0 | Image downscale for texture baking |
 | `texture_bake` | `min_keyframe_translation` | 0.0 | Min camera translation (m) between texture keyframes |
 | `texture_bake` | `min_keyframe_rotation_deg` | 5.0 | Min camera rotation (°) between texture keyframes |
 | `texture_bake` | `min_keyframes` | 30 | Minimum keyframes after subsampling |
 
-## Internal: cross-container symlinks
+---
 
-The pipeline uses **relative symlinks** to map sparse keyframe indices (from SfM) to the contiguous `left{N:06d}` indices expected by BundleSDF, without copying large depth and mask files.
+## SAM3D Pipeline
 
-For these symlinks to resolve correctly across container boundaries, all symlink targets must live under `job_dir`. The `v2d_hoi_object_reconstruction` container and the `v2d_bundlesdf` container each mount `job_dir` at a different internal path (`/data/frames_meta` and `/data/config` respectively), so a symlink created as `../../depth/000001.png` from `stage1_recon/depth/` resolves to `job_dir/depth/000001.png` in both containers.
+Single-image 3D reconstruction per representative frame. No multi-stage scan required.
 
-This constraint means:
-- `depth/` must be a direct subdirectory of `job_dir` — ✓ always true
-- `masks/` must also be a direct subdirectory of `job_dir` — ✓ SAM2 outputs to `job_dir/masks/0/`
-
-If you supply external depth or mask directories outside `job_dir`, the pipeline will fail silently with broken symlinks inside BundleSDF. Keep all intermediate data within `job_dir`.
-
-## Input from MCAP bag
-
-If raw data is an MCAP bag instead of a `mapping_data` directory:
+### Quick Start
 
 ```bash
 python modules/v2d_hoi_object_reconstruction/docker/run_reconstruction.py \
-  --mcap_file /path/to/2026-03-12_airplane/ \
-  --job_dir   data/hoi_obj_recon/jobs/2026-03-12_airplane \
-  --prompt    "airplane"
+  --mapping_data_dir data/hoi_obj_recon/raw_data/<job> \
+  --job_dir          data/outputs/hoi_recon/<job> \
+  --prompt           "basketball" \
+  --mode sam3d
 ```
 
-## FoundationPose Tracking Only
+With depth-assisted scale estimation:
 
-To run FoundationPose tracking with an existing mesh (skips reconstruction), prepare the job directory first then skip all reconstruction steps:
+```bash
+python ... --mode sam3d --sam3d_use_depth
+```
+
+### Pipeline Steps
+
+```
+mapping_data_dir  (images + frames_meta.json)
+    ↓
+1.  prepare_FP_folder   → job_dir/left/, right/, calibration.json, video.mp4
+    ↓
+2.  CuSFM               → sfm/keyframes/frames_meta.json  (camera poses for frame selection)
+    ↓
+2b. Stage-1 auto-detect → stage1_detect_debug/result.json  (exclude transition frames)
+    ↓
+3.  Grounding DINO      → grounding_dino_bboxes.json
+4b. SAM2                → masks/  (all frames — required for SRT scale)
+[4a. FoundationStereo]  → depth/  (optional, only with --sam3d_use_depth)
+    ↓
+S1. Select frames       → sam3d/selected_frames.json  (one per azimuthal bin)
+S2. SAM3D               → sam3d/<frame_id>/mesh.glb + transform.json + intrinsics.json
+S3. SRT scale           → sam3d/<frame_id>/srt/srt_result.json + output_scaled.glb
+S4. Render debug        → sam3d/<frame_id>/render_debug.jpg
+```
+
+### Results
+
+- `sam3d/<frame_id>/mesh.glb` — raw SAM3D mesh (SAM3D camera space)
+- `sam3d/<frame_id>/srt/output_scaled.glb` — scale-corrected mesh (world space)
+- `sam3d/<frame_id>/srt/srt_result.json` — estimated scale, rotation, translation
+- `sam3d/<frame_id>/render_debug.jpg` — SAM3D mesh overlaid on source image
+
+### Key Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--sam3d_use_depth` | off | Use FoundationStereo depth as extra loss in SRT scale estimation |
+| `--sam3d_bin_deg DEG` | 60.0 | Azimuthal bin size for frame selection |
+| `--sam3d_seed N` | 42 | Random seed for SAM3D inference |
+
+### Skip Flags (SAM3D)
+
+```
+--skip_prepare  --skip_sfm  --skip_stage1_detect  --skip_dino  --skip_depth  --skip_mask
+--skip_select_frames  --skip_sam3d  --skip_srt_scale  --skip_render_debug
+```
+
+---
+
+## Troubleshooting
+
+Start from the final output and work backwards.
+
+### BundleSDF: Bad final mesh
+
+**Step 1 — Check Stage-1 mesh** (`stage1_recon/textured_mesh.obj`).
+
+If Stage-1 mesh is bad, check inputs in order:
+
+1. **Masks** — Spot-check `masks/0/`. Object should be cleanly segmented in every frame.
+   - Wrong box: try a more specific `--prompt` (e.g. `"red spray bottle"` not `"bottle"`)
+   - Mask drifts: adjust `foundationpose.reference_frame` in the pipeline config
+
+2. **Camera poses and point cloud** — Run:
+   ```bash
+   python modules/v2d_bundlesdf/tools/visualize_reconstruction_standalone.py <job_dir>/stage1_recon/
+   ```
+   Cameras should orbit the object cleanly and the point cloud should form a coherent shape.
+
+3. **Surface holes** — If cameras/point cloud are good but mesh has holes:
+   - Increase `nerf.trunc` (default `0.01`, try `0.02`)
+   - Decrease `nerf.mesh_resolution`, must stay ≤ `trunc` (default `0.005`, try `0.003`)
+   - Increase `texture_bake.texture_res` for sharper texture (default `2048`, try `4096`)
+
+If Stage-1 is good but final mesh is bad, the problem is in two-stage alignment:
+
+1. **FP tracking** — Watch `fp_render/render.mp4`. The mesh overlay should stay locked to the object. Drifting indicates poor FoundationPose tracking.
+
+2. **World poses** — Inspect `poses_world_debug.png`:
+   - Object position (subplot 3): near-flat during Stage 1 and Stage 2
+   - Angular velocity (subplot 5): spike only during stage transition
+   - Vertical lines show detected stage boundaries — verify they match the video
+
+### BundleSDF: FoundationPose weights not found
+
+```
+[error] FoundationPose weights not found at: ...
+```
+
+Download them:
+```bash
+python modules/v2d_foundation_pose/docker/run_download_weights.py \
+  --output_dir data/weights/foundationpose
+```
+
+### BundleSDF: zfar clipping artifacts
+
+If the mesh appears sliced at a fixed distance, the zfar clipping plane is too close. This is patched in the `v2d_bundlesdf` Dockerfile — rebuild the container:
+```bash
+docker build -t v2d_bundlesdf modules/v2d_bundlesdf/docker/
+```
+
+### Internal: cross-container symlinks
+
+The pipeline uses **relative symlinks** to map sparse keyframe indices (from SfM) to contiguous `left{N:06d}` indices expected by BundleSDF, without copying large depth and mask files.
+
+All symlink targets must live under `job_dir`. The `v2d_hoi_object_reconstruction` container and the `v2d_bundlesdf` container each mount `job_dir` at a different internal path, so a relative symlink like `../../depth/000001.png` resolves correctly in both.
+
+**Constraints:**
+- `depth/` must be a direct subdirectory of `job_dir` ✓
+- `masks/` must also be a direct subdirectory of `job_dir` ✓
+
+If you supply external depth or mask directories outside `job_dir`, symlinks inside BundleSDF will be broken. Keep all intermediate data within `job_dir`.
+
+### FoundationPose Tracking Only
+
+To run FoundationPose tracking with an existing mesh (skips reconstruction):
 
 ```bash
 python modules/v2d_hoi_object_reconstruction/docker/run_reconstruction.py \
@@ -154,51 +297,15 @@ python modules/v2d_hoi_object_reconstruction/docker/run_reconstruction.py \
 
 Place the mesh at `<job_dir>/mesh_input.obj` before running.
 
+---
+
 ## Tools
 
 | Tool | Location | Description |
 |------|----------|-------------|
-| `detect_stage1_end.py` | `v2d_hoi_object_reconstruction/lib/` | Manually inspect Stage-1 end detection from a CuSFM trajectory |
-| `visualize_reconstruction_standalone.py` | `v2d_bundlesdf/tools/` | Visualize BundleSDF camera trajectory and point cloud for reconstruction-quality checks |
+| `detect_stage1_end.py` | `v2d_hoi_object_reconstruction/lib/` | Manually inspect Stage-1 end detection from CuSFM trajectory |
+| `visualize_reconstruction_standalone.py` | `v2d_bundlesdf/tools/` | Visualize camera trajectory and point cloud for reconstruction-quality checks |
 | `plot_tum_file.py` | `v2d_cusfm/tools/` | Plot TUM-format trajectory file |
 | `spin_mesh_video.py` | `tools/` | Render a spinning video of a mesh |
 | `fuse_depth_to_pointcloud.py` | `v2d_bundlesdf/tools/` | Fuse depth maps into a point cloud |
 | `view_glb.py` | `tools/` | View a `.glb` mesh file |
-
-## Troubleshooting
-
-Start from the final mesh and work backwards.
-
-### Step 1 — Check the final mesh
-
-Open `merged_recon/textured_mesh.obj`. If it looks good, you're done.
-
-### Step 2 — If the final mesh is bad, check Stage-1 mesh
-
-Open `stage1_recon/textured_mesh.obj`.
-
-**If Stage-1 mesh is bad**, the inputs to NeRF are wrong. Check in order:
-
-1. **Masks** — Spot-check `masks/0/`. The object should be cleanly segmented in every frame.
-   - Box wrong: first try a more specific `--prompt` (e.g. `"red spray bottle"` instead of `"bottle"`); if the box is still wrong, override with `--bbox x1,y1,x2,y2`
-   - Mask drifts: adjust `foundationpose.reference_frame` in the pipeline config
-
-2. **Camera poses and point cloud** — Inspect the camera trajectory and fused point cloud used for Stage-1 NeRF:
-   ```bash
-   python modules/v2d_bundlesdf/tools/visualize_reconstruction_standalone.py <job_dir>/stage1_recon/
-   ```
-   Cameras should orbit the object cleanly and the point cloud should form a coherent object shape. Bad poses or a noisy/sparse point cloud will produce poor NeRF geometry regardless of mask quality.
-
-3. **Holes on the mesh surface** — If cameras and point cloud look good but the mesh has surface holes, try adjusting parameters in `lib/data/configs/theseus_optimizer_hawk.yaml`:
-   - Increase `nerf.trunc` to fill holes in under-observed regions (default `0.01`, try `0.02`)
-   - Decrease `nerf.mesh_resolution` for a finer voxel grid, must be ≤ `trunc` (default `0.005`, try `0.003`)
-   - Increase `texture_bake.texture_res` for sharper texture (default `2048`, try `4096`)
-
-**If Stage-1 mesh is good but final mesh is bad**, the problem is in the two-stage alignment. Check:
-
-1. **FP tracking** — Watch `fp_render/render.mp4`. The Stage-1 mesh overlay should stay locked to the object throughout. Drifting or jumping indicates poor FoundationPose tracking.
-
-2. **World poses** — Inspect `poses_world_debug.png`:
-   - Object position (subplot 3) should be near-flat during Stage 1 and Stage 2
-   - Angular velocity (subplot 5) should spike only during the transition between stages
-   - Vertical lines show the detected stage boundaries — verify they match the video

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/README.md
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/README.md
@@ -189,7 +189,10 @@ mapping_data_dir  (images + frames_meta.json)
 S1. Select frames       → sam3d/selected_frames.json  (one per azimuthal bin)
 S2. SAM3D               → sam3d/<frame_id>/mesh.glb + transform.json + intrinsics.json
 S3. SRT scale           → sam3d/<frame_id>/srt/srt_result.json + output_scaled.glb
+                          (Stage-1 frames only — object stationary)
 S4. Render debug        → sam3d/<frame_id>/render_debug.jpg
+S5. Render video        → sam3d/<frame_id>/render_video.mp4
+                          (textured mesh overlaid on Stage-1 keyframes via open3d)
 ```
 
 ### Results
@@ -197,7 +200,8 @@ S4. Render debug        → sam3d/<frame_id>/render_debug.jpg
 - `sam3d/<frame_id>/mesh.glb` — raw SAM3D mesh (SAM3D camera space)
 - `sam3d/<frame_id>/srt/output_scaled.glb` — scale-corrected mesh (world space)
 - `sam3d/<frame_id>/srt/srt_result.json` — estimated scale, rotation, translation
-- `sam3d/<frame_id>/render_debug.jpg` — SAM3D mesh overlaid on source image
+- `sam3d/<frame_id>/render_debug.jpg` — SAM3D mesh overlaid on source image (single frame)
+- `sam3d/<frame_id>/render_video.mp4` — textured mesh overlaid on all Stage-1 keyframes
 
 ### Key Options
 
@@ -211,7 +215,7 @@ S4. Render debug        → sam3d/<frame_id>/render_debug.jpg
 
 ```
 --skip_prepare  --skip_sfm  --skip_stage1_detect  --skip_dino  --skip_depth  --skip_mask
---skip_select_frames  --skip_sam3d  --skip_srt_scale  --skip_render_debug
+--skip_select_frames  --skip_sam3d  --skip_srt_scale  --skip_render_debug  --skip_render_video
 ```
 
 ---

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/docker/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
 ]
 
 [tool.setuptools]
-packages = ["v2d_hoi_object_reconstruction.docker"]
+packages = ["v2d_hoi_object_reconstruction.docker", "v2d_hoi_object_reconstruction.lib"]
 
 [tool.setuptools.package-dir]
 "v2d_hoi_object_reconstruction.docker" = "."
+"v2d_hoi_object_reconstruction.lib" = "../lib"

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/docker/run_reconstruction.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/docker/run_reconstruction.py
@@ -31,8 +31,9 @@ Two modes:
  [4a. Depth (optional)]           – FoundationStereo depth, used by SRT scale (--sam3d_use_depth)
   S1. Select frames               – pick one frame per azimuthal bin (60° default)
   S2. SAM3D                       – run SAM3D on each selected frame → GLB mesh
-  S3. SRT scale                   – estimate scale+pose from silhouette IoU + optional depth
-  S4. Render debug                – render debug overlay for each SAM3D mesh
+  S3. SRT scale                   – estimate scale+pose using Stage-1 silhouettes only
+  S4. Render debug                – render debug overlay image for each SAM3D mesh
+  S5. Render video                – project SRT mesh onto all Stage-1 keyframes → render_video.mp4
 
 Two frames_meta.json files are used:
   - mapping_data_dir/frames_meta.json          : input metadata (timestamps, no poses)
@@ -57,7 +58,7 @@ Skip flags (BundleSDF):
 
 Skip flags (SAM3D):
     --skip_prepare  --skip_sfm  --skip_stage1_detect  --skip_dino  --skip_depth  --skip_mask
-    --skip_select_frames  --skip_sam3d  --skip_srt_scale  --skip_render_debug
+    --skip_select_frames  --skip_sam3d  --skip_srt_scale  --skip_render_debug  --skip_render_video
 """
 
 import argparse
@@ -326,6 +327,8 @@ def main():
                         help="SAM3D mode: skip SRT scale estimation")
     parser.add_argument("--skip_render_debug",  action="store_true",
                         help="SAM3D mode: skip SAM3D debug render")
+    parser.add_argument("--skip_render_video",  action="store_true",
+                        help="SAM3D mode: skip Stage-1 overlay video render")
 
     args = parser.parse_args()
 
@@ -474,6 +477,15 @@ def main():
         _step("sfm", _sfm)
 
     # ── Step 2b: Auto-detect Stage-1 end (if not manually specified) ─────────
+    # Even when skipping detection, try to load an existing result.json so that
+    # downstream steps (SRT, render_video) have stage1_end_frame available.
+    if stage1_end_frame is None:
+        _existing = Path(job_dir) / "stage1_detect_debug" / "result.json"
+        if _existing.exists():
+            with open(_existing) as _f:
+                stage1_end_frame = json.load(_f).get("stage1_end_frame")
+            print(f"[pipeline] stage1_end_frame={stage1_end_frame} (loaded from existing result.json)")
+
     if stage1_end_frame is None and not args.skip_stage1_detect:
         print("[pipeline] auto-detecting Stage-1 end from CuSFM trajectory")
         detect_script = Path(__file__).parent.parent / "lib" / "detect_stage1_end.py"
@@ -861,6 +873,7 @@ def main():
                     glb_path=glb_path,
                     output_dir=srt_out,
                     use_depth=args.sam3d_use_depth,
+                    stage1_end_frame=stage1_end_frame,
                 )
                 elapsed = time.time() - t0
                 _timings[f"srt_{frame_id}"] = elapsed
@@ -891,6 +904,41 @@ def main():
                 elapsed = time.time() - t0
                 _timings[f"render_debug_{frame_id}"] = elapsed
                 print(f"[pipeline] render_debug {frame_id} done in {elapsed:.1f}s")
+
+        # ── Step S5: Stage-1 textured overlay video (pyrender inside v2d_sam3d) ──────
+        if not args.skip_render_video:
+            if stage1_end_frame is None:
+                print("[pipeline] skip_render_video: stage1_end_frame unknown, cannot render Stage-1 video",
+                      file=sys.stderr)
+            else:
+                c_job = "/data/job"
+                for frame_id in selected_frames:
+                    srt_out = sam3d_dir / frame_id / "srt"
+                    if not (srt_out / "output_scaled.glb").exists():
+                        print(f"[pipeline] render_video {frame_id}: srt output not found, skipping")
+                        continue
+                    frames_dir = sam3d_dir / frame_id / "render_video_frames"
+                    video_path = sam3d_dir / frame_id / "render_video.mp4"
+                    c_glb     = f"{c_job}/sam3d/{frame_id}/srt/output_scaled.glb"
+                    c_out     = f"{c_job}/sam3d/{frame_id}/render_video_frames"
+                    print(f"[pipeline] render_video {frame_id} (stage1_end_frame={stage1_end_frame})")
+                    # Mount local modules/ as /workspace so new lib files are
+                    # picked up without rebuilding the container (editable install).
+                    _modules_dir = str(Path(__file__).parents[2])
+                    _step(f"render_video_{frame_id}", lambda _fid=frame_id, _cg=c_glb, _co=c_out, _md=_modules_dir: _run_gpu(
+                        IMAGE_SAM3D,
+                        [
+                            "python", "-m", "v2d.sam3d.lib.render_textured_video",
+                            "--job_dir",          c_job,
+                            "--glb_path",         _cg,
+                            "--output_dir",       _co,
+                            "--stage1_end_frame", str(stage1_end_frame),
+                        ],
+                        mounts=[(job_dir, "/data/job"), (_md, "/workspace")],
+                        user=f"{os.getuid()}:{os.getgid()}",
+                    ))
+                    _step(f"render_video_stitch_{frame_id}", lambda _fd=frames_dir, _vp=video_path:
+                          stitch_mp4(str(_fd), str(_vp)))
 
     total = time.time() - _t_total
     print("\n[pipeline] ── Timing summary ──────────────────────────")

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/docker/run_reconstruction.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/docker/run_reconstruction.py
@@ -1,63 +1,63 @@
 """
 End-to-end object reconstruction pipeline (HOST-SIDE orchestrator).
 
-Two-stage scan (object stationary → rotated → stationary) → complete textured mesh.
+Two modes:
+  bundlesdf (default) – Two-stage scan (stationary → rotated → stationary) → textured mesh
+  sam3d               – Select representative frames → SAM3D per-frame → SRT scale estimation
 
-Steps:
-  0.  MCAP convert (optional)     – convert ROS2 MCAP bag → mapping_data directory
-                                    (only when --mcap_file is used instead of --mapping_data_dir)
+── BundleSDF steps ──────────────────────────────────────────────────────────────────
   1.  prepare_FP_folder           – copy images, write calibration + video
-  2.  CuSFM                       – run on mapping_data_dir (original images)
-                                    → job_dir/sfm/keyframes/frames_meta.json with poses
+  2.  CuSFM                       – → job_dir/sfm/keyframes/frames_meta.json with poses
   2b. Stage-1 auto-detect         – detect Stage-1 end from CuSFM trajectory slope
-                                    (skipped if --stage1_end_frame/timestamp provided)
   3.  Grounding DINO               – detect object bbox from text prompt
   4a. Depth (parallel workers)    – FoundationStereo depth for ALL frames
   4b. Mask                        – SAM2 masks for ALL frames
-  5.  Stage-1 recon setup         – filter Stage-1 SfM keyframes,
-                                    create stage1_recon/ with depth symlinks
+  5.  Stage-1 recon setup         – filter Stage-1 SfM keyframes + depth symlinks
   6.  Stage-1 NeRF                – reconstruct Stage-1 mesh (bottom missing)
   7.  Center mesh                 – shift mesh centroid to origin
   8.  FoundationPose tracking     – track all frames with Stage-1 mesh
   9.  World poses                 – compute T_world_from_obj + auto-detect stages
-  10. Merged recon setup          – align Stage-2 keyframes into Stage-1 obj frame,
-                                    create merged_recon/ with depth symlinks
+  10. Merged recon setup          – align Stage-2 keyframes into Stage-1 obj frame
   11. Full NeRF                   – reconstruct complete mesh from both stages
+  12. FP tracking (final)         – track all frames with final textured mesh
+  13. FP render (final)           – render overlay video with final textured mesh
 
-  12. FP tracking (final)     – track all frames with final textured mesh
-  13. FP render (final)        – render overlay video with final textured mesh
+── SAM3D steps ──────────────────────────────────────────────────────────────────────
+  1.  prepare_FP_folder           – copy images, write calibration + video
+  2.  CuSFM                       – camera poses for frame selection + SRT scale
+  2b. Stage-1 auto-detect         – detect Stage-1 end (used to exclude transition frames)
+  3.  Grounding DINO               – detect object bbox from text prompt
+  4b. Mask                        – SAM2 masks for ALL frames (used for SRT scale)
+ [4a. Depth (optional)]           – FoundationStereo depth, used by SRT scale (--sam3d_use_depth)
+  S1. Select frames               – pick one frame per azimuthal bin (60° default)
+  S2. SAM3D                       – run SAM3D on each selected frame → GLB mesh
+  S3. SRT scale                   – estimate scale+pose from silhouette IoU + optional depth
+  S4. Render debug                – render debug overlay for each SAM3D mesh
 
 Two frames_meta.json files are used:
-  - mapping_data_dir/frames_meta.json  : input metadata (timestamps, no poses)
-                                         → used to build timestamp → seq_idx map
-  - job_dir/sfm/keyframes/frames_meta.json : CuSFM output (poses for keyframes)
-                                             → used for camera-to-world poses
+  - mapping_data_dir/frames_meta.json          : input metadata (timestamps, no poses)
+  - job_dir/sfm/keyframes/frames_meta.json     : CuSFM output (camera-to-world poses)
 
-Usage (from mapping_data directory):
+Usage:
     python run_reconstruction.py \\
         --mapping_data_dir /home/.../mapping_data/2026-02-18_..._bowl \\
         --job_dir          /data/hoi_obj_recon/2026-02-18_..._bowl \\
-        --prompt           "bowl" \\
-        --config           /workspace/v2d_bundlesdf/lib/data/configs/theseus_optimizer_hawk.yaml
+        --prompt           "bowl"
 
-Usage (from raw MCAP bag directory):
+    # SAM3D mode:
     python run_reconstruction.py \\
-        --mcap_file  /path/to/2026-03-12_airplane/ \\
-        --job_dir    /data/hoi_obj_recon/2026-03-12_airplane \\
-        --prompt     "airplane" \\
-        --real2sim_path /home/jryu/workspaces/real2sim   # optional if real2sim is pip-installed
+        --mapping_data_dir ... --job_dir ... --prompt "bowl" \\
+        --mode sam3d [--sam3d_use_depth] [--sam3d_bin_deg 60] [--sam3d_seed 42]
 
-    # Optional: override auto-detected Stage-1 split
-        --stage1_end_frame 400          # explicit frame index
-        --stage1_end_timestamp <ns>     # or by nanosecond timestamp
-        --stage1_buffer_deg 10          # buffer before detected transition (default: 10°)
-
-Skip flags (to resume from a checkpoint):
-    --skip_mcap_convert
-    --skip_prepare  --skip_sfm  --skip_dino  --skip_depth  --skip_mask
+Skip flags (BundleSDF):
+    --skip_prepare  --skip_sfm  --skip_stage1_detect  --skip_dino  --skip_depth  --skip_mask
     --skip_stage1_setup  --skip_stage1_nerf  --skip_center_mesh
     --skip_fp_tracking  --skip_fp_render  --skip_world_poses  --skip_merged_setup  --skip_full_nerf
     --skip_final_fp_tracking  --skip_final_fp_render
+
+Skip flags (SAM3D):
+    --skip_prepare  --skip_sfm  --skip_stage1_detect  --skip_dino  --skip_depth  --skip_mask
+    --skip_select_frames  --skip_sam3d  --skip_srt_scale  --skip_render_debug
 """
 
 import argparse
@@ -75,6 +75,14 @@ import numpy as np
 from v2d.docker.container import run_in_container
 from v2d.foundation_pose.docker.run_video_to_poses import run_video_to_poses as _run_fp_tracking
 from v2d.common.datatypes import Transform3d
+from v2d.sam3d.docker.run_image_to_mesh import run_image_to_mesh as _run_sam3d
+from v2d.sam3d.docker.run_render_debug_image import run_render_debug_image as _run_sam3d_render
+
+from v2d_hoi_object_reconstruction.lib.select_sam3d_frames import (
+    select_frames_by_angle_bins,
+    select_frames_fallback,
+)
+from v2d_hoi_object_reconstruction.lib.scale_mesh_srt import estimate_srt_for_frame
 
 
 # ── Image names ────────────────────────────────────────────────────────────────
@@ -86,6 +94,7 @@ IMAGE_GROUNDING_DINO        = "v2d_grounding_dino"
 IMAGE_FOUNDATION_STEREO     = "v2d_foundation_stereo"
 IMAGE_SAM2                  = "v2d_sam2"
 IMAGE_FOUNDATIONPOSE_RENDER = "v2d_foundation_pose"
+IMAGE_SAM3D                 = "v2d_sam3d"
 
 
 # ── Constants ──────────────────────────────────────────────────────────────────
@@ -94,9 +103,10 @@ from v2d_hoi_object_reconstruction.docker._pipeline_utils import (
     IMAGE_EXTENSIONS, detect_gpu_ids, count_images,
 )
 
-_DATA_DIR         = Path(__file__).parents[3] / "data"    # reconstruction/data/
-_WEIGHTS_DIR      = _DATA_DIR / "weights"                 # reconstruction/data/weights/
-_FP_WEIGHTS_DIR   = _WEIGHTS_DIR / "foundationpose"       # reconstruction/data/weights/foundationpose/
+_DATA_DIR           = Path(__file__).parents[3] / "data"    # reconstruction/data/
+_WEIGHTS_DIR        = _DATA_DIR / "weights"                 # reconstruction/data/weights/
+_FP_WEIGHTS_DIR     = _WEIGHTS_DIR / "foundationpose"       # reconstruction/data/weights/foundationpose/
+_SAM3D_WEIGHTS_DIR  = _WEIGHTS_DIR / "sam3d"               # reconstruction/data/weights/sam3d/
 
 # Config paths (host-side; mounted into containers at runtime)
 _DEFAULT_PIPELINE_CONFIG_HOST = str(Path(__file__).parent.parent / "lib" / "data" / "configs" / "hoi_pipeline.yaml")
@@ -243,16 +253,8 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
-    input_group = parser.add_mutually_exclusive_group(required=True)
-    input_group.add_argument("--mapping_data_dir",
+    parser.add_argument("--mapping_data_dir", required=True,
                         help="Raw mapping data directory (frames_meta.json + images)")
-    input_group.add_argument("--mcap_file",
-                        help="ROS2 MCAP bag directory (e.g. /data/2026-03-12_airplane/); "
-                             "will be auto-converted to mapping_data at <job_dir>/mapping_data/ "
-                             "(requires real2sim)")
-    parser.add_argument("--real2sim_path", default=None,
-                        help="Path to real2sim repo (used with --mcap_file). "
-                             "If not set, uses installed real2sim package.")
     parser.add_argument("--job_dir", required=True,
                         help="Output root (e.g. /data/hoi_obj_recon/<job>)")
     parser.add_argument("--prompt", required=True,
@@ -284,9 +286,17 @@ def main():
     parser.add_argument("--gpu_ids", type=int, nargs="+", default=None,
                         help="GPU IDs (default: auto-detect)")
 
+    # Mode
+    parser.add_argument("--mode", choices=["bundlesdf", "sam3d"], default="bundlesdf",
+                        help="Reconstruction mode (default: bundlesdf)")
+    parser.add_argument("--sam3d_use_depth", action="store_true",
+                        help="SAM3D mode: also run FoundationStereo depth for SRT scale estimation")
+    parser.add_argument("--sam3d_bin_deg", type=float, default=60.0,
+                        help="SAM3D mode: azimuthal bin size for frame selection (default: 60°)")
+    parser.add_argument("--sam3d_seed", type=int, default=42,
+                        help="SAM3D mode: random seed passed to SAM3D (default: 42)")
+
     # Skip flags
-    parser.add_argument("--skip_mcap_convert",   action="store_true",
-                        help="Skip MCAP→mapping_data conversion (mapping_data must already exist)")
     parser.add_argument("--skip_prepare",        action="store_true")
     parser.add_argument("--skip_sfm",            action="store_true")
     parser.add_argument("--skip_stage1_detect",  action="store_true",
@@ -307,6 +317,15 @@ def main():
                         help="Skip FoundationPose tracking with final textured mesh")
     parser.add_argument("--skip_final_fp_render",      action="store_true",
                         help="Skip FoundationPose render overlay video with final textured mesh")
+    # SAM3D-specific skip flags
+    parser.add_argument("--skip_select_frames", action="store_true",
+                        help="SAM3D mode: skip representative-frame selection")
+    parser.add_argument("--skip_sam3d",         action="store_true",
+                        help="SAM3D mode: skip SAM3D mesh reconstruction (reuse existing GLBs)")
+    parser.add_argument("--skip_srt_scale",     action="store_true",
+                        help="SAM3D mode: skip SRT scale estimation")
+    parser.add_argument("--skip_render_debug",  action="store_true",
+                        help="SAM3D mode: skip SAM3D debug render")
 
     args = parser.parse_args()
 
@@ -334,32 +353,7 @@ def main():
     job_dir = os.path.abspath(args.job_dir)
     os.makedirs(job_dir, exist_ok=True)
 
-    # ── Step 0: MCAP → mapping_data conversion ────────────────────────────────
-    if args.mcap_file:
-        mapping_data_dir = Path(job_dir) / "mapping_data"
-        if not args.skip_mcap_convert:
-            print(f"[pipeline] converting MCAP → {mapping_data_dir}")
-            mapping_data_dir.mkdir(parents=True, exist_ok=True)
-
-            env = os.environ.copy()
-            if args.real2sim_path:
-                env["PYTHONPATH"] = f"{args.real2sim_path}:{env.get('PYTHONPATH', '')}"
-
-            convert_cmd = [
-                sys.executable, "-m", "real2sim.rosbag_to_mapping_data.main",
-                "--sensor_data_bag_file", args.mcap_file,
-                "--output_folder_path",  str(mapping_data_dir),
-                "--no-generate_edex",
-            ]
-
-            result = subprocess.run(convert_cmd, env=env)
-            if result.returncode != 0:
-                raise RuntimeError("MCAP conversion failed")
-            print(f"[pipeline] MCAP conversion done → {mapping_data_dir}")
-        else:
-            print(f"[pipeline] skipping MCAP conversion, using {mapping_data_dir}")
-    else:
-        mapping_data_dir = Path(os.path.abspath(args.mapping_data_dir))
+    mapping_data_dir = Path(os.path.abspath(args.mapping_data_dir))
 
     ref_frame        = ref_frame_cfg
     gpu_ids          = args.gpu_ids or detect_gpu_ids()
@@ -508,7 +502,7 @@ def main():
         _timings["stage1_detect"] = time.time() - t0
         print(f"[pipeline] stage1_detect done in {_timings['stage1_detect']:.1f}s → seq_idx {stage1_end_frame}")
 
-    if stage1_end_frame is None:
+    if stage1_end_frame is None and args.mode == "bundlesdf":
         raise ValueError(
             "Stage-1 end frame could not be determined. "
             "Provide --stage1_end_frame, --stage1_end_timestamp, "
@@ -566,7 +560,10 @@ def main():
             dino_bbox_str = ",".join(str(int(b)) for b in [box['x0'], box['y0'], box['x1'], box['y1']])
 
     # ── Steps 4a + 4b: Depth + Mask (parallel) ───────────────────────────────
-    if not args.skip_depth or not args.skip_mask:
+    # In SAM3D mode depth is optional (only if --sam3d_use_depth); mask is always needed
+    _run_depth = not args.skip_depth and (args.mode == "bundlesdf" or args.sam3d_use_depth)
+    _run_mask  = not args.skip_mask
+    if _run_depth or _run_mask:
         n_frames = count_images(os.path.join(job_dir, "left"))
 
         def run_depth():
@@ -594,9 +591,9 @@ def main():
         t0 = time.time()
         tasks = {}
         with ThreadPoolExecutor(max_workers=2) as pool:
-            if not args.skip_depth:
+            if _run_depth:
                 tasks['depth'] = pool.submit(run_depth)
-            if not args.skip_mask:
+            if _run_mask:
                 tasks['mask']  = pool.submit(run_mask)
             for name, fut in tasks.items():
                 fut.result()
@@ -606,7 +603,7 @@ def main():
         print(f"[pipeline] depth+mask done in {elapsed:.1f}s")
 
     # ── Step 5: Stage-1 recon setup ───────────────────────────────────────────
-    if not args.skip_stage1_setup:
+    if args.mode == "bundlesdf" and not args.skip_stage1_setup:
         print("[pipeline] setting up Stage-1 reconstruction directory")
         _step("stage1_setup", lambda: run_in_container(
             image=IMAGE_HOI,
@@ -629,7 +626,7 @@ def main():
     if nerf_config_path:
         _nerf_inputs["config"] = nerf_config_path
 
-    if not args.skip_stage1_nerf:
+    if args.mode == "bundlesdf" and not args.skip_stage1_nerf:
         print("[pipeline] running Stage-1 NeRF reconstruction")
         bbox_str = dino_bbox_str
         _step("stage1_nerf", lambda: run_in_container(
@@ -645,7 +642,7 @@ def main():
         ))
 
     # ── Step 7: Center mesh ───────────────────────────────────────────────────
-    if not args.skip_center_mesh:
+    if args.mode == "bundlesdf" and not args.skip_center_mesh:
         print("[pipeline] centering mesh")
         _step("center_mesh", lambda: run_in_container(
             image=IMAGE_HOI,
@@ -655,7 +652,7 @@ def main():
         ))
 
     # ── Step 8: FoundationPose tracking ───────────────────────────────────────
-    if not args.skip_fp_tracking:
+    if args.mode == "bundlesdf" and not args.skip_fp_tracking:
         if not os.path.exists(mask_path):
             print(f"[error] mask not found: {mask_path}", file=sys.stderr)
             sys.exit(1)
@@ -681,7 +678,7 @@ def main():
         ))
 
     # ── Step 8b: FoundationPose render overlay ────────────────────────────────
-    if not args.skip_fp_render:
+    if args.mode == "bundlesdf" and not args.skip_fp_render:
         _convert_poses_to_matrix(poses_dir)
         print("[pipeline] rendering FoundationPose overlay video")
         _step("fp_render", lambda: _run_gpu(
@@ -703,7 +700,7 @@ def main():
             os.path.join(job_dir, "fp_render", "render.mp4")))
 
     # ── Step 9: World poses + stage detection ─────────────────────────────────
-    if not args.skip_world_poses:
+    if args.mode == "bundlesdf" and not args.skip_world_poses:
         print("[pipeline] computing world poses and detecting stages")
         _step("world_poses", lambda: run_in_container(
             image=IMAGE_HOI,
@@ -722,7 +719,7 @@ def main():
         ))
 
     # ── Step 10: Merged recon setup ───────────────────────────────────────────
-    if not args.skip_merged_setup:
+    if args.mode == "bundlesdf" and not args.skip_merged_setup:
         print("[pipeline] setting up merged reconstruction directory")
         _step("merged_setup", lambda: run_in_container(
             image=IMAGE_HOI,
@@ -741,7 +738,7 @@ def main():
         ))
 
     # ── Step 11: Full NeRF reconstruction ─────────────────────────────────────
-    if not args.skip_full_nerf:
+    if args.mode == "bundlesdf" and not args.skip_full_nerf:
         print("[pipeline] running full NeRF reconstruction (both stages)")
         bbox_str = dino_bbox_str
         _step("full_nerf", lambda: run_in_container(
@@ -757,7 +754,7 @@ def main():
         ))
 
     # ── Step 12: FP tracking with final textured mesh ────────────────────────
-    if not args.skip_final_fp_tracking:
+    if args.mode == "bundlesdf" and not args.skip_final_fp_tracking:
         print("[pipeline] running FoundationPose tracking with final textured mesh")
         _step("final_fp_tracking", lambda: _run_fp_tracking(
             video_path=os.path.join(job_dir, "video.mp4"),
@@ -771,7 +768,7 @@ def main():
         ))
 
     # ── Step 13: FP render overlay with final textured mesh ───────────────────
-    if not args.skip_final_fp_render:
+    if args.mode == "bundlesdf" and not args.skip_final_fp_render:
         _convert_poses_to_matrix(poses_final_dir)
         print("[pipeline] rendering FoundationPose overlay video with final textured mesh")
         _step("final_fp_render", lambda: _run_gpu(
@@ -791,6 +788,109 @@ def main():
         _step("final_fp_render_stitch", lambda: stitch_mp4(
             os.path.join(job_dir, "fp_render_final"),
             os.path.join(job_dir, "fp_render_final", "render.mp4")))
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # SAM3D pipeline (steps S1–S4)
+    # ══════════════════════════════════════════════════════════════════════════
+    if args.mode == "sam3d":
+        sam3d_dir = Path(job_dir) / "sam3d"
+        sam3d_dir.mkdir(parents=True, exist_ok=True)
+
+        # ── Step S1: Select representative frames ─────────────────────────────
+        selected_frames: list[str] = []
+        if not args.skip_select_frames:
+            print(f"[pipeline] selecting SAM3D frames (bin_deg={args.sam3d_bin_deg}°)")
+            t0 = time.time()
+            selected_frames = select_frames_by_angle_bins(
+                Path(job_dir), bin_deg=args.sam3d_bin_deg
+            )
+            if not selected_frames:
+                print("  [pipeline] SfM fallback: using top-N mask-area frames")
+                selected_frames = select_frames_fallback(Path(job_dir), n=6)
+            _timings["select_frames"] = time.time() - t0
+            print(f"[pipeline] select_frames done in {_timings['select_frames']:.1f}s "
+                  f"→ {len(selected_frames)} frames: {selected_frames}")
+            # Persist selection so later steps can resume
+            (sam3d_dir / "selected_frames.json").write_text(
+                json.dumps(selected_frames, indent=2)
+            )
+        else:
+            sel_path = sam3d_dir / "selected_frames.json"
+            if sel_path.exists():
+                selected_frames = json.loads(sel_path.read_text())
+                print(f"[pipeline] skip_select_frames: loaded {len(selected_frames)} frames from {sel_path}")
+            else:
+                print("[warning] skip_select_frames but selected_frames.json not found; "
+                      "SAM3D and SRT steps will have no frames to process", file=sys.stderr)
+
+        # ── Step S2: SAM3D mesh reconstruction per frame ──────────────────────
+        if not args.skip_sam3d:
+            for frame_id in selected_frames:
+                frame_out = sam3d_dir / frame_id
+                frame_out.mkdir(parents=True, exist_ok=True)
+                image_path  = os.path.join(job_dir, "left",    f"{frame_id}.jpg")
+                mask_path_f = os.path.join(job_dir, "masks", "0", f"{frame_id}.png")
+                print(f"[pipeline] SAM3D frame {frame_id}")
+                t0 = time.time()
+                _run_sam3d(
+                    image_path=image_path,
+                    mask_path=mask_path_f,
+                    mesh_path=str(frame_out / "mesh.glb"),
+                    transform_path=str(frame_out / "transform.json"),
+                    intrinsics_path=str(frame_out / "intrinsics.json"),
+                    weights_dir=str(_SAM3D_WEIGHTS_DIR),
+                    seed=args.sam3d_seed,
+                )
+                elapsed = time.time() - t0
+                _timings[f"sam3d_{frame_id}"] = elapsed
+                print(f"[pipeline] SAM3D {frame_id} done in {elapsed:.1f}s")
+
+        # ── Step S3: SRT scale estimation ─────────────────────────────────────
+        if not args.skip_srt_scale:
+            for frame_id in selected_frames:
+                glb_path = sam3d_dir / frame_id / "mesh.glb"
+                if not glb_path.exists():
+                    print(f"[warning] SAM3D output not found for frame {frame_id}: {glb_path}",
+                          file=sys.stderr)
+                    continue
+                srt_out = sam3d_dir / frame_id / "srt"
+                print(f"[pipeline] SRT scale estimation for frame {frame_id}")
+                t0 = time.time()
+                srt_result = estimate_srt_for_frame(
+                    job_dir=Path(job_dir),
+                    glb_path=glb_path,
+                    output_dir=srt_out,
+                    use_depth=args.sam3d_use_depth,
+                )
+                elapsed = time.time() - t0
+                _timings[f"srt_{frame_id}"] = elapsed
+                scale = srt_result.get("scale", float("nan"))
+                print(f"[pipeline] SRT {frame_id} done in {elapsed:.1f}s  scale={scale:.4f}")
+
+        # ── Step S4: Render debug images ──────────────────────────────────────
+        # Uses the original SAM3D transform/intrinsics so the mesh renders back
+        # onto the source image from the SAM3D viewpoint.
+        if not args.skip_render_debug:
+            for frame_id in selected_frames:
+                frame_out = sam3d_dir / frame_id
+                glb_path        = frame_out / "mesh.glb"
+                transform_path  = frame_out / "transform.json"
+                intrinsics_path = frame_out / "intrinsics.json"
+                if not glb_path.exists() or not transform_path.exists():
+                    continue
+                image_path = os.path.join(job_dir, "left", f"{frame_id}.jpg")
+                print(f"[pipeline] SAM3D render debug frame {frame_id}")
+                t0 = time.time()
+                _run_sam3d_render(
+                    image_path=image_path,
+                    mesh_path=str(glb_path),
+                    transform_path=str(transform_path),
+                    intrinsics_path=str(intrinsics_path),
+                    output_image_path=str(frame_out / "render_debug.jpg"),
+                )
+                elapsed = time.time() - t0
+                _timings[f"render_debug_{frame_id}"] = elapsed
+                print(f"[pipeline] render_debug {frame_id} done in {elapsed:.1f}s")
 
     total = time.time() - _t_total
     print("\n[pipeline] ── Timing summary ──────────────────────────")

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/scale_mesh_srt.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/scale_mesh_srt.py
@@ -1,0 +1,968 @@
+"""Scale + Rotation + Translation (SRT) estimation for SAM3D meshes.
+
+Multi-view silhouette alignment: optimises scale, orientation, and translation
+so that the SAM3D mesh projects consistently onto the observed object masks.
+
+Ported and adapted from robomem/robomem/sam3d_post/estimate_srt.py.
+Key adaptations vs the original:
+  - Poses come from CuSFM keyframes (sfm/keyframes/frames_meta.json)
+    rather than FoundationPose tracking output.
+  - Depth maps are read from FoundationStereo 16-bit inverse-depth PNG
+    (job_dir/depth/) instead of .npy files.
+  - No external robomem / edex dependencies: intrinsics are loaded from
+    job_dir/intrinsics/<frame>.json (v2d_common CameraIntrinsics format).
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import math
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import cv2
+import numpy as np
+from numpy.typing import NDArray
+from PIL import Image
+from scipy.optimize import minimize
+from scipy.spatial import cKDTree
+from scipy.spatial.transform import Rotation
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Internal camera intrinsics
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class _Intrinsics:
+    fx: float
+    fy: float
+    cx: float
+    cy: float
+    width: int
+    height: int
+
+
+def _load_intrinsics(intrinsics_json: Path) -> _Intrinsics:
+    with open(intrinsics_json) as f:
+        d = json.load(f)
+    return _Intrinsics(
+        fx=float(d["fx"]), fy=float(d["fy"]),
+        cx=float(d["cx"]), cy=float(d["cy"]),
+        width=int(d["width"]), height=int(d["height"]),
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# FrameView
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class FrameView:
+    """One frame's data for silhouette alignment."""
+    frame_name: str
+    intrinsics: _Intrinsics
+    # world-to-camera 4×4 matrix (T_cam_from_world)
+    world_to_cam: NDArray[np.float64]
+    mask_u8: NDArray[np.uint8]
+    dt_to_fg: NDArray[np.float32]
+    mask_boundary_uv: NDArray[np.int32]
+    mask_extent: float = 0.0
+    depth: Optional[NDArray[np.float32]] = None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Low-level helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _compute_dt(mask_u8: NDArray[np.uint8]) -> NDArray[np.float32]:
+    fg = mask_u8 > 127
+    inv = (~fg).astype(np.uint8)
+    return cv2.distanceTransform(inv, distanceType=cv2.DIST_L2, maskSize=3).astype(np.float32)
+
+
+def _mask_boundary(mask_u8: NDArray[np.uint8]) -> NDArray[np.int32]:
+    binary = (mask_u8 > 127).astype(np.uint8) * 255
+    contours, _ = cv2.findContours(binary, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not contours:
+        return np.zeros((0, 2), dtype=np.int32)
+    canvas = np.zeros_like(binary)
+    cv2.drawContours(canvas, contours, -1, 255, 1)
+    ys, xs = np.nonzero(canvas)
+    if xs.size == 0:
+        return np.zeros((0, 2), dtype=np.int32)
+    return np.stack([xs.astype(np.int32), ys.astype(np.int32)], axis=1)
+
+
+def _project(
+    pts_cam: NDArray[np.float64], intr: _Intrinsics
+) -> Tuple[NDArray[np.float32], NDArray[np.float32], NDArray[np.bool_]]:
+    x, y, z = pts_cam[:, 0], pts_cam[:, 1], pts_cam[:, 2]
+    ok = z > 1e-3
+    u = (intr.fx * (x / np.where(ok, z, 1.0)) + intr.cx).astype(np.float32)
+    v = (intr.fy * (y / np.where(ok, z, 1.0)) + intr.cy).astype(np.float32)
+    inb = ok & (u >= 0) & (u < intr.width) & (v >= 0) & (v < intr.height)
+    return u, v, inb
+
+
+def _bilinear(
+    img: NDArray[np.float32], u: NDArray[np.float32], v: NDArray[np.float32]
+) -> NDArray[np.float32]:
+    h, w = img.shape[:2]
+    u0 = np.floor(u).astype(np.int32)
+    v0 = np.floor(v).astype(np.int32)
+    u1 = np.clip(u0 + 1, 0, w - 1)
+    v1 = np.clip(v0 + 1, 0, h - 1)
+    du = (u - u0.astype(np.float32)).astype(np.float32)
+    dv = (v - v0.astype(np.float32)).astype(np.float32)
+    return (
+        (1 - du) * (1 - dv) * img[v0, u0]
+        + du * (1 - dv) * img[v0, u1]
+        + (1 - du) * dv * img[v1, u0]
+        + du * dv * img[v1, u1]
+    ).astype(np.float32)
+
+
+def _huber(x: NDArray[np.float32], delta: float) -> NDArray[np.float32]:
+    absx = np.abs(x)
+    q = absx <= delta
+    out = np.empty_like(x, dtype=np.float32)
+    out[q] = 0.5 * x[q] ** 2
+    out[~q] = delta * (absx[~q] - 0.5 * delta)
+    return out
+
+
+def _raster_iou(
+    u: NDArray[np.float32],
+    v: NDArray[np.float32],
+    mask_u8: NDArray[np.uint8],
+    downsample: int = 4,
+) -> float:
+    h, w = mask_u8.shape
+    hs, ws = h // downsample, w // downsample
+    if hs < 2 or ws < 2:
+        return 1.0
+    gt = cv2.resize(mask_u8, (ws, hs), interpolation=cv2.INTER_AREA)
+    gt_bin = gt > 127
+    us = np.clip((u / downsample).astype(np.int32), 0, ws - 1)
+    vs = np.clip((v / downsample).astype(np.int32), 0, hs - 1)
+    proj = np.zeros((hs, ws), dtype=np.uint8)
+    proj[vs, us] = 1
+    n_proj = int(np.sum(proj))
+    n_gt = int(np.sum(gt_bin))
+    if n_proj < 1 or n_gt < 1:
+        return 1.0
+    r = max(1, min(int(round(math.sqrt(n_gt / n_proj / math.pi))), 8))
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (2 * r + 1, 2 * r + 1))
+    proj = cv2.dilate(proj, kernel, iterations=1)
+    proj_bin = proj > 0
+    intersection = float(np.sum(gt_bin & proj_bin))
+    union = float(np.sum(gt_bin | proj_bin))
+    return 1.0 - intersection / union if union >= 1 else 1.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Data loading
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _aa_to_matrix(aa: dict) -> np.ndarray:
+    axis = np.array([aa["x"], aa["y"], aa["z"]])
+    norm = np.linalg.norm(axis)
+    if norm < 1e-12:
+        return np.eye(3)
+    return Rotation.from_rotvec((axis / norm) * np.deg2rad(aa["angle_degrees"])).as_matrix()
+
+
+def load_sfm_keyframe_poses(job_dir: Path) -> Dict[str, NDArray[np.float64]]:
+    """Load CuSFM left-camera keyframe poses as world-to-camera 4×4 matrices.
+
+    Returns {frame_stem: T_cam_from_world(4×4)} keyed by zero-padded frame ID.
+    """
+    sfm_kf_path = job_dir / "sfm" / "keyframes" / "frames_meta.json"
+    frames_meta_path = job_dir / "frames_meta.json"
+    if not sfm_kf_path.exists() or not frames_meta_path.exists():
+        raise FileNotFoundError(
+            f"SfM keyframe data not found under {job_dir}/sfm/keyframes/"
+        )
+
+    with open(frames_meta_path) as f:
+        meta = json.load(f)
+    cam_params = meta["camera_params_id_to_camera_params"]
+
+    left_sids: dict[int, int] = {}
+    right_sids: set[int] = set()
+    for kf in meta["keyframes_metadata"]:
+        cam_id = kf["camera_params_id"]
+        sid = int(kf["synced_sample_id"])
+        sensor = cam_params[cam_id]["sensor_meta_data"]["sensor_name"]
+        if "front_stereo_camera_left" in sensor:
+            left_sids[sid] = int(kf["timestamp_microseconds"])
+        elif "front_stereo_camera_right" in sensor:
+            right_sids.add(sid)
+
+    common_sids = sorted(set(left_sids) & right_sids)
+    ts_to_seq_idx = {left_sids[sid]: i for i, sid in enumerate(common_sids)}
+
+    with open(sfm_kf_path) as f:
+        sfm = json.load(f)
+
+    poses: Dict[str, NDArray[np.float64]] = {}
+    for kf in sfm["keyframes_metadata"]:
+        if "front_stereo_camera_left" not in kf.get("image_name", ""):
+            continue
+        ts_us = int(kf["timestamp_microseconds"])
+        seq_idx = ts_to_seq_idx.get(ts_us)
+        if seq_idx is None:
+            continue
+        aa = kf["camera_to_world"]["axis_angle"]
+        t_d = kf["camera_to_world"]["translation"]
+        R_c2w = _aa_to_matrix(aa)
+        t_c2w = np.array([t_d["x"], t_d["y"], t_d["z"]])
+        # Build camera-to-world 4×4, then invert → world-to-camera
+        T_c2w = np.eye(4, dtype=np.float64)
+        T_c2w[:3, :3] = R_c2w
+        T_c2w[:3, 3] = t_c2w
+        T_w2c = np.linalg.inv(T_c2w)
+        poses[f"{seq_idx:06d}"] = T_w2c
+
+    if not poses:
+        raise ValueError("No left-camera keyframes found in SfM output")
+    return poses
+
+
+def load_depth_png(depth_path: Path) -> NDArray[np.float32]:
+    """Load a FoundationStereo 16-bit inverse-depth PNG → float32 depth in metres."""
+    img = Image.open(depth_path)
+    inv_depth = np.array(img).astype(np.float32)
+    # Encoding: pixel = 65535 * (1 / (depth_m + 1))  →  depth_m = 65535/pixel - 1
+    with np.errstate(divide="ignore", invalid="ignore"):
+        depth_m = np.where(inv_depth > 0, 65535.0 / inv_depth - 1.0, 0.0)
+    return depth_m.astype(np.float32)
+
+
+def load_glb_vertices(glb_path: Path) -> NDArray[np.float64]:
+    """Parse a binary GLB and return POSITION vertices as (N, 3) float64."""
+    data = glb_path.read_bytes()
+    magic, version, _ = struct.unpack_from("<III", data, 0)
+    if magic != 0x46546C67:
+        raise ValueError(f"Bad GLB magic in {glb_path}")
+    c0_len, _ = struct.unpack_from("<II", data, 12)
+    gltf = json.loads(data[20: 20 + c0_len].decode("utf-8").strip().rstrip("\x00"))
+    pos_idx = gltf["meshes"][0]["primitives"][0]["attributes"]["POSITION"]
+    acc = gltf["accessors"][pos_idx]
+    bv = gltf["bufferViews"][acc.get("bufferView", 0)]
+    bin_start = 20 + c0_len
+    c1_len, _ = struct.unpack_from("<II", data, bin_start)
+    bin_data = data[bin_start + 8: bin_start + 8 + c1_len]
+    byte_off = bv.get("byteOffset", 0) + acc.get("byteOffset", 0)
+    count = acc["count"]
+    verts = np.frombuffer(bin_data, dtype=np.float32, count=count * 3, offset=byte_off).reshape(-1, 3)
+    return verts.astype(np.float64)
+
+
+def export_scaled_glb(
+    glb_path: Path,
+    out_path: Path,
+    *,
+    orientation_matrix: NDArray[np.float64],
+    rotation_matrix: NDArray[np.float64],
+    scale: float,
+    mesh_center: NDArray[np.float64],
+    translation: NDArray[np.float64],
+) -> None:
+    """Write a scaled/aligned GLB by binary-patching POSITION (and NORMAL) vertices."""
+    data = bytearray(glb_path.read_bytes())
+    magic, version, _ = struct.unpack_from("<III", data, 0)
+    if magic != 0x46546C67:
+        raise ValueError(f"Bad GLB magic in {glb_path}")
+    c0_len, _ = struct.unpack_from("<II", data, 12)
+    gltf = json.loads(bytes(data[20: 20 + c0_len]).decode("utf-8").strip().rstrip("\x00"))
+    bin_chunk_offset = 20 + c0_len
+    bin_start = bin_chunk_offset + 8
+
+    mc = np.asarray(mesh_center, dtype=np.float64).reshape(1, 3)
+    t = np.asarray(translation, dtype=np.float64).reshape(1, 3)
+    s = float(scale)
+    R_full = np.asarray(rotation_matrix, dtype=np.float64) @ np.asarray(orientation_matrix, dtype=np.float64)
+
+    def _patch_vec3(accessor_idx: int, transform_fn) -> None:
+        acc = gltf["accessors"][accessor_idx]
+        if acc["type"] != "VEC3" or acc["componentType"] != 5126:
+            return
+        bv = gltf["bufferViews"][acc["bufferView"]]
+        byte_off = bin_start + bv.get("byteOffset", 0) + acc.get("byteOffset", 0)
+        stride = bv.get("byteStride", 12)
+        count = acc["count"]
+        pts = np.empty((count, 3), dtype=np.float32)
+        for i in range(count):
+            pts[i] = struct.unpack_from("<3f", data, byte_off + i * stride)
+        pts_out = transform_fn(pts.astype(np.float64)).astype(np.float32)
+        for i in range(count):
+            struct.pack_into("<3f", data, byte_off + i * stride, *pts_out[i].tolist())
+        acc["min"] = pts_out.min(axis=0).tolist()
+        acc["max"] = pts_out.max(axis=0).tolist()
+
+    def _xform_pos(pts):
+        return (rotation_matrix @ (orientation_matrix @ (pts - mc).T)).T * s + t
+
+    def _xform_nrm(nrm):
+        n = (R_full @ nrm.T).T
+        norms = np.maximum(np.linalg.norm(n, axis=1, keepdims=True), 1e-12)
+        return n / norms
+
+    for mesh_obj in gltf.get("meshes", []):
+        for prim in mesh_obj.get("primitives", []):
+            attrs = prim.get("attributes", {})
+            if "POSITION" in attrs:
+                _patch_vec3(attrs["POSITION"], _xform_pos)
+            if "NORMAL" in attrs:
+                _patch_vec3(attrs["NORMAL"], _xform_nrm)
+
+    new_json = json.dumps(gltf, separators=(",", ":")).encode("utf-8")
+    pad = (4 - len(new_json) % 4) % 4
+    new_json += b" " * pad
+    out_buf = bytearray()
+    out_buf += struct.pack("<III", magic, version, 0)
+    out_buf += struct.pack("<II", len(new_json), 0x4E4F534A)
+    out_buf += new_json
+    out_buf += bytes(data[bin_chunk_offset:])
+    struct.pack_into("<I", out_buf, 8, len(out_buf))
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_bytes(bytes(out_buf))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# View building
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _filter_pose_drift(
+    names: List[str],
+    poses: Dict[str, NDArray[np.float64]],
+    jump_factor: float = 10.0,
+) -> List[str]:
+    if len(names) <= 2:
+        return names
+    # Camera position in world = -R.T @ t  (where pose is T_cam_from_world)
+    positions = np.array(
+        [-poses[n][:3, :3].T @ poses[n][:3, 3] for n in names],
+        dtype=np.float64,
+    )
+    diffs = np.linalg.norm(np.diff(positions, axis=0), axis=1)
+    med = float(np.median(diffs))
+    if med < 1e-9:
+        return names
+    threshold = max(jump_factor * med, 0.5)
+    for i, d in enumerate(diffs):
+        if d > threshold:
+            removed = len(names) - (i + 1)
+            if removed > 0:
+                print(f"  [pose-drift] Removed {removed} frames from index {i + 1} "
+                      f"(jump {d:.3f}m, threshold {threshold:.3f}m)")
+            return names[: i + 1]
+    return names
+
+
+def build_frame_views(
+    intrinsics: _Intrinsics,
+    poses: Dict[str, NDArray[np.float64]],
+    masks_dir: Path,
+    depth_dir: Optional[Path],
+    frame_step: int = 1,
+    max_views: int = 0,
+) -> List[FrameView]:
+    """Build FrameView list from SfM poses and mask directory."""
+    mask_files = {p.stem: p for p in sorted(masks_dir.glob("*.png"))}
+    common = sorted(set(poses.keys()) & set(mask_files.keys()))
+    if not common:
+        raise ValueError("No frames in common between SfM poses and masks")
+
+    common = _filter_pose_drift(common, poses)
+    if frame_step > 1:
+        common = common[::frame_step]
+    if max_views > 0:
+        common = common[:max_views]
+
+    views: List[FrameView] = []
+    skipped = 0
+    for name in common:
+        img = cv2.imread(str(mask_files[name]), cv2.IMREAD_UNCHANGED)
+        if img is None:
+            skipped += 1
+            continue
+        if img.ndim == 3:
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        mask = np.asarray(img, dtype=np.uint8)
+        fg_count = int(np.count_nonzero(mask > 127))
+        if fg_count < 50:
+            skipped += 1
+            continue
+        ys, xs = np.nonzero(mask > 127)
+        mask_ext = float(max(int(np.ptp(xs)), int(np.ptp(ys))))
+
+        depth: Optional[NDArray[np.float32]] = None
+        if depth_dir is not None:
+            depth_path = depth_dir / f"{name}.png"
+            if depth_path.exists():
+                depth = load_depth_png(depth_path)
+
+        views.append(FrameView(
+            frame_name=name,
+            intrinsics=intrinsics,
+            world_to_cam=poses[name],
+            mask_u8=mask,
+            dt_to_fg=_compute_dt(mask),
+            mask_boundary_uv=_mask_boundary(mask),
+            mask_extent=mask_ext,
+            depth=depth,
+        ))
+
+    if skipped:
+        print(f"  Skipped {skipped} frames (missing mask or <50 fg pixels)")
+    if not views:
+        raise ValueError("No valid views after filtering")
+    return views
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SRT evaluation
+# ─────────────────────────────────────────────────────────────────────────────
+
+def generate_axis_orientations() -> Dict[str, NDArray[np.float64]]:
+    """All 48 signed axis permutations."""
+    mats: Dict[str, NDArray[np.float64]] = {}
+    for perm in itertools.permutations(range(3)):
+        for signs in itertools.product([1, -1], repeat=3):
+            m = np.zeros((3, 3), dtype=np.float64)
+            for out_ax, (in_ax, sgn) in enumerate(zip(perm, signs)):
+                m[out_ax, in_ax] = float(sgn)
+            det = int(round(float(np.linalg.det(m))))
+            s_str = "".join(str(s) for s in signs)
+            key = f"perm({perm[0]},{perm[1]},{perm[2]})_s{s_str}_det{det}"
+            mats[key] = m
+    return mats
+
+
+def evaluate_srt(
+    vertices: NDArray[np.float64],
+    views: Sequence[FrameView],
+    *,
+    scale: float,
+    orient: NDArray[np.float64],
+    rotvec: NDArray[np.float64],
+    translation: NDArray[np.float64],
+    mesh_center: NDArray[np.float64],
+    dt_clip: float = 20.0,
+    huber_delta: float = 3.0,
+    coverage_weight: float = 0.5,
+    iou_weight: float = 2.0,
+    depth_weight: float = 1.0,
+    max_pts: int = 25000,
+    max_boundary: int = 5000,
+    rng: Optional[np.random.Generator] = None,
+) -> float:
+    if rng is None:
+        rng = np.random.default_rng(0)
+
+    v = vertices - mesh_center.reshape(1, 3)
+    v = v @ orient.T
+    if np.any(rotvec != 0):
+        v = (Rotation.from_rotvec(rotvec).as_matrix() @ v.T).T
+    pts_w = v * float(scale) + translation.reshape(1, 3)
+    pts_h = np.hstack([pts_w, np.ones((pts_w.shape[0], 1), dtype=np.float64)])
+
+    losses: List[float] = []
+    for view in views:
+        view_dt_clip = max(dt_clip, 0.1 * view.mask_extent) if view.mask_extent > 0 else dt_clip
+        pts_c = (view.world_to_cam @ pts_h.T).T[:, :3]
+        u, vv, inb = _project(pts_c, view.intrinsics)
+
+        if not np.any(inb):
+            losses.append(float(view_dt_clip))
+            continue
+
+        ui_all, vi_all = u[inb], vv[inb]
+        zi_all = pts_c[inb, 2].astype(np.float32)
+
+        ui, vi, zi = ui_all, vi_all, zi_all
+        if ui.size > max_pts:
+            idx = rng.choice(ui.size, size=max_pts, replace=False)
+            ui, vi, zi = ui[idx], vi[idx], zi[idx]
+
+        dt_vals = np.minimum(_bilinear(view.dt_to_fg, ui, vi), view_dt_clip)
+        view_loss = float(np.mean(_huber(dt_vals, huber_delta)))
+
+        if coverage_weight > 0 and view.mask_boundary_uv.shape[0] > 0 and ui.size > 0:
+            bnd = view.mask_boundary_uv
+            if bnd.shape[0] > max_boundary:
+                bnd = bnd[rng.choice(bnd.shape[0], size=max_boundary, replace=False)]
+            tree = cKDTree(np.stack([ui, vi], axis=1).astype(np.float64))
+            dists, _ = tree.query(bnd.astype(np.float64), k=1, workers=-1)
+            cov_dt = np.minimum(dists.astype(np.float32), view_dt_clip)
+            view_loss += coverage_weight * float(np.mean(_huber(cov_dt, huber_delta)))
+
+        if iou_weight > 0 and ui_all.size > 0:
+            view_loss += iou_weight * _raster_iou(ui_all, vi_all, view.mask_u8)
+
+        if depth_weight > 0 and view.depth is not None and ui.size > 0:
+            depth_obs = _bilinear(view.depth, ui, vi)
+            valid_depth = (depth_obs > 0.01) & np.isfinite(depth_obs)
+            if np.any(valid_depth):
+                focal = (view.intrinsics.fx + view.intrinsics.fy) * 0.5
+                depth_err_px = (
+                    np.abs(zi[valid_depth] - depth_obs[valid_depth])
+                    * focal
+                    / np.maximum(depth_obs[valid_depth], 0.01)
+                )
+                depth_err_px = np.minimum(depth_err_px, view_dt_clip)
+                view_loss += depth_weight * float(np.mean(_huber(depth_err_px, huber_delta)))
+
+        losses.append(view_loss)
+
+    return float(np.mean(losses))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Initialization helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _estimate_object_center(views: Sequence[FrameView]) -> NDArray[np.float64]:
+    """Estimate 3D object centre via ray triangulation (with depth fallback)."""
+    cam_origins = np.array(
+        [-v.world_to_cam[:3, :3].T @ v.world_to_cam[:3, 3] for v in views],
+        dtype=np.float64,
+    )
+    cam_centroid = np.mean(cam_origins, axis=0)
+
+    # Depth back-projection (when available)
+    has_depth = any(v.depth is not None for v in views)
+    if has_depth:
+        rng = np.random.default_rng(0)
+        pts_3d: List[NDArray] = []
+        for view in views:
+            if view.depth is None:
+                continue
+            fg = view.mask_u8 > 127
+            ys, xs = np.nonzero(fg)
+            if xs.size < 10:
+                continue
+            if xs.size > 2000:
+                idx = rng.choice(xs.size, size=2000, replace=False)
+                xs, ys = xs[idx], ys[idx]
+            d = view.depth[ys, xs].astype(np.float64)
+            valid = (d > 0.01) & np.isfinite(d)
+            if not np.any(valid):
+                continue
+            xs_v, ys_v, d_v = xs[valid].astype(np.float64), ys[valid].astype(np.float64), d[valid]
+            intr = view.intrinsics
+            x_cam = (xs_v - intr.cx) / intr.fx * d_v
+            y_cam = (ys_v - intr.cy) / intr.fy * d_v
+            pts_cam = np.column_stack([x_cam, y_cam, d_v, np.ones_like(d_v)])
+            T_c2w = np.linalg.inv(view.world_to_cam)
+            pts_w = (T_c2w @ pts_cam.T).T[:, :3]
+            pts_3d.append(pts_w)
+        if pts_3d:
+            all_pts = np.concatenate(pts_3d, axis=0)
+            center = np.median(all_pts, axis=0).astype(np.float64)
+            dist = float(np.median(np.linalg.norm(cam_origins - center, axis=1)))
+            if dist < 20.0:
+                return center
+
+    # Ray triangulation
+    A = np.zeros((3, 3), dtype=np.float64)
+    b_vec = np.zeros(3, dtype=np.float64)
+    for view in views:
+        ys, xs = np.nonzero(view.mask_u8 > 127)
+        if xs.size == 0:
+            continue
+        cu, cv = float(np.mean(xs)), float(np.mean(ys))
+        intr = view.intrinsics
+        ray_cam = np.array([(cu - intr.cx) / intr.fx, (cv - intr.cy) / intr.fy, 1.0])
+        ray_cam /= np.linalg.norm(ray_cam)
+        T_c2w = np.linalg.inv(view.world_to_cam)
+        ray_w = T_c2w[:3, :3] @ ray_cam
+        ray_w /= np.linalg.norm(ray_w)
+        origin = T_c2w[:3, 3]
+        P = np.eye(3) - np.outer(ray_w, ray_w)
+        A += P
+        b_vec += P @ origin
+
+    try:
+        center = np.linalg.solve(A, b_vec)
+    except np.linalg.LinAlgError:
+        center = cam_centroid.copy()
+
+    cam_spread = float(np.max(np.ptp(cam_origins, axis=0)))
+    dist = float(np.median(np.linalg.norm(cam_origins - center, axis=1)))
+    if dist > max(5.0, cam_spread * 5.0):
+        mean_dir = np.zeros(3)
+        for view in views:
+            T_c2w = np.linalg.inv(view.world_to_cam)
+            mean_dir += T_c2w[:3, :3] @ np.array([0, 0, 1.0])
+        mean_dir /= max(np.linalg.norm(mean_dir), 1e-12)
+        center = cam_centroid + mean_dir * cam_spread * 0.5
+
+    return center
+
+
+def _estimate_initial_scale(
+    views: Sequence[FrameView],
+    mesh_extent: float,
+    object_center: NDArray[np.float64],
+) -> float:
+    scales: List[float] = []
+    for view in views:
+        ys, xs = np.nonzero(view.mask_u8 > 127)
+        if xs.size < 10:
+            continue
+        mask_px = float(max(np.ptp(xs), np.ptp(ys)))
+        cam_pos = -view.world_to_cam[:3, :3].T @ view.world_to_cam[:3, 3]
+        dist = float(np.linalg.norm(cam_pos - object_center))
+        if dist < 1e-4:
+            continue
+        focal = (view.intrinsics.fx + view.intrinsics.fy) * 0.5
+        obj_m = mask_px * dist / focal
+        if mesh_extent > 1e-9:
+            scales.append(obj_m / mesh_extent)
+    return float(np.median(scales)) if scales else 1.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Axis search + optimization
+# ─────────────────────────────────────────────────────────────────────────────
+
+def run_axis_search(
+    vertices: NDArray[np.float64],
+    views: Sequence[FrameView],
+    mesh_center: NDArray[np.float64],
+    translation: NDArray[np.float64],
+    s0: float,
+    top_k: int = 5,
+    max_views: int = 15,
+) -> List[Tuple[str, NDArray[np.float64], float]]:
+    all_orients = generate_axis_orientations()
+    rng = np.random.default_rng(0)
+    view_subset = list(views)
+    if len(view_subset) > max_views:
+        idxs = np.linspace(0, len(view_subset) - 1, max_views, dtype=int)
+        view_subset = [view_subset[i] for i in idxs]
+
+    rv0 = np.zeros(3)
+    results: List[Tuple[str, NDArray[np.float64], float]] = []
+    best_key, best_loss = "", float("inf")
+    total = len(all_orients)
+    for i, (key, mat) in enumerate(all_orients.items()):
+        loss = evaluate_srt(
+            vertices, view_subset, scale=s0, orient=mat, rotvec=rv0,
+            translation=translation, mesh_center=mesh_center,
+            coverage_weight=0.5, iou_weight=1.0, depth_weight=0.0,
+            max_pts=10000, rng=rng,
+        )
+        results.append((key, mat, loss))
+        if loss < best_loss:
+            best_loss = loss
+            best_key = key
+        if (i + 1) % 12 == 0:
+            print(f"  axis search: {i + 1}/{total}  best={best_key}  loss={best_loss:.4f}")
+
+    results.sort(key=lambda x: x[2])
+    top = results[:top_k]
+    print(f"  Top-{top_k} orientations:")
+    for rank, (k, _, l) in enumerate(top):
+        print(f"    #{rank + 1}  {k}  loss={l:.4f}")
+    return top
+
+
+def optimize_srt(
+    vertices: NDArray[np.float64],
+    views: Sequence[FrameView],
+    orient: NDArray[np.float64],
+    mesh_center: NDArray[np.float64],
+    t_init: NDArray[np.float64],
+    s_init: float,
+    *,
+    mode: str = "str",
+    s_bounds: Tuple[float, float] = (0.001, 100.0),
+    dt_clip: float = 20.0,
+    huber_delta: float = 3.0,
+    coverage_weight: float = 0.5,
+    iou_weight: float = 2.0,
+    depth_weight: float = 1.0,
+    maxiter: int = 120,
+) -> Dict[str, object]:
+    rng = np.random.default_rng(0)
+    log_s0 = math.log(max(float(s_init), 1e-12))
+    log_s_min = math.log(max(float(s_bounds[0]), 1e-12))
+    log_s_max = math.log(float(s_bounds[1]))
+
+    cam_positions = np.array(
+        [-v.world_to_cam[:3, :3].T @ v.world_to_cam[:3, 3] for v in views],
+        dtype=np.float64,
+    )
+    t_bound = float(np.max(np.ptp(cam_positions, axis=0))) * 0.5
+    rot_bound = 45.0 * math.pi / 180.0
+
+    tracker: Dict = {"n": 0, "best_loss": float("inf"), "best_x": None}
+
+    def _obj(x):
+        n = tracker["n"]
+        tracker["n"] = n + 1
+        s_val = math.exp(float(x[0]))
+        t_val = t_init.copy()
+        rv_val = np.zeros(3)
+        if mode in ("st", "str"):
+            t_val = np.array([float(x[1]), float(x[2]), float(x[3])])
+        if mode == "str":
+            rv_val = np.array([float(x[4]), float(x[5]), float(x[6])])
+        loss = evaluate_srt(
+            vertices, views, scale=s_val, orient=orient, rotvec=rv_val,
+            translation=t_val, mesh_center=mesh_center, dt_clip=dt_clip,
+            huber_delta=huber_delta, coverage_weight=coverage_weight,
+            iou_weight=iou_weight, depth_weight=depth_weight, rng=rng,
+        )
+        if loss < tracker["best_loss"]:
+            tracker["best_loss"] = loss
+            tracker["best_x"] = x.copy()
+        if n % 20 == 0:
+            print(f"  [opt_{mode}] eval={n:04d}  s={s_val:.4f}  loss={loss:.6f}  best={tracker['best_loss']:.6f}")
+        return loss
+
+    t0 = t_init.astype(np.float64)
+    if mode == "s":
+        x0 = np.array([log_s0])
+        bounds = [(log_s_min, log_s_max)]
+    elif mode == "st":
+        x0 = np.array([log_s0, t0[0], t0[1], t0[2]])
+        bounds = [(log_s_min, log_s_max),
+                  (t0[0] - t_bound, t0[0] + t_bound),
+                  (t0[1] - t_bound, t0[1] + t_bound),
+                  (t0[2] - t_bound, t0[2] + t_bound)]
+    else:
+        x0 = np.array([log_s0, t0[0], t0[1], t0[2], 0.0, 0.0, 0.0])
+        bounds = [(log_s_min, log_s_max),
+                  (t0[0] - t_bound, t0[0] + t_bound),
+                  (t0[1] - t_bound, t0[1] + t_bound),
+                  (t0[2] - t_bound, t0[2] + t_bound),
+                  (-rot_bound, rot_bound),
+                  (-rot_bound, rot_bound),
+                  (-rot_bound, rot_bound)]
+
+    res = minimize(_obj, x0, method="Powell", bounds=bounds, options={"maxiter": maxiter})
+    best_x = tracker["best_x"] if tracker["best_x"] is not None else res.x
+
+    s_best = math.exp(float(best_x[0]))
+    t_best = t_init.copy()
+    rv_best = np.zeros(3)
+    if mode in ("st", "str"):
+        t_best = np.array([float(best_x[1]), float(best_x[2]), float(best_x[3])])
+    if mode == "str":
+        rv_best = np.array([float(best_x[4]), float(best_x[5]), float(best_x[6])])
+
+    R_mat = Rotation.from_rotvec(rv_best).as_matrix()
+    final_loss = evaluate_srt(
+        vertices, views, scale=s_best, orient=orient, rotvec=rv_best,
+        translation=t_best, mesh_center=mesh_center, dt_clip=dt_clip,
+        huber_delta=huber_delta, coverage_weight=coverage_weight,
+        iou_weight=iou_weight, depth_weight=depth_weight, rng=rng,
+    )
+    return {
+        "scale": s_best,
+        "translation": t_best.tolist(),
+        "rotvec": rv_best.tolist(),
+        "rotation_matrix": R_mat.tolist(),
+        "total_loss": final_loss,
+        "optimizer_nfev": int(res.nfev),
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Debug overlays
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _write_debug_overlays(
+    vertices: NDArray[np.float64],
+    views: Sequence[FrameView],
+    orient: NDArray[np.float64],
+    rotvec: NDArray[np.float64],
+    scale: float,
+    translation: NDArray[np.float64],
+    mesh_center: NDArray[np.float64],
+    output_dir: Path,
+    images_dir: Optional[Path] = None,
+) -> None:
+    rng = np.random.default_rng(0)
+    debug_dir = output_dir / "debug"
+    debug_dir.mkdir(parents=True, exist_ok=True)
+
+    v = vertices - mesh_center.reshape(1, 3)
+    v = v @ orient.T
+    if np.any(rotvec != 0):
+        v = (Rotation.from_rotvec(rotvec).as_matrix() @ v.T).T
+    pts_w = v * float(scale) + translation.reshape(1, 3)
+    pts_h = np.hstack([pts_w, np.ones((pts_w.shape[0], 1))])
+
+    MAX_PTS = 30000
+    for view in views:
+        pts_c = (view.world_to_cam @ pts_h.T).T[:, :3]
+        u, vv, inb = _project(pts_c, view.intrinsics)
+        h, w = view.mask_u8.shape[:2]
+
+        # Base: image if available, else dark canvas
+        if images_dir is not None:
+            img_path = images_dir / f"{view.frame_name}.jpg"
+            canvas = cv2.imread(str(img_path)) if img_path.exists() else None
+        else:
+            canvas = None
+        if canvas is None:
+            canvas = np.full((h, w, 3), 40, dtype=np.uint8)
+
+        binary = (view.mask_u8 > 127).astype(np.uint8) * 255
+        contours, _ = cv2.findContours(binary, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        cv2.drawContours(canvas, contours, -1, (0, 0, 255), 2)
+
+        ui, vi_vis = u[inb], vv[inb]
+        if ui.size > MAX_PTS:
+            idx = rng.choice(ui.size, MAX_PTS, replace=False)
+            ui, vi_vis = ui[idx], vi_vis[idx]
+        for uu, vvi in zip(ui, vi_vis):
+            cv2.circle(canvas, (int(uu), int(vvi)), 1, (255, 255, 0), -1)
+
+        cv2.putText(canvas, f"{view.frame_name}  N={int(ui.size)}",
+                    (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (255, 255, 255), 2)
+        cv2.imwrite(str(debug_dir / f"{view.frame_name}.jpg"), canvas)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main entry
+# ─────────────────────────────────────────────────────────────────────────────
+
+def estimate_srt_for_frame(
+    job_dir: Path,
+    glb_path: Path,
+    output_dir: Path,
+    *,
+    frame_step: int = 5,
+    max_views: int = 100,
+    mode: str = "str",
+    maxiter: int = 120,
+    iou_weight: float = 2.0,
+    depth_weight: float = 1.0,
+    use_depth: bool = False,
+    debug: bool = True,
+) -> dict:
+    """Estimate scale+rotation+translation for a SAM3D mesh using SfM poses + masks.
+
+    Args:
+        job_dir:      HOI reconstruction job directory (must have sfm/, masks/, intrinsics/).
+        glb_path:     SAM3D output GLB mesh.
+        output_dir:   Where to write srt_result.json and output_scaled.glb.
+        frame_step:   Use every Nth keyframe (speed vs. accuracy).
+        max_views:    Cap on number of views (0 = all).
+        mode:         's' scale-only, 'st' scale+translation, 'str' all DOF.
+        maxiter:      Powell optimiser iterations.
+        iou_weight:   Weight for rasterised silhouette IoU loss.
+        depth_weight: Weight for depth loss (only when use_depth=True and depth available).
+        use_depth:    If True, load depth maps from job_dir/depth/.
+        debug:        Write per-view overlay images.
+
+    Returns:
+        The srt_result dict (also written to output_dir/srt_result.json).
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Load intrinsics from the first available file in job_dir/intrinsics/
+    intrinsics_dir = job_dir / "intrinsics"
+    intr_files = sorted(intrinsics_dir.glob("*.json"))
+    if not intr_files:
+        raise FileNotFoundError(f"No intrinsics JSON found in {intrinsics_dir}")
+    intrinsics = _load_intrinsics(intr_files[0])
+
+    # Load SfM keyframe poses
+    print(f"[srt] Loading SfM keyframe poses from {job_dir}/sfm/keyframes/ …")
+    poses = load_sfm_keyframe_poses(job_dir)
+    print(f"[srt] {len(poses)} keyframe poses loaded")
+
+    # Build views
+    masks_dir = job_dir / "masks" / "0"
+    depth_dir: Optional[Path] = (job_dir / "depth") if use_depth else None
+    views = build_frame_views(
+        intrinsics, poses, masks_dir, depth_dir,
+        frame_step=frame_step, max_views=max_views,
+    )
+    print(f"[srt] {len(views)} views built (frame_step={frame_step}, max_views={max_views})")
+
+    # Load mesh vertices
+    print(f"[srt] Loading mesh vertices from {glb_path} …")
+    vertices = load_glb_vertices(glb_path)
+    print(f"[srt] {len(vertices)} vertices")
+
+    mesh_center = vertices.mean(axis=0)
+    mesh_extent = float(np.max(np.ptp(vertices - mesh_center, axis=0)))
+
+    # Initial estimates
+    object_center = _estimate_object_center(views)
+    s_init = _estimate_initial_scale(views, mesh_extent, object_center)
+    print(f"[srt] Initial scale estimate: {s_init:.4f}")
+    print(f"[srt] Estimated object center: {object_center}")
+
+    # Axis search
+    print("[srt] Running axis orientation search …")
+    top_orients = run_axis_search(vertices, views, mesh_center, object_center, s_init)
+
+    # Optimise for each top orientation, pick best
+    best_result: Optional[dict] = None
+    best_loss = float("inf")
+    best_orient: Optional[NDArray] = None
+
+    for rank, (key, orient_mat, _) in enumerate(top_orients):
+        print(f"\n[srt] Optimising orientation #{rank + 1}: {key}")
+        result = optimize_srt(
+            vertices, views, orient_mat, mesh_center, object_center, s_init,
+            mode=mode, iou_weight=iou_weight, depth_weight=depth_weight,
+            maxiter=maxiter,
+        )
+        print(f"  → loss={result['total_loss']:.6f}  scale={result['scale']:.4f}")
+        if result["total_loss"] < best_loss:
+            best_loss = result["total_loss"]
+            best_result = result
+            best_orient = orient_mat
+
+    assert best_result is not None
+    best_result["orientation_key"] = top_orients[0][0]
+    best_result["mesh_center"] = mesh_center.tolist()
+    best_result["num_views"] = len(views)
+
+    # Save result JSON
+    result_path = output_dir / "srt_result.json"
+    with open(result_path, "w") as f:
+        json.dump(best_result, f, indent=2)
+    print(f"\n[srt] Result saved → {result_path}")
+
+    # Export scaled GLB
+    out_glb = output_dir / "output_scaled.glb"
+    export_scaled_glb(
+        glb_path, out_glb,
+        orientation_matrix=best_orient,
+        rotation_matrix=np.array(best_result["rotation_matrix"]),
+        scale=best_result["scale"],
+        mesh_center=mesh_center,
+        translation=np.array(best_result["translation"]),
+    )
+    print(f"[srt] Scaled mesh saved → {out_glb}")
+
+    # Debug overlays
+    if debug:
+        images_dir = job_dir / "left"
+        _write_debug_overlays(
+            vertices, views, best_orient,
+            np.array(best_result["rotvec"]),
+            best_result["scale"],
+            np.array(best_result["translation"]),
+            mesh_center, output_dir,
+            images_dir=images_dir if images_dir.is_dir() else None,
+        )
+        print(f"[srt] Debug overlays → {output_dir / 'debug'}/")
+
+    return best_result

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/scale_mesh_srt.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/scale_mesh_srt.py
@@ -372,12 +372,21 @@ def build_frame_views(
     depth_dir: Optional[Path],
     frame_step: int = 1,
     max_views: int = 0,
+    max_frame: Optional[int] = None,
 ) -> List[FrameView]:
     """Build FrameView list from SfM poses and mask directory."""
     mask_files = {p.stem: p for p in sorted(masks_dir.glob("*.png"))}
     common = sorted(set(poses.keys()) & set(mask_files.keys()))
     if not common:
         raise ValueError("No frames in common between SfM poses and masks")
+
+    if max_frame is not None:
+        common = [n for n in common if int(n) <= max_frame]
+        if not common:
+            raise ValueError(
+                f"No frames remaining after max_frame={max_frame} filter. "
+                "Check that stage1_end_frame is correct."
+            )
 
     common = _filter_pose_drift(common, poses)
     if frame_step > 1:
@@ -851,26 +860,44 @@ def estimate_srt_for_frame(
     depth_weight: float = 1.0,
     use_depth: bool = False,
     debug: bool = True,
+    stage1_end_frame: Optional[int] = None,
 ) -> dict:
     """Estimate scale+rotation+translation for a SAM3D mesh using SfM poses + masks.
 
+    Only Stage-1 frames (object stationary) are used for silhouette alignment.
+    Stage-2 frames (object moved/rotated) would provide contradictory signals and
+    degrade the estimate.
+
     Args:
-        job_dir:      HOI reconstruction job directory (must have sfm/, masks/, intrinsics/).
-        glb_path:     SAM3D output GLB mesh.
-        output_dir:   Where to write srt_result.json and output_scaled.glb.
-        frame_step:   Use every Nth keyframe (speed vs. accuracy).
-        max_views:    Cap on number of views (0 = all).
-        mode:         's' scale-only, 'st' scale+translation, 'str' all DOF.
-        maxiter:      Powell optimiser iterations.
-        iou_weight:   Weight for rasterised silhouette IoU loss.
-        depth_weight: Weight for depth loss (only when use_depth=True and depth available).
-        use_depth:    If True, load depth maps from job_dir/depth/.
-        debug:        Write per-view overlay images.
+        job_dir:           HOI reconstruction job directory (must have sfm/, masks/, intrinsics/).
+        glb_path:          SAM3D output GLB mesh.
+        output_dir:        Where to write srt_result.json and output_scaled.glb.
+        frame_step:        Use every Nth keyframe (speed vs. accuracy).
+        max_views:         Cap on number of views (0 = all).
+        mode:              's' scale-only, 'st' scale+translation, 'str' all DOF.
+        maxiter:           Powell optimiser iterations.
+        iou_weight:        Weight for rasterised silhouette IoU loss.
+        depth_weight:      Weight for depth loss (only when use_depth=True and depth available).
+        use_depth:         If True, load depth maps from job_dir/depth/.
+        debug:             Write per-view overlay images.
+        stage1_end_frame:  Inclusive upper bound on frame index for Stage-1.
+                           If None, auto-read from stage1_detect_debug/result.json.
 
     Returns:
         The srt_result dict (also written to output_dir/srt_result.json).
     """
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Auto-read stage1_end_frame if not supplied
+    if stage1_end_frame is None:
+        detect_result = job_dir / "stage1_detect_debug" / "result.json"
+        if detect_result.exists():
+            with open(detect_result) as f:
+                stage1_end_frame = json.load(f).get("stage1_end_frame")
+            if stage1_end_frame is not None:
+                print(f"[srt] stage1_end_frame={stage1_end_frame} (from {detect_result.name})")
+        if stage1_end_frame is None:
+            print("[srt] Warning: stage1_end_frame not found; using all SfM keyframes including Stage-2")
 
     # Load intrinsics from the first available file in job_dir/intrinsics/
     intrinsics_dir = job_dir / "intrinsics"
@@ -884,14 +911,16 @@ def estimate_srt_for_frame(
     poses = load_sfm_keyframe_poses(job_dir)
     print(f"[srt] {len(poses)} keyframe poses loaded")
 
-    # Build views
+    # Build views — restricted to Stage-1 frames only
     masks_dir = job_dir / "masks" / "0"
     depth_dir: Optional[Path] = (job_dir / "depth") if use_depth else None
     views = build_frame_views(
         intrinsics, poses, masks_dir, depth_dir,
         frame_step=frame_step, max_views=max_views,
+        max_frame=stage1_end_frame,
     )
-    print(f"[srt] {len(views)} views built (frame_step={frame_step}, max_views={max_views})")
+    print(f"[srt] {len(views)} views built "
+          f"(frame_step={frame_step}, max_views={max_views}, stage1_end_frame={stage1_end_frame})")
 
     # Load mesh vertices
     print(f"[srt] Loading mesh vertices from {glb_path} …")

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/select_sam3d_frames.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/select_sam3d_frames.py
@@ -1,0 +1,202 @@
+"""Select representative frames for SAM3D reconstruction.
+
+Uses CuSFM camera trajectory to pick one frame per azimuthal angle bin,
+preferring frames with the largest object mask area within each bin.
+
+Falls back to top-N by mask area if SfM data is unavailable.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from PIL import Image
+from scipy.spatial.transform import Rotation
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SfM pose loading
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _aa_to_matrix(aa: dict) -> np.ndarray:
+    axis = np.array([aa["x"], aa["y"], aa["z"]])
+    norm = np.linalg.norm(axis)
+    if norm < 1e-12:
+        return np.eye(3)
+    return Rotation.from_rotvec((axis / norm) * np.deg2rad(aa["angle_degrees"])).as_matrix()
+
+
+def _load_sfm_keyframes(
+    sfm_keyframes_path: Path,
+    frames_meta_path: Path,
+) -> Optional[tuple[np.ndarray, np.ndarray]]:
+    """Load CuSFM left-camera keyframe seq_indices and world positions.
+
+    Returns (seq_indices, positions) or None if data is missing.
+    seq_indices[i] is the sequential frame index matching left/*.jpg filenames.
+    """
+    if not sfm_keyframes_path.exists() or not frames_meta_path.exists():
+        return None
+
+    with open(frames_meta_path) as f:
+        meta = json.load(f)
+    cam_params = meta["camera_params_id_to_camera_params"]
+
+    left_sids: dict[int, int] = {}
+    right_sids: set[int] = set()
+    for kf in meta["keyframes_metadata"]:
+        cam_id = kf["camera_params_id"]
+        sid = int(kf["synced_sample_id"])
+        sensor = cam_params[cam_id]["sensor_meta_data"]["sensor_name"]
+        if "front_stereo_camera_left" in sensor:
+            left_sids[sid] = int(kf["timestamp_microseconds"])
+        elif "front_stereo_camera_right" in sensor:
+            right_sids.add(sid)
+    common_sids = sorted(set(left_sids) & right_sids)
+    ts_to_seq_idx = {left_sids[sid]: i for i, sid in enumerate(common_sids)}
+
+    with open(sfm_keyframes_path) as f:
+        sfm = json.load(f)
+
+    frames: list[tuple[int, np.ndarray]] = []
+    for kf in sfm["keyframes_metadata"]:
+        if "front_stereo_camera_left" not in kf.get("image_name", ""):
+            continue
+        ts_us = int(kf["timestamp_microseconds"])
+        seq_idx = ts_to_seq_idx.get(ts_us)
+        if seq_idx is None:
+            continue
+        aa = kf["camera_to_world"]["axis_angle"]
+        t = kf["camera_to_world"]["translation"]
+        R = _aa_to_matrix(aa)
+        # Camera position in world = R @ [0,0,0] + t = t (since c2w)
+        pos = np.array([t["x"], t["y"], t["z"]])
+        frames.append((seq_idx, pos))
+
+    if not frames:
+        return None
+
+    frames.sort(key=lambda x: x[0])
+    seq_indices = np.array([f[0] for f in frames])
+    positions = np.array([f[1] for f in frames])
+    return seq_indices, positions
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Azimuthal angle computation
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _cumulative_azimuth(positions: np.ndarray) -> np.ndarray:
+    """Fit a plane via PCA, project positions onto it, return cumulative azimuth."""
+    centroid = positions.mean(axis=0)
+    _, _, Vt = np.linalg.svd(positions - centroid, full_matrices=False)
+    basis_u, basis_v = Vt[0], Vt[1]
+    pts_c = (positions - centroid) @ np.stack([basis_u, basis_v], axis=1)
+    pts_c -= pts_c.mean(axis=0)
+    angles_raw = np.arctan2(pts_c[:, 1], pts_c[:, 0])
+    angles_unwrap = np.unwrap(angles_raw)
+    angles_unwrap -= angles_unwrap[0]
+    return np.rad2deg(angles_unwrap)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Mask area helper
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _mask_area(mask_path: Path) -> int:
+    arr = np.array(Image.open(mask_path).convert("L"))
+    return int(np.sum(arr > 0))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Public API
+# ─────────────────────────────────────────────────────────────────────────────
+
+def select_frames_by_angle_bins(
+    job_dir: Path,
+    bin_deg: float = 60.0,
+) -> list[str]:
+    """Select one frame per azimuthal bin using the CuSFM camera trajectory.
+
+    Covers both Stage-1 and Stage-2 of the scan.  Within each bin the frame
+    with the largest mask area (best object visibility) is chosen.
+
+    The transition region around stage1_end_frame (from
+    stage1_detect_debug/result.json) is excluded to avoid the manual-flip
+    frames where masks are unreliable.
+
+    Returns a list of zero-padded frame ID strings e.g. ['000842', '001203'].
+    Returns [] if SfM data is unavailable (caller should fall back).
+    """
+    sfm_kf = job_dir / "sfm" / "keyframes" / "frames_meta.json"
+    frames_meta = job_dir / "frames_meta.json"
+    masks_dir = job_dir / "masks" / "0"
+
+    sfm_data = _load_sfm_keyframes(sfm_kf, frames_meta)
+    if sfm_data is None:
+        print("  [select_frames] SfM data not found, will fall back to mask-area selection")
+        return []
+
+    seq_indices, positions = sfm_data
+    angles_deg = _cumulative_azimuth(positions)
+
+    # Exclude transition frames (the manual flip) using stage1_detect result
+    detect_result = job_dir / "stage1_detect_debug" / "result.json"
+    if detect_result.exists():
+        with open(detect_result) as f:
+            det = json.load(f)
+        stage1_end = det.get("stage1_end_frame")
+        if stage1_end is not None:
+            # Exclude a window of ±30 frames around stage1_end as a conservative buffer
+            transition_lo = max(0, stage1_end - 30)
+            transition_hi = stage1_end + 60
+            keep = ~((seq_indices >= transition_lo) & (seq_indices <= transition_hi))
+            seq_indices = seq_indices[keep]
+            angles_deg = angles_deg[keep]
+
+    if len(seq_indices) == 0:
+        return []
+
+    angle_min = angles_deg.min()
+    angle_max = angles_deg.max()
+    n_bins = max(1, int(np.ceil((angle_max - angle_min) / bin_deg)))
+    bin_edges = np.linspace(angle_min, angle_max, n_bins + 1)
+
+    selected: list[str] = []
+    for b in range(n_bins):
+        lo, hi = bin_edges[b], bin_edges[b + 1]
+        in_bin = np.where((angles_deg >= lo) & (angles_deg < hi))[0]
+        if len(in_bin) == 0:
+            continue
+        best_idx: Optional[int] = None
+        best_area = -1
+        for i in in_bin:
+            seq = seq_indices[i]
+            mask_path = masks_dir / f"{seq:06d}.png"
+            if not mask_path.exists():
+                continue
+            area = _mask_area(mask_path)
+            if area > best_area:
+                best_area = area
+                best_idx = int(seq)
+        if best_idx is not None:
+            selected.append(f"{best_idx:06d}")
+
+    return selected
+
+
+def select_frames_fallback(job_dir: Path, n: int = 6) -> list[str]:
+    """Fallback: return top-n frame IDs by mask area."""
+    masks_dir = job_dir / "masks" / "0"
+    if not masks_dir.is_dir():
+        return []
+    scored = []
+    for p in sorted(masks_dir.iterdir()):
+        if p.suffix.lower() != ".png":
+            continue
+        scored.append((_mask_area(p), p.stem))
+    scored.sort(reverse=True)
+    return [stem for _, stem in scored[:n]]

--- a/reconstruction/modules/v2d_sam3d/lib/render_textured_video.py
+++ b/reconstruction/modules/v2d_sam3d/lib/render_textured_video.py
@@ -1,0 +1,192 @@
+"""Render a Stage-1 overlay video: textured SRT mesh projected via open3d.
+
+Runs inside the v2d_sam3d container (has open3d with Filament/EGL backend).
+For each Stage-1 SfM keyframe the mesh is rendered offscreen with its original
+texture and alpha-composited onto the source image.
+
+Usage (inside container):
+    python -m v2d.sam3d.lib.render_textured_video \
+        --job_dir  /data/job \
+        --glb_path /data/job/sam3d/000651/srt/output_scaled.glb \
+        --output_dir /data/job/sam3d/000651/render_video_frames \
+        --stage1_end_frame 319
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import cv2
+import numpy as np
+import open3d as o3d
+import open3d.visualization.rendering as rendering
+
+
+# ── SfM pose loading ──────────────────────────────────────────────────────────
+
+def _aa_to_matrix(aa: dict) -> np.ndarray:
+    x, y, z = aa["x"], aa["y"], aa["z"]
+    angle = math.radians(aa["angle_degrees"])
+    norm = math.sqrt(x * x + y * y + z * z)
+    if norm < 1e-12:
+        return np.eye(3)
+    x, y, z = x / norm, y / norm, z / norm
+    c, s = math.cos(angle), math.sin(angle)
+    t = 1.0 - c
+    return np.array([
+        [t*x*x + c,   t*x*y - s*z, t*x*z + s*y],
+        [t*x*y + s*z, t*y*y + c,   t*y*z - s*x],
+        [t*x*z - s*y, t*y*z + s*x, t*z*z + c  ],
+    ])
+
+
+def _load_sfm_poses(job_dir: Path) -> dict[str, np.ndarray]:
+    """Return {frame_id: T_cam_from_world (4×4, OpenCV)} for left-camera keyframes."""
+    with open(job_dir / "frames_meta.json") as f:
+        meta = json.load(f)
+    cam_params = meta["camera_params_id_to_camera_params"]
+
+    left_sids: dict[int, int] = {}
+    right_sids: set[int] = set()
+    for kf in meta["keyframes_metadata"]:
+        sid = int(kf["synced_sample_id"])
+        sensor = cam_params[kf["camera_params_id"]]["sensor_meta_data"]["sensor_name"]
+        if "front_stereo_camera_left" in sensor:
+            left_sids[sid] = int(kf["timestamp_microseconds"])
+        elif "front_stereo_camera_right" in sensor:
+            right_sids.add(sid)
+
+    common = sorted(set(left_sids) & right_sids)
+    ts_to_seq = {left_sids[s]: i for i, s in enumerate(common)}
+
+    with open(job_dir / "sfm" / "keyframes" / "frames_meta.json") as f:
+        sfm = json.load(f)
+
+    poses: dict[str, np.ndarray] = {}
+    for kf in sfm["keyframes_metadata"]:
+        if "front_stereo_camera_left" not in kf.get("image_name", ""):
+            continue
+        seq_idx = ts_to_seq.get(int(kf["timestamp_microseconds"]))
+        if seq_idx is None:
+            continue
+        aa = kf["camera_to_world"]["axis_angle"]
+        t  = kf["camera_to_world"]["translation"]
+        T_c2w = np.eye(4)
+        T_c2w[:3, :3] = _aa_to_matrix(aa)
+        T_c2w[:3,  3] = [t["x"], t["y"], t["z"]]
+        poses[f"{seq_idx:06d}"] = np.linalg.inv(T_c2w)
+    return poses
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def render_textured_video(
+    job_dir: Path,
+    glb_path: Path,
+    output_dir: Path,
+    stage1_end_frame: int,
+    alpha: float = 0.6,
+) -> int:
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Intrinsics
+    intr_files = sorted((job_dir / "intrinsics").glob("*.json"))
+    if not intr_files:
+        raise FileNotFoundError(f"No intrinsics in {job_dir / 'intrinsics'}")
+    with open(intr_files[0]) as f:
+        intr = json.load(f)
+    fx, fy = float(intr["fx"]), float(intr["fy"])
+    cx, cy = float(intr["cx"]), float(intr["cy"])
+    width, height = int(intr["width"]), int(intr["height"])
+    K = np.array([[fx, 0.0, cx],
+                  [0.0, fy, cy],
+                  [0.0, 0.0, 1.0]])
+
+    # SfM poses filtered to Stage-1
+    poses = _load_sfm_poses(job_dir)
+    stage1_frames = sorted(
+        [n for n in poses if int(n) <= stage1_end_frame],
+        key=lambda n: int(n),
+    )
+    if not stage1_frames:
+        raise ValueError(f"No SfM keyframes ≤ stage1_end_frame={stage1_end_frame}")
+    print(f"[render_textured] {len(stage1_frames)} Stage-1 keyframes (≤ {stage1_end_frame})")
+
+    # Load mesh
+    print(f"[render_textured] loading mesh: {glb_path}")
+    mesh = o3d.io.read_triangle_mesh(str(glb_path), enable_post_processing=True)
+    if not mesh.has_vertex_normals():
+        mesh.compute_vertex_normals()
+    print(f"[render_textured] mesh: {len(mesh.vertices)} vertices, {len(mesh.triangles)} triangles, "
+          f"has_textures={mesh.has_textures()}, has_vertex_colors={mesh.has_vertex_colors()}")
+
+    # Build material: prefer texture if available
+    mat = rendering.MaterialRecord()
+    mat.shader = "defaultLit"
+
+    # Build renderer once, reuse for all frames
+    render = rendering.OffscreenRenderer(width, height)
+    render.scene.set_background(np.array([0.0, 0.0, 0.0, 1.0]))
+    render.scene.add_geometry("mesh", mesh, mat)
+    render.scene.scene.set_sun_light(
+        direction=[-1.0, -1.0, -1.0],
+        color=[1.0, 1.0, 1.0],
+        intensity=75000,
+    )
+    render.scene.scene.enable_sun_light(True)
+
+    images_dir = job_dir / "left"
+    n_written  = 0
+    n_total    = len(stage1_frames)
+    for frame_id in stage1_frames:
+        img_path = images_dir / f"{frame_id}.jpg"
+        if not img_path.exists():
+            continue
+        img_bgr = cv2.imread(str(img_path))
+        if img_bgr is None:
+            continue
+
+        # Set camera: K (3×3) + T_cam_from_world (4×4, OpenCV convention)
+        render.setup_camera(K, poses[frame_id], width, height)
+
+        color_o3d = render.render_to_image()          # RGB uint8
+        depth_o3d = render.render_to_depth_image()    # float32 metres
+
+        color_rgb = np.asarray(color_o3d)             # H×W×3
+        depth     = np.asarray(depth_o3d)             # H×W
+
+        # Composite: blend where mesh is visible (depth > 0 and < far plane)
+        mask       = (depth > 0.0) & (depth < 1e4)
+        color_bgr  = color_rgb[:, :, ::-1].astype(np.float32)
+        img_f      = img_bgr.astype(np.float32)
+        blended    = (color_bgr * alpha + img_f * (1.0 - alpha)).clip(0, 255).astype(np.uint8)
+        result     = np.where(mask[:, :, None], blended, img_bgr)
+
+        out_path = output_dir / f"{n_written:06d}.jpg"
+        cv2.imwrite(str(out_path), result, [cv2.IMWRITE_JPEG_QUALITY, 90])
+        n_written += 1
+        print(f"[render_textured] frame {n_written}/{n_total}  (id={frame_id})", flush=True)
+
+    print(f"[render_textured] wrote {n_written} frames → {output_dir}")
+    return n_written
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--job_dir",          required=True)
+    parser.add_argument("--glb_path",         required=True)
+    parser.add_argument("--output_dir",       required=True)
+    parser.add_argument("--stage1_end_frame", type=int, required=True)
+    parser.add_argument("--alpha",            type=float, default=0.6)
+    args = parser.parse_args()
+
+    render_textured_video(
+        job_dir=Path(args.job_dir),
+        glb_path=Path(args.glb_path),
+        output_dir=Path(args.output_dir),
+        stage1_end_frame=args.stage1_end_frame,
+        alpha=args.alpha,
+    )


### PR DESCRIPTION
## Summary

  - Add `--mode sam3d` to `run_reconstruction.py`: single-image 3D reconstruction via SAM3D per representative frame, with silhouette-based SRT scale estimation            
  - SRT scale estimation uses **Stage-1 frames only** (object stationary, seq_idx ≤ `stage1_end_frame`)                                                            
    — Stage-2 frames (object rotated) give contradictory signals and are now filtered out                                                                      
  - Add render video step (S5): projects SRT textured mesh onto all Stage-1 SfM keyframes via                                                                         open3d `OffscreenRenderer` and stitches into `render_video.mp4`
  - Fix: `stage1_end_frame` is now loaded from existing `result.json` even when `--skip_stage1_detect` is passed, so downstream steps (SRT, render_video) always have it 