### PR TITLE
use nvbundlesdf branch for NVLabs/BundleSDF

### DIFF
--- a/reconstruction/modules/v2d_bundlesdf/docker/Dockerfile
+++ b/reconstruction/modules/v2d_bundlesdf/docker/Dockerfile
@@ -181,7 +181,7 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
 # Install BundleSDF CUDA extension
-RUN git clone https://github.com/NVLabs/BundleSDF.git /BundleSDF
+RUN git clone --branch nvbundlesdf --depth 1 https://github.com/NVLabs/BundleSDF.git /BundleSDF
 RUN cp -r /BundleSDF/mycuda /customize_cuda && \
     cd /customize_cuda && \
     TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;9.0" FORCE_CUDA=1 pip install . --no-build-isolation


### PR DESCRIPTION
## Summary

  - Switches the `NVLabs/BundleSDF` clone in the `v2d_bundlesdf` Dockerfile from the default branch to `nvbundlesdf`
  - Adds `--depth 1` for a shallow clone (faster build)

  The `nvbundlesdf` branch is an NVIDIA-maintained branch that removes the BundleFusion GPU solver (PR #208 `rm_bundlefusion`),
  resulting in a cleaner build. The build outputs (`my_cpp*.so`, `libBundleTrack.so`, `libMY_CUDA_LIB.so`) are identical to the
  default branch — verified by a successful Docker build.