### PR TITLE
[robotic grounding] Add whole-body retargeting and kinematic replay

### DIFF
--- a/robotic_grounding/README.md
+++ b/robotic_grounding/README.md
@@ -55,6 +55,8 @@ python scripts/rsl_rl/dummy_agent.py --task Sharpa-V2P-Debug-v0
 To create a debug environment for other tasks, use `sharpa_debug_env_cfg.py` as a template—inherit from your base environment config and override the actions with GUI-controlled versions (`JointGUIActionCfg`, `ObjectPoseGUIActionCfg`, `RewardVisualizerCfg`). Remember to disable action related MDP terms since the debug env does not have the original actions.
 
 ## Retargeting
+
+### Hand-only (Sharpa / Arctic)
 ```bash
 python scripts/retarget/arctic_loader.py --save # Check the file for arguments
 python scripts/retarget/arctic_to_sharpa.py --save # Check the file for arguments
@@ -62,6 +64,53 @@ python scripts/retarget/vis_retargeted.py # Need to run retargeting and save res
 ```
 
 For Arctic motion files, download them from [here](https://drive.google.com/file/d/1rL4T9N4AwQoWRqS5pOuB6a0D0B9Y8dsP/view?usp=sharing) and extract to `source/robotic_grounding/robotic_grounding/assets/human_motion_data/arctic`. (TODO: We need to figure out an appropriate way for data storage)
+
+### Whole-body (NVHuman → G1)
+```bash
+# Retarget and save Parquet (data_folder must contain nova_params_opt.pt, poses.npy, object/textured_mesh.obj)
+python scripts/retarget/nvhuman_to_g1.py <data_folder> --save
+
+# Visualize retargeting in Viser (port 8080)
+python scripts/retarget/nvhuman_to_g1.py <data_folder> --visualize
+```
+
+### Kinematic replay (all schemas)
+Replay retargeted motion in Isaac Lab. Supports both whole-body (G1) and dual floating-hand (Sharpa/Dex3) data.
+Robot and object are teleported kinematically — no physics forces act on them.
+```bash
+# Replay G1 retargeted data (loops by default)
+python scripts/replay_motion.py \
+    --motion_file source/robotic_grounding/robotic_grounding/assets/human_motion_data/nvhuman_g1_processed/sequence_id=<seq>/robot_name=g1
+
+# Replay hand-only data
+python scripts/replay_motion.py \
+    --motion_file source/robotic_grounding/robotic_grounding/assets/human_motion_data/arctic_processed/sequence_id=<seq>/robot_name=sharpa_wave
+
+# Options
+python scripts/replay_motion.py --motion_file <path> --speed 0.5   # Slow motion
+python scripts/replay_motion.py --motion_file <path> --no-loop     # Stop at last frame
+python scripts/replay_motion.py --motion_file <path> --headless    # No GUI
+```
+
+### Support surface reconstruction
+Detect where objects rest on surfaces above the ground plane and generate collision geometry for RL training.
+```bash
+# For hand-only datasets (auto-detects schema)
+python scripts/reconstruct_support_surfaces.py --input_dir <loader_output_dir> --sequence_id <seq>
+
+# For G1 whole-body retargeted data
+python scripts/reconstruct_support_surfaces.py --input_dir source/robotic_grounding/robotic_grounding/assets/human_motion_data/nvhuman_g1_processed --sequence_id <seq>
+
+# Or use the dataset shortcut
+python scripts/reconstruct_support_surfaces.py --dataset nvhuman_g1 --sequence_id <seq>
+```
+
+Objects resting on the ground are automatically filtered out (threshold configurable via `--ground_threshold`).
+
+### Scene viewer (static spawn verification)
+```bash
+python scripts/view_scene.py --motion_file <parquet_partition_path>
+```
 
 ## RL training
 ```bash

--- a/robotic_grounding/scripts/reconstruct_support_surfaces.py
+++ b/robotic_grounding/scripts/reconstruct_support_surfaces.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
-"""Reconstruct support surfaces from object still-poses in TACO/ARCTIC sequences.
+"""Reconstruct support surfaces from object still-poses.
 
-Reads Parquet from the loader output; object meshes are loaded from the object_mesh_paths
-field in the schema (one path per body), like vis_retargeted.py.
+Supports all retarget schemas: ManoSharpa (TACO/ARCTIC/OakInk2/HOT3D),
+NvhumanDex3, and NvhumanG1 (whole-body).  The schema is auto-detected from
+parquet columns.
+
+Disks whose bottom Z is near the ground plane (below ``--ground_threshold``)
+are filtered out automatically — the existing ground plane in the sim scene
+already provides that surface.
 
 Usage:
-  1. Run loader first: python scripts/retarget/taco_loader.py --save  (or arctic_loader.py --save)
+  1. Run retarget/loader first (e.g. taco_loader.py --save, nvhuman_to_g1.py --save)
   2. python scripts/reconstruct_support_surfaces.py --input_dir ... [--sequence_id ID]
 """
 
@@ -15,16 +20,24 @@ import random
 from pathlib import Path
 
 import numpy as np
+import pyarrow.parquet as pq
 import trimesh
 from pxr import Gf, Usd, UsdGeom, UsdPhysics
 from robotic_grounding.retarget import HUMAN_MOTION_DATA_DIR
 from robotic_grounding.retarget.data_logger import (
     ManoSharpaData,
+    NvhumanDex3Data,
+    NvhumanG1Data,
     add_sequence_filter_args,
     filter_sequence_ids,
     list_sequence_ids,
 )
 from scipy.spatial.transform import Rotation
+
+try:
+    from robotic_grounding.assets.robot_registry import get_robot_spec as _get_robot_spec
+except ModuleNotFoundError:
+    _get_robot_spec = None  # type: ignore[assignment]
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -33,8 +46,10 @@ DEFAULT_INPUT_DIR_TACO = HUMAN_MOTION_DATA_DIR / "taco" / "taco_loaded"
 DEFAULT_INPUT_DIR_ARCTIC = HUMAN_MOTION_DATA_DIR / "arctic" / "arctic_loaded"
 DEFAULT_INPUT_DIR_OAKINK2 = HUMAN_MOTION_DATA_DIR / "oakink2" / "oakink2_loaded"
 DEFAULT_INPUT_DIR_HOT3D = HUMAN_MOTION_DATA_DIR / "hot3d" / "hot3d_loaded"
+DEFAULT_INPUT_DIR_G1 = HUMAN_MOTION_DATA_DIR / "nvhuman_g1_processed"
 
 DISK_HEIGHT = 0.01  # thin disk thickness in meters
+GROUND_Z_THRESHOLD = 0.05  # disks below this Z are on the ground plane
 
 
 # ---------------------------------------------------------------------------
@@ -61,25 +76,48 @@ def _load_object_meshes_from_paths(
     return meshes
 
 
+def _detect_parquet_schema(input_dir: Path) -> str:
+    """Detect which data logger schema a parquet dataset uses."""
+    columns = set(pq.read_table(str(input_dir), use_pandas_metadata=False).schema.names)
+    if "robot_root_position" in columns:
+        return "nvhuman_g1"
+    if "robot_right_wrist_euler_xyz" in columns:
+        return "nvhuman_dex3"
+    return "mano_sharpa"
+
+
+def _load_parquet_data(
+    input_dir: Path, sequence_id: str, schema: str
+) -> ManoSharpaData | NvhumanDex3Data | NvhumanG1Data:
+    """Load one sequence from Parquet using the appropriate data logger class."""
+    filters = [("sequence_id", "=", sequence_id)]
+    if schema == "nvhuman_g1":
+        return NvhumanG1Data.from_parquet(str(input_dir), filters=filters)
+    if schema == "nvhuman_dex3":
+        return NvhumanDex3Data.from_parquet(str(input_dir), filters=filters)
+    return ManoSharpaData.from_parquet(str(input_dir), filters=filters)
+
+
 def load_object_mesh_and_poses(
     input_dir: Path,
     sequence_id: str,
-) -> tuple[ManoSharpaData, dict[str, trimesh.Trimesh]]:
+    schema: str | None = None,
+) -> tuple[ManoSharpaData | NvhumanDex3Data | NvhumanG1Data, dict[str, trimesh.Trimesh]]:
     """Load one sequence from Parquet and its object meshes via object_mesh_paths.
 
     Returns:
-        data: ManoSharpaData with object_body_position, object_body_wxyz, etc.
+        data: Data logger instance with object_body_position, object_body_wxyz, etc.
         object_meshes: dict[body_name] -> trimesh.
     """
-    data = ManoSharpaData.from_parquet(
-        str(input_dir),
-        filters=[("sequence_id", "=", sequence_id)],
-    )
+    if schema is None:
+        schema = _detect_parquet_schema(input_dir)
+    data = _load_parquet_data(input_dir, sequence_id, schema)
     object_mesh_paths = getattr(data, "object_mesh_paths", None) or []
-    if object_mesh_paths and len(object_mesh_paths) == len(data.object_body_names):
+    object_body_names = getattr(data, "object_body_names", None) or []
+    if object_mesh_paths and len(object_mesh_paths) == len(object_body_names):
         object_meshes = _load_object_meshes_from_paths(
             object_mesh_paths,
-            data.object_body_names,
+            object_body_names,
         )
     else:
         object_meshes = {}
@@ -151,13 +189,17 @@ def _frames_where_object_still(
     return np.nonzero(result)[0]
 
 
-def still_frames_from_mano_sharpa_data(
-    data: ManoSharpaData,
+def still_frames_from_object_data(
+    data: ManoSharpaData | NvhumanDex3Data | NvhumanG1Data,
     body_index: int = 0,
     pos_threshold_m: float = 0.001,
     angle_threshold_rad: float = 0.01,
 ) -> np.ndarray:
-    """Return frame indices where the given object body is still."""
+    """Return frame indices where the given object body is still.
+
+    Works with any schema that has ``object_body_position`` and
+    ``object_body_wxyz`` fields.
+    """
     positions = np.array(data.object_body_position, dtype=np.float64)
     quats = np.array(data.object_body_wxyz, dtype=np.float64)
     positions = positions[:, body_index, :]
@@ -168,6 +210,10 @@ def still_frames_from_mano_sharpa_data(
         pos_threshold_m=pos_threshold_m,
         angle_threshold_rad=angle_threshold_rad,
     )
+
+
+# Keep the old name as an alias for backward compatibility.
+still_frames_from_mano_sharpa_data = still_frames_from_object_data
 
 
 def extract_continuous_segments(still_frames: np.ndarray) -> list[np.ndarray]:
@@ -375,9 +421,9 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--dataset",
-        choices=("taco", "arctic", "oakink2", "hot3d"),
+        choices=("taco", "arctic", "oakink2", "hot3d", "nvhuman_g1"),
         default="oakink2",
-        help="Dataset for default input_dir when --input_dir not set (default: taco).",
+        help="Dataset for default input_dir when --input_dir not set.",
     )
     add_sequence_filter_args(parser)
     parser.add_argument(
@@ -391,23 +437,59 @@ def _parse_args() -> argparse.Namespace:
         default=None,
         help="Output .usda path for support surfaces (default: <sequence_id>_support.usda).",
     )
+    parser.add_argument(
+        "--ground_threshold",
+        type=float,
+        default=GROUND_Z_THRESHOLD,
+        help=(
+            f"Disks with z <= this are on the ground plane and skipped "
+            f"(default: {GROUND_Z_THRESHOLD}m)."
+        ),
+    )
     return parser.parse_args()
 
 
+def _compute_height_offset(data: ManoSharpaData | NvhumanDex3Data | NvhumanG1Data, schema: str) -> float:
+    """Compute the Z offset needed to align parquet data with the spawned scene.
+
+    Object and support-surface positions from the retarget pipeline are
+    already in a ground-relative frame (Z=0 at foot level) that matches the
+    sim ground plane, so no offset is needed for any schema.
+    """
+    return 0.0
+
+
 def _process_sequence(
-    input_dir: Path, sequence_id: str, output_override: str | None
+    input_dir: Path,
+    sequence_id: str,
+    output_override: str | None,
+    schema: str | None = None,
+    ground_z_threshold: float = GROUND_Z_THRESHOLD,
 ) -> None:
     """Process a single sequence: detect still frames, compute disks, write USD."""
-    data, object_meshes = load_object_mesh_and_poses(input_dir, sequence_id)
+    if schema is None:
+        schema = _detect_parquet_schema(input_dir)
+    data, object_meshes = load_object_mesh_and_poses(
+        input_dir, sequence_id, schema=schema
+    )
 
-    num_frames = len(data.mano_right_trans)
+    height_offset = _compute_height_offset(data, schema)
+    if abs(height_offset) > 1e-6:
+        print(f"  Applying height offset: {height_offset:.4f}m (schema={schema})")
+
+    object_body_names = getattr(data, "object_body_names", None) or []
+    num_frames = len(getattr(data, "object_body_position", []))
     print(f"\nSequence: {sequence_id}")
     print(f"Frames: {num_frames}")
-    print(f"Object bodies: {data.object_body_names}")
-    for name in data.object_body_names:
+    print(f"Object bodies: {object_body_names}")
+    for name in object_body_names:
         mesh = object_meshes.get(name)
         n_verts = mesh.vertices.shape[0] if mesh is not None else 0
         print(f"  {name}: mesh vertices={n_verts}")
+
+    if num_frames == 0 or not object_body_names:
+        print("No object trajectory data — skipping.")
+        return
 
     # For articulated objects, only reconstruct support surfaces for the root body
     # (index 0). Child bodies are connected via joints and don't rest on surfaces.
@@ -416,7 +498,7 @@ def _process_sequence(
 
     all_disks: dict[str, list[tuple[float, float, float, float]]] = {}
 
-    for body_idx, body_name in enumerate(data.object_body_names):
+    for body_idx, body_name in enumerate(object_body_names):
         if is_articulated and body_idx > 0:
             print(f"  Skipping {body_name}: child body of articulated object")
             continue
@@ -425,7 +507,7 @@ def _process_sequence(
             print(f"  Skipping {body_name}: no mesh loaded")
             continue
 
-        still_frames = still_frames_from_mano_sharpa_data(data, body_index=body_idx)
+        still_frames = still_frames_from_object_data(data, body_index=body_idx)
         segments = extract_continuous_segments(still_frames)
         print(
             f"  {body_name}: {len(still_frames)} still frames, {len(segments)} segment(s)"
@@ -450,11 +532,26 @@ def _process_sequence(
 
         if body_disks:
             merged = merge_overlapping_disks(body_disks)
-            print(f"    merged {len(body_disks)} disk(s) -> {len(merged)}")
-            all_disks[body_name] = merged
+            # Apply height offset so disk positions match the spawned scene.
+            if abs(height_offset) > 1e-6:
+                merged = [(cx, cy, z + height_offset, r) for cx, cy, z, r in merged]
+            # Filter out disks on the ground plane — the sim ground handles those.
+            above_ground = [d for d in merged if d[2] > ground_z_threshold]
+            on_ground = len(merged) - len(above_ground)
+            if on_ground:
+                print(
+                    f"    filtered {on_ground} disk(s) at ground level "
+                    f"(z <= {ground_z_threshold:.3f}m)"
+                )
+            print(
+                f"    merged {len(body_disks)} disk(s) -> {len(merged)}, "
+                f"kept {len(above_ground)} above ground"
+            )
+            if above_ground:
+                all_disks[body_name] = above_ground
 
     if not all_disks:
-        print("No support disks generated.")
+        print("No support disks needed (object on ground or always held).")
         return
 
     total = sum(len(v) for v in all_disks.values())
@@ -478,6 +575,8 @@ def main() -> None:
         input_dir = DEFAULT_INPUT_DIR_ARCTIC
     elif args.dataset == "hot3d":
         input_dir = DEFAULT_INPUT_DIR_HOT3D
+    elif args.dataset == "nvhuman_g1":
+        input_dir = DEFAULT_INPUT_DIR_G1
     else:
         input_dir = DEFAULT_INPUT_DIR_OAKINK2
     if not input_dir.is_dir():
@@ -499,8 +598,17 @@ def main() -> None:
     ids_to_process = filter_sequence_ids(sequence_ids, args)
     print(f"Processing {len(ids_to_process)} of {len(sequence_ids)} sequence(s).")
 
+    schema = _detect_parquet_schema(input_dir)
+    print(f"Detected schema: {schema}")
+
     for sequence_id in ids_to_process:
-        _process_sequence(input_dir, sequence_id, args.output)
+        _process_sequence(
+            input_dir,
+            sequence_id,
+            args.output,
+            schema=schema,
+            ground_z_threshold=args.ground_threshold,
+        )
 
 
 if __name__ == "__main__":

--- a/robotic_grounding/scripts/reconstruct_support_surfaces.py
+++ b/robotic_grounding/scripts/reconstruct_support_surfaces.py
@@ -35,7 +35,9 @@ from robotic_grounding.retarget.data_logger import (
 from scipy.spatial.transform import Rotation
 
 try:
-    from robotic_grounding.assets.robot_registry import get_robot_spec as _get_robot_spec
+    from robotic_grounding.assets.robot_registry import (
+        get_robot_spec as _get_robot_spec,
+    )
 except ModuleNotFoundError:
     _get_robot_spec = None  # type: ignore[assignment]
 
@@ -102,7 +104,9 @@ def load_object_mesh_and_poses(
     input_dir: Path,
     sequence_id: str,
     schema: str | None = None,
-) -> tuple[ManoSharpaData | NvhumanDex3Data | NvhumanG1Data, dict[str, trimesh.Trimesh]]:
+) -> tuple[
+    ManoSharpaData | NvhumanDex3Data | NvhumanG1Data, dict[str, trimesh.Trimesh]
+]:
     """Load one sequence from Parquet and its object meshes via object_mesh_paths.
 
     Returns:
@@ -449,7 +453,9 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _compute_height_offset(data: ManoSharpaData | NvhumanDex3Data | NvhumanG1Data, schema: str) -> float:
+def _compute_height_offset(
+    data: ManoSharpaData | NvhumanDex3Data | NvhumanG1Data, schema: str
+) -> float:
     """Compute the Z offset needed to align parquet data with the spawned scene.
 
     Object and support-surface positions from the retarget pipeline are

--- a/robotic_grounding/scripts/replay_motion.py
+++ b/robotic_grounding/scripts/replay_motion.py
@@ -1,0 +1,488 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+
+"""Kinematic playback of retargeted motion data in Isaac Lab.
+
+Supports both whole-body (G1) and dual floating-hand (Sharpa/Dex3) schemas.
+Robot and object are teleported each sim step — no physics forces act on them.
+Object collision geometry is disabled to avoid interpenetration artifacts from
+the retargeted IK solution.  Playback loops by default; use ``--no-loop`` to
+stop at the last frame.
+
+Usage:
+    python scripts/replay_motion.py \
+        --motion_file source/robotic_grounding/robotic_grounding/assets/human_motion_data/nvhuman_g1_processed/sequence_id=<seq>/robot_name=g1
+
+    python scripts/replay_motion.py --motion_file <path> --speed 0.5
+    python scripts/replay_motion.py --motion_file <path> --no-loop
+    python scripts/replay_motion.py --motion_file <path> --headless
+"""
+
+import argparse
+from typing import Any
+
+from isaaclab.app import AppLauncher
+
+parser = argparse.ArgumentParser(description="Replay retargeted motion from Parquet.")
+parser.add_argument(
+    "--motion_file", type=str, required=True, help="Parquet partition dir."
+)
+parser.add_argument(
+    "--speed", type=float, default=1.0, help="Playback speed multiplier."
+)
+parser.add_argument(
+    "--no-loop",
+    action="store_true",
+    help="Stop at the last frame instead of looping (default: loop).",
+)
+parser.add_argument("--num_envs", type=int, default=1, help="Number of environments.")
+AppLauncher.add_app_launcher_args(parser)
+args_cli = parser.parse_args()
+
+app_launcher = AppLauncher(args_cli)
+simulation_app = app_launcher.app
+
+# --- Isaac / torch imports after AppLauncher ---------------------------------
+import torch  # noqa: E402
+from isaaclab.envs import ManagerBasedEnv  # noqa: E402
+from isaaclab.utils import configclass  # noqa: E402
+from robotic_grounding.tasks.scene_utils.replay_data import (  # noqa: E402
+    DualHandTrajectory,
+    SingleRobotTrajectory,
+    load_replay_trajectory,
+)
+from robotic_grounding.tasks.scene_utils.scene_viewer_env_cfg import (  # noqa: E402
+    SceneViewerEnvCfg,
+)
+from scipy.spatial.transform import Rotation as R  # noqa: E402
+
+# =============================================================================
+# Env configuration — kinematic replay variant
+# =============================================================================
+
+
+def _disable_gravity_in_articulation_cfg(cfg: Any) -> Any:
+    """Return articulation cfg with gravity disabled in rigid properties."""
+    spawn = getattr(cfg, "spawn", None)
+    rigid_props = getattr(spawn, "rigid_props", None)
+    if spawn is None or rigid_props is None:
+        return cfg
+    return cfg.replace(
+        spawn=spawn.replace(
+            rigid_props=rigid_props.replace(disable_gravity=True),
+        )
+    )
+
+
+@configclass
+class ReplayEnvCfg(SceneViewerEnvCfg):
+    """Env cfg for kinematic trajectory replay."""
+
+    def __post_init__(self) -> None:
+        """Post-init: build viewer scene, then apply replay-only overrides."""
+        super().__post_init__()
+
+        # Replay: never resolve robot-object or robot-fixed collisions.
+        self.events.setup_collision_groups.params["disable_robot_to_object_collisions"] = (
+            True
+        )
+        self.events.setup_collision_groups.params[
+            "disable_robot_to_fixed_object_collisions"
+        ] = True
+
+        # Replay object(s): collision OFF + kinematic + gravity OFF.
+        object_names = self.events.setup_collision_groups.params.get("object_names", [])
+        for name in object_names:
+            obj_cfg = getattr(self.scene, name, None)
+            if obj_cfg is None:
+                continue
+            spawn = getattr(obj_cfg, "spawn", None)
+            rigid_props = getattr(spawn, "rigid_props", None)
+            collision_props = getattr(spawn, "collision_props", None)
+            if spawn is None or rigid_props is None:
+                continue
+            new_rigid_props = rigid_props.replace(
+                disable_gravity=True,
+                kinematic_enabled=True,
+            )
+            if collision_props is not None:
+                spawn = spawn.replace(
+                    rigid_props=new_rigid_props,
+                    collision_props=collision_props.replace(collision_enabled=False),
+                )
+            else:
+                spawn = spawn.replace(rigid_props=new_rigid_props)
+            setattr(self.scene, name, obj_cfg.replace(spawn=spawn))
+
+        # Replay robot(s): disable gravity for static kinematic playback.
+        if hasattr(self.scene, "robot"):
+            self.scene.robot = _disable_gravity_in_articulation_cfg(self.scene.robot)
+        if hasattr(self.scene, "right_robot"):
+            self.scene.right_robot = _disable_gravity_in_articulation_cfg(
+                self.scene.right_robot
+            )
+        if hasattr(self.scene, "left_robot"):
+            self.scene.left_robot = _disable_gravity_in_articulation_cfg(
+                self.scene.left_robot
+            )
+
+
+# =============================================================================
+# Trajectory loading
+# =============================================================================
+
+
+def _get_spawn_root_z(env_cfg: ReplayEnvCfg) -> float:
+    """Read spawn root Z from the robot articulation cfg's initial state.
+
+    Falls back to 0.0 for dual-hand layouts (floating wrist, no world-frame root).
+    """
+    robot_cfg = getattr(env_cfg.scene, "robot", None)
+    if robot_cfg is not None:
+        init_state = getattr(robot_cfg, "init_state", None)
+        if init_state is not None:
+            pos = getattr(init_state, "pos", None)
+            if pos is not None and len(pos) >= 3:
+                return float(pos[2])
+    return 0.0
+
+
+class Trajectory:
+    """Load replay trajectory tensors for single-robot or dual-hand layouts."""
+
+    def __init__(
+        self,
+        motion_file: str,
+        device: torch.device,
+        spawn_root_z: float = 0.0,
+    ) -> None:
+        """Load trajectory arrays from Parquet into GPU tensors.
+
+        Args:
+            motion_file: Path to Parquet partition directory.
+            device: Target torch device.
+            spawn_root_z: Initial root Z from the spawned robot cfg used to
+                calibrate the height offset so the robot stands on the ground.
+        """
+        replay = load_replay_trajectory(motion_file)
+        self.fps = replay.fps
+        self.num_frames = replay.num_frames
+        self.robot_layout = replay.robot_layout
+
+        if replay.object_traj is not None:
+            self.object_root_pos = torch.tensor(
+                replay.object_traj.root_position,
+                dtype=torch.float32,
+                device=device,
+            )
+            self.object_root_wxyz = torch.tensor(
+                replay.object_traj.root_wxyz,
+                dtype=torch.float32,
+                device=device,
+            )
+        else:
+            self.object_root_pos = torch.empty(0, 3, dtype=torch.float32, device=device)
+            self.object_root_wxyz = torch.empty(0, 4, dtype=torch.float32, device=device)
+
+        if isinstance(replay, SingleRobotTrajectory):
+            self.robot_joint_names = list(replay.robot_joint_names)
+            self.robot_root_pos = torch.tensor(
+                replay.robot_root_position, dtype=torch.float32, device=device
+            )
+            self.robot_root_wxyz = torch.tensor(
+                replay.robot_root_wxyz, dtype=torch.float32, device=device
+            )
+            self.robot_joint_pos = torch.tensor(
+                replay.robot_joint_positions, dtype=torch.float32, device=device
+            )
+
+            first_root_z = float(self.robot_root_pos[0, 2].item())
+            # Auto-detect legacy vs grounded retarget output:
+            # - Legacy data had root Z near 0 and needs a global lift.
+            # - New retargeted data is already world/ground-aligned and must
+            #   keep robot/object in the same frame (no replay-time offset).
+            legacy_root_z_threshold = 0.3
+            if first_root_z < legacy_root_z_threshold:
+                self.height_offset = spawn_root_z - first_root_z
+                self.robot_root_pos[:, 2] += self.height_offset
+                if self.object_root_pos.shape[0] > 0:
+                    self.object_root_pos[:, 2] += self.height_offset
+            else:
+                self.height_offset = 0.0
+            return
+
+        if isinstance(replay, DualHandTrajectory):
+            self.right_joint_names = list(replay.right_joint_names)
+            self.left_joint_names = list(replay.left_joint_names)
+            self.right_wrist_pos = torch.tensor(
+                replay.right_wrist_position, dtype=torch.float32, device=device
+            )
+            self.left_wrist_pos = torch.tensor(
+                replay.left_wrist_position, dtype=torch.float32, device=device
+            )
+            if replay.wrist_orientation_format == "wxyz":
+                self.right_wrist_wxyz = torch.tensor(
+                    replay.right_wrist_orientation, dtype=torch.float32, device=device
+                )
+                self.left_wrist_wxyz = torch.tensor(
+                    replay.left_wrist_orientation, dtype=torch.float32, device=device
+                )
+            else:
+                right_wxyz = [
+                    R.from_euler("XYZ", xyz, degrees=False).as_quat(scalar_first=True)
+                    for xyz in replay.right_wrist_orientation
+                ]
+                left_wxyz = [
+                    R.from_euler("XYZ", xyz, degrees=False).as_quat(scalar_first=True)
+                    for xyz in replay.left_wrist_orientation
+                ]
+                self.right_wrist_wxyz = torch.tensor(
+                    right_wxyz, dtype=torch.float32, device=device
+                )
+                self.left_wrist_wxyz = torch.tensor(
+                    left_wxyz, dtype=torch.float32, device=device
+                )
+            self.right_finger_joints = torch.tensor(
+                replay.right_finger_joints, dtype=torch.float32, device=device
+            )
+            self.left_finger_joints = torch.tensor(
+                replay.left_finger_joints, dtype=torch.float32, device=device
+            )
+            self.height_offset = 0.0
+            return
+
+        raise ValueError(f"Unsupported replay trajectory type: {type(replay).__name__}")
+
+
+def _build_joint_reorder(
+    parquet_names: list[str], sim_names: list[str]
+) -> torch.Tensor | None:
+    """Map from Parquet joint order → Isaac joint order. None if already identical."""
+    if parquet_names == sim_names:
+        return None
+    sim_name_to_idx = {n: i for i, n in enumerate(sim_names)}
+    indices: list[int] = []
+    for pq_name in parquet_names:
+        if pq_name not in sim_name_to_idx:
+            raise ValueError(
+                f"Parquet joint '{pq_name}' not found in spawned robot joints: "
+                f"{sim_names}"
+            )
+        indices.append(sim_name_to_idx[pq_name])
+    return torch.tensor(indices, dtype=torch.long)
+
+
+def _write_single_robot_frame(
+    robot: Any,
+    traj: Trajectory,
+    t: int,
+    env_origins: torch.Tensor,
+    num_envs: int,
+    device: torch.device,
+    sim_joint_names: list[str],
+    reorder: torch.Tensor | None,
+) -> None:
+    root_pos = traj.robot_root_pos[t].unsqueeze(0).expand(num_envs, -1)
+    root_wxyz = traj.robot_root_wxyz[t].unsqueeze(0).expand(num_envs, -1)
+    root_pos_w = root_pos + env_origins
+    root_pose = torch.cat([root_pos_w, root_wxyz], dim=-1)
+    robot.write_root_pose_to_sim(root_pose)
+    robot.write_root_velocity_to_sim(torch.zeros(num_envs, 6, device=device))
+
+    joint_pos_t = traj.robot_joint_pos[t].unsqueeze(0).expand(num_envs, -1)
+    if reorder is not None:
+        sim_jpos = torch.zeros(num_envs, len(sim_joint_names), device=device)
+        sim_jpos[:, reorder] = joint_pos_t
+    else:
+        sim_jpos = joint_pos_t
+    robot.write_joint_state_to_sim(sim_jpos, torch.zeros_like(sim_jpos))
+
+
+def _write_dual_hand_frame(
+    right_robot: Any,
+    left_robot: Any,
+    traj: Trajectory,
+    t: int,
+    env_origins: torch.Tensor,
+    num_envs: int,
+    device: torch.device,
+    right_sim_joint_names: list[str],
+    left_sim_joint_names: list[str],
+    right_reorder: torch.Tensor | None,
+    left_reorder: torch.Tensor | None,
+) -> None:
+    right_pos = traj.right_wrist_pos[t].unsqueeze(0).expand(num_envs, -1) + env_origins
+    right_wxyz = traj.right_wrist_wxyz[t].unsqueeze(0).expand(num_envs, -1)
+    right_pose = torch.cat([right_pos, right_wxyz], dim=-1)
+    right_robot.write_root_pose_to_sim(right_pose)
+    right_robot.write_root_velocity_to_sim(torch.zeros(num_envs, 6, device=device))
+
+    left_pos = traj.left_wrist_pos[t].unsqueeze(0).expand(num_envs, -1) + env_origins
+    left_wxyz = traj.left_wrist_wxyz[t].unsqueeze(0).expand(num_envs, -1)
+    left_pose = torch.cat([left_pos, left_wxyz], dim=-1)
+    left_robot.write_root_pose_to_sim(left_pose)
+    left_robot.write_root_velocity_to_sim(torch.zeros(num_envs, 6, device=device))
+
+    right_joints = traj.right_finger_joints[t].unsqueeze(0).expand(num_envs, -1)
+    if right_reorder is not None:
+        right_sim_joints = torch.zeros(num_envs, len(right_sim_joint_names), device=device)
+        right_sim_joints[:, right_reorder] = right_joints
+    else:
+        right_sim_joints = right_joints
+    right_robot.write_joint_state_to_sim(
+        right_sim_joints,
+        torch.zeros_like(right_sim_joints),
+    )
+
+    left_joints = traj.left_finger_joints[t].unsqueeze(0).expand(num_envs, -1)
+    if left_reorder is not None:
+        left_sim_joints = torch.zeros(num_envs, len(left_sim_joint_names), device=device)
+        left_sim_joints[:, left_reorder] = left_joints
+    else:
+        left_sim_joints = left_joints
+    left_robot.write_joint_state_to_sim(
+        left_sim_joints,
+        torch.zeros_like(left_sim_joints),
+    )
+
+
+def _write_object_frame(
+    obj: Any | None,
+    traj: Trajectory,
+    t: int,
+    env_origins: torch.Tensor,
+    num_envs: int,
+    device: torch.device,
+) -> None:
+    if obj is None or t >= traj.object_root_pos.shape[0]:
+        return
+    obj_pos = traj.object_root_pos[t].unsqueeze(0).expand(num_envs, -1)
+    obj_wxyz = traj.object_root_wxyz[t].unsqueeze(0).expand(num_envs, -1)
+    obj_pos_w = obj_pos + env_origins
+    obj_pose = torch.cat([obj_pos_w, obj_wxyz], dim=-1)
+    obj.write_root_pose_to_sim(obj_pose)
+    obj.write_root_velocity_to_sim(torch.zeros(num_envs, 6, device=device))
+
+
+# =============================================================================
+# Main
+# =============================================================================
+
+
+def main() -> None:
+    """Run kinematic trajectory replay."""
+    cfg = ReplayEnvCfg(motion_file=args_cli.motion_file)
+    cfg.scene.num_envs = args_cli.num_envs
+
+    env = ManagerBasedEnv(cfg=cfg)
+    env.reset()
+    device = env.device
+
+    spawn_root_z = _get_spawn_root_z(cfg)
+    traj = Trajectory(args_cli.motion_file, device, spawn_root_z=spawn_root_z)
+
+    # Resolve object handle by scene-config name (not hardcoded "object")
+    object_names = cfg.events.setup_collision_groups.params.get("object_names", [])
+    obj = env.scene[object_names[0]] if object_names else None
+
+    # Resolve robot handle(s) and reorder maps based on replay layout.
+    robot = None
+    right_robot = None
+    left_robot = None
+    sim_joint_names = []
+    right_sim_joint_names = []
+    left_sim_joint_names = []
+    reorder = None
+    right_reorder = None
+    left_reorder = None
+    if traj.robot_layout == "single_robot":
+        robot = env.scene["robot"]
+        sim_joint_names = list(robot.joint_names)
+        reorder = _build_joint_reorder(traj.robot_joint_names, sim_joint_names)
+    else:
+        right_robot = env.scene["right_robot"]
+        left_robot = env.scene["left_robot"]
+        right_sim_joint_names = list(right_robot.joint_names)
+        left_sim_joint_names = list(left_robot.joint_names)
+        right_reorder = _build_joint_reorder(
+            traj.right_joint_names, right_sim_joint_names
+        )
+        left_reorder = _build_joint_reorder(
+            traj.left_joint_names, left_sim_joint_names
+        )
+
+    num_envs = env.num_envs
+    env_origins = env.scene.env_origins  # (num_envs, 3)
+
+    actions = torch.zeros(num_envs, 0, device=device)
+    frame_f = 0.0
+    frame_step = cfg.sim.dt * traj.fps * args_cli.speed
+    loop = not args_cli.no_loop
+
+    print(f"[INFO] Replaying {traj.num_frames} frames at {traj.fps:.0f} fps "
+          f"(speed={args_cli.speed}x, loop={loop})")
+    print("[INFO] Close the window to exit.")
+
+    while simulation_app.is_running():
+        frame_i = int(frame_f)
+        if frame_i >= traj.num_frames:
+            if loop:
+                frame_f -= traj.num_frames
+                frame_i = int(frame_f)
+            else:
+                break
+        t = frame_i
+
+        if traj.robot_layout == "single_robot":
+            _write_single_robot_frame(
+                robot=robot,
+                traj=traj,
+                t=t,
+                env_origins=env_origins,
+                num_envs=num_envs,
+                device=device,
+                sim_joint_names=sim_joint_names,
+                reorder=reorder,
+            )
+        else:
+            _write_dual_hand_frame(
+                right_robot=right_robot,
+                left_robot=left_robot,
+                traj=traj,
+                t=t,
+                env_origins=env_origins,
+                num_envs=num_envs,
+                device=device,
+                right_sim_joint_names=right_sim_joint_names,
+                left_sim_joint_names=left_sim_joint_names,
+                right_reorder=right_reorder,
+                left_reorder=left_reorder,
+            )
+
+        _write_object_frame(
+            obj=obj,
+            traj=traj,
+            t=t,
+            env_origins=env_origins,
+            num_envs=num_envs,
+            device=device,
+        )
+
+        env.step(actions)
+
+        frame_f += frame_step
+        if t > 0 and t % 100 == 0:
+            secs = t / traj.fps if traj.fps else 0
+            print(f"[INFO] Frame {t}/{traj.num_frames} ({secs:.1f}s)")
+
+    env.close()
+
+
+if __name__ == "__main__":
+    main()
+    simulation_app.close()

--- a/robotic_grounding/scripts/replay_motion.py
+++ b/robotic_grounding/scripts/replay_motion.py
@@ -81,16 +81,23 @@ def _disable_gravity_in_articulation_cfg(cfg: Any) -> Any:
 
 @configclass
 class ReplayEnvCfg(SceneViewerEnvCfg):
-    """Env cfg for kinematic trajectory replay."""
+    """Env cfg for kinematic trajectory replay.
+
+    Note: This config disables collisions and gravity on all replayed bodies
+    because the robot and object are teleported each step from the parquet
+    trajectory (no physics forces act on them). Any contact-based rewards or
+    termination signals would not be meaningful in this env; use a physics
+    env (e.g. ManagerBasedRLEnv) for those.
+    """
 
     def __post_init__(self) -> None:
         """Post-init: build viewer scene, then apply replay-only overrides."""
         super().__post_init__()
 
         # Replay: never resolve robot-object or robot-fixed collisions.
-        self.events.setup_collision_groups.params["disable_robot_to_object_collisions"] = (
-            True
-        )
+        self.events.setup_collision_groups.params[
+            "disable_robot_to_object_collisions"
+        ] = True
         self.events.setup_collision_groups.params[
             "disable_robot_to_fixed_object_collisions"
         ] = True
@@ -187,7 +194,9 @@ class Trajectory:
             )
         else:
             self.object_root_pos = torch.empty(0, 3, dtype=torch.float32, device=device)
-            self.object_root_wxyz = torch.empty(0, 4, dtype=torch.float32, device=device)
+            self.object_root_wxyz = torch.empty(
+                0, 4, dtype=torch.float32, device=device
+            )
 
         if isinstance(replay, SingleRobotTrajectory):
             self.robot_joint_names = list(replay.robot_joint_names)
@@ -330,7 +339,9 @@ def _write_dual_hand_frame(
 
     right_joints = traj.right_finger_joints[t].unsqueeze(0).expand(num_envs, -1)
     if right_reorder is not None:
-        right_sim_joints = torch.zeros(num_envs, len(right_sim_joint_names), device=device)
+        right_sim_joints = torch.zeros(
+            num_envs, len(right_sim_joint_names), device=device
+        )
         right_sim_joints[:, right_reorder] = right_joints
     else:
         right_sim_joints = right_joints
@@ -341,7 +352,9 @@ def _write_dual_hand_frame(
 
     left_joints = traj.left_finger_joints[t].unsqueeze(0).expand(num_envs, -1)
     if left_reorder is not None:
-        left_sim_joints = torch.zeros(num_envs, len(left_sim_joint_names), device=device)
+        left_sim_joints = torch.zeros(
+            num_envs, len(left_sim_joint_names), device=device
+        )
         left_sim_joints[:, left_reorder] = left_joints
     else:
         left_sim_joints = left_joints
@@ -412,9 +425,7 @@ def main() -> None:
         right_reorder = _build_joint_reorder(
             traj.right_joint_names, right_sim_joint_names
         )
-        left_reorder = _build_joint_reorder(
-            traj.left_joint_names, left_sim_joint_names
-        )
+        left_reorder = _build_joint_reorder(traj.left_joint_names, left_sim_joint_names)
 
     num_envs = env.num_envs
     env_origins = env.scene.env_origins  # (num_envs, 3)
@@ -424,8 +435,10 @@ def main() -> None:
     frame_step = cfg.sim.dt * traj.fps * args_cli.speed
     loop = not args_cli.no_loop
 
-    print(f"[INFO] Replaying {traj.num_frames} frames at {traj.fps:.0f} fps "
-          f"(speed={args_cli.speed}x, loop={loop})")
+    print(
+        f"[INFO] Replaying {traj.num_frames} frames at {traj.fps:.0f} fps "
+        f"(speed={args_cli.speed}x, loop={loop})"
+    )
     print("[INFO] Close the window to exit.")
 
     while simulation_app.is_running():

--- a/robotic_grounding/scripts/retarget/nvhuman_to_g1.py
+++ b/robotic_grounding/scripts/retarget/nvhuman_to_g1.py
@@ -34,7 +34,11 @@ import trimesh
 import viser
 from robotic_grounding.retarget import G1_URDF_DIR, HUMAN_MOTION_DATA_DIR
 from robotic_grounding.retarget.data_logger import NvhumanG1Data
-from robotic_grounding.retarget.params import NVHUMAN_JOINTS_ORDER
+from robotic_grounding.retarget.params import (
+    G1_FOOT_FRAME_NAMES,
+    NVHUMAN_FOOT_JOINT_NAMES,
+    NVHUMAN_JOINTS_ORDER,
+)
 from robotic_grounding.retarget.read_nvhuman import NVHuman
 from robotic_grounding.retarget.whole_body_kinematics import G1WholeBodyKinematics
 from scipy.spatial.transform import Rotation as R
@@ -234,7 +238,9 @@ def main() -> None:
         for _line in _f:
             if _line.startswith("v "):
                 _parts = _line.split()
-                _obj_verts.append([float(_parts[1]), float(_parts[2]), float(_parts[3])])
+                _obj_verts.append(
+                    [float(_parts[1]), float(_parts[2]), float(_parts[3])]
+                )
     object_mesh_vertices = np.array(_obj_verts, dtype=np.float64)
 
     # Setup data logger
@@ -335,25 +341,16 @@ def main() -> None:
 
     # Source foot joints used for robust ground estimation. Using only feet
     # avoids noisy non-foot joints pulling the ground estimate down.
-    source_foot_joint_names = [
-        "LeftFoot",
-        "RightFoot",
-        "LeftToeBase",
-        "RightToeBase",
-        "LeftToeEnd",
-        "RightToeEnd",
-    ]
     source_foot_joint_idxs = [
         NVHUMAN_JOINTS_ORDER.index(name)
-        for name in source_foot_joint_names
+        for name in NVHUMAN_FOOT_JOINT_NAMES
         if name in NVHUMAN_JOINTS_ORDER
     ]
 
     # Frame-0 foot Z reference (in IK frame) used to detect and correct
     # downward drift from noisy source reconstruction.
-    foot_frame_names = ["left_ankle_roll_link", "right_ankle_roll_link"]
     foot_frame_idxs = [
-        list(kin.robot_frame_names.values()).index(fn) for fn in foot_frame_names
+        list(kin.robot_frame_names.values()).index(fn) for fn in G1_FOOT_FRAME_NAMES
     ]
     foot_z_ref: float | None = None
 
@@ -382,14 +379,14 @@ def main() -> None:
             if drift < 0:
                 q[2] -= drift
 
-        # Compute object pose in robot coordinate system.
-        # Object rotation is a world-frame transform (not a body-local joint
-        # rotation), so we left-multiply by the coordinate change matrix
-        # rather than using the similarity transform (R @ M @ R^T) that
-        # transform_source_rotation applies for joint rotations.
+        # Compute object pose in robot coordinate system. Object rotation is
+        # a world-frame transform (not a body-local joint rotation), so we use
+        # transform_world_rotation (left-multiply by R_src_to_robot) rather
+        # than transform_source_rotation (similarity transform R @ M @ R^T
+        # used for body-local joint rotations).
         obj_pose = object_poses[frame_idx]
         obj_position = kin.transform_source_position(obj_pose[:3, 3])
-        obj_rotation_mat = kin._R_nvhuman_to_robot @ obj_pose[:3, :3]
+        obj_rotation_mat = kin.transform_world_rotation(obj_pose[:3, :3])
         obj_rotation = R.from_matrix(obj_rotation_mat)
 
         # On frame 0, estimate ground from source feet only and shift into
@@ -412,7 +409,9 @@ def main() -> None:
         # the object above the aligned skeleton/robot).
         if frame_idx == 0:
             obj_pos_for_mesh_check = obj_position.copy()
-            obj_verts_world = (obj_rotation_mat @ object_mesh_vertices.T).T + obj_pos_for_mesh_check
+            obj_verts_world = (
+                obj_rotation_mat @ object_mesh_vertices.T
+            ).T + obj_pos_for_mesh_check
             object_z_lift = max(0.0, -float(np.min(obj_verts_world[:, 2])))
 
         # Extract head trajectory in robot coordinate system

--- a/robotic_grounding/scripts/retarget/nvhuman_to_g1.py
+++ b/robotic_grounding/scripts/retarget/nvhuman_to_g1.py
@@ -1,0 +1,534 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+
+"""Script to retarget NVHuman motion to G1 whole body using Pink IK solver.
+
+Writes Parquet under ``HUMAN_MOTION_DATA_DIR/nvhuman_g1_processed`` with
+``partition_cols=(sequence_id, robot_name)``, e.g.
+``.../sequence_id=<folder_name>/robot_name=g1/``. That layout is what
+``SceneConfig`` / Isaac Lab use (``robot_name`` must match the registry key
+``g1``).
+
+Usage:
+    python scripts/retarget/nvhuman_to_g1.py <data_folder> --save
+    python scripts/retarget/nvhuman_to_g1.py <data_folder> --visualize
+
+Where data_folder contains:
+    - nova_params_opt.pt (motion parameters)
+    - poses.npy (object trajectory as 4x4 transforms)
+    - object/textured_mesh.obj (object mesh; also used to build a URDF for sim)
+"""
+
+import argparse
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+import trimesh
+import viser
+from robotic_grounding.retarget import G1_URDF_DIR, HUMAN_MOTION_DATA_DIR
+from robotic_grounding.retarget.data_logger import NvhumanG1Data
+from robotic_grounding.retarget.params import NVHUMAN_JOINTS_ORDER
+from robotic_grounding.retarget.read_nvhuman import NVHuman
+from robotic_grounding.retarget.whole_body_kinematics import G1WholeBodyKinematics
+from scipy.spatial.transform import Rotation as R
+from tqdm import tqdm
+
+G1_URDF = G1_URDF_DIR / "main_with_hand.urdf"
+PACKAGE_DIRS = [str(G1_URDF_DIR)]
+SAVE_DIR = HUMAN_MOTION_DATA_DIR / "nvhuman_g1_processed"
+
+
+def _usd_safe(name: str) -> str:
+    """Make a name safe for USD prim paths (no leading digits, no @ etc.)."""
+    safe = name.replace("@", "_")
+    if safe and (safe[0].isdigit() or not (safe[0].isalpha() or safe[0] == "_")):
+        return f"obj_{safe}"
+    return safe
+
+
+def _build_object_urdf(mesh_path: str, urdf_path: Path) -> str:
+    """Write a simple rigid-object URDF that references ``mesh_path``."""
+    urdf_path.parent.mkdir(parents=True, exist_ok=True)
+    urdf_text = f"""<?xml version="1.0"?>
+<robot name="retarget_object">
+  <link name="object">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.0"/>
+      <inertia ixx="0.01" ixy="0.0" ixz="0.0" iyy="0.01" iyz="0.0" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="{mesh_path}"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="{mesh_path}"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>
+"""
+    urdf_path.write_text(urdf_text, encoding="utf-8")
+    return str(urdf_path.resolve())
+
+
+def _compute_mesh_radius(mesh_path: str) -> float:
+    """Compute max radius from mesh centroid."""
+    mesh = trimesh.load(mesh_path)
+    if isinstance(mesh, trimesh.Scene):
+        mesh = mesh.dump(concatenate=True)
+    vertices = np.asarray(mesh.vertices, dtype=np.float64)
+    if len(vertices) == 0:
+        return 0.0
+    centered = vertices - vertices.mean(axis=0, keepdims=True)
+    return float(np.linalg.norm(centered, axis=1).max())
+
+
+def _get_robot_joint_position_names(
+    kin: G1WholeBodyKinematics, base_q_size: int
+) -> list[str]:
+    """Return names aligned to ``q[base_q_size:]`` ordering."""
+    indexed_names: list[tuple[int, str]] = []
+    for joint_idx in range(1, kin.robot.model.njoints):
+        joint_name = str(kin.robot.model.names[joint_idx])
+        q_start = int(kin.robot.model.idx_qs[joint_idx])
+        q_size = int(kin.robot.model.nqs[joint_idx])
+        for local_idx in range(q_size):
+            q_idx = q_start + local_idx
+            if q_idx < base_q_size:
+                continue
+            label = joint_name if q_size == 1 else f"{joint_name}[{local_idx}]"
+            indexed_names.append((q_idx, label))
+    indexed_names.sort(key=lambda x: x[0])
+    return [name for _, name in indexed_names]
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Retarget NVHuman motion to G1 whole body"
+    )
+    parser.add_argument(
+        "data_folder",
+        type=str,
+        help="Path to folder containing nova_params_opt.pt, object mesh, and poses.npy",
+    )
+    parser.add_argument("--visualize", action="store_true", help="Enable visualization")
+    parser.add_argument("--save", action="store_true", help="Save retargeted data")
+    parser.add_argument(
+        "--scale", type=float, default=1.0, help="Scale factor from NVHuman to robot"
+    )
+    return parser.parse_args()
+
+
+def load_data(folder_path: str) -> tuple[str, str, np.ndarray]:
+    """Load motion params and object data from folder.
+
+    Args:
+        folder_path: Path to folder containing nova_params_opt.pt, object mesh, poses.npy
+
+    Returns:
+        Tuple of (motion_params_path, mesh_path, poses)
+        poses are normalized to match NVHuman's origin normalization
+    """
+    folder = Path(folder_path).resolve()
+    motion_params_path = str(folder / "nova_params_opt.pt")
+    mesh_path = str(folder / "object" / "textured_mesh.obj")
+    poses_path = folder / "poses.npy"
+
+    required = {
+        "nova_params_opt.pt": folder / "nova_params_opt.pt",
+        "poses.npy": poses_path,
+        "object/textured_mesh.obj": folder / "object" / "textured_mesh.obj",
+    }
+    missing = [name for name, p in required.items() if not p.is_file()]
+    if missing:
+        msg = (
+            f"Data folder is missing required files: {missing}\n"
+            f"  Resolved folder: {folder}\n"
+            f"Expected layout:\n"
+            f"  {folder}/nova_params_opt.pt\n"
+            f"  {folder}/poses.npy\n"
+            f"  {folder}/object/textured_mesh.obj\n"
+            "If you run inside Docker, host paths like /home/... are not visible "
+            "unless bind-mounted. Mount your data (e.g. -v /host/data:/data/reconstructed_data) "
+            "and pass the in-container path to this script."
+        )
+        raise FileNotFoundError(msg)
+
+    object_poses = np.load(poses_path)
+
+    params = torch.load(motion_params_path)
+    global_orient_first = params["global_orient"][0].cpu().numpy()
+    transl_first = params["transl"][0].cpu().numpy()
+
+    R_first = R.from_rotvec(global_orient_first).as_matrix()
+    R_first_inv = R_first.T
+
+    norm_transform = np.eye(4)
+    norm_transform[:3, :3] = R_first_inv
+    norm_transform[:3, 3] = -R_first_inv @ transl_first
+
+    object_poses_normalized = np.array([norm_transform @ pose for pose in object_poses])
+
+    return motion_params_path, mesh_path, object_poses_normalized
+
+
+def main() -> None:
+    """Main function."""
+    args = parse_args()
+
+    # Load all data from folder
+    data_folder = Path(args.data_folder)
+    motion_params_path, object_mesh_path, object_poses = load_data(args.data_folder)
+    print(f"Loaded data from {data_folder}")
+    print(f"  Motion params: {motion_params_path}")
+    print(f"  Object mesh: {object_mesh_path}")
+    print(f"  Object poses: {len(object_poses)} frames")
+
+    # Initialize whole body kinematics
+    kin = G1WholeBodyKinematics(
+        robot_asset_path=str(G1_URDF),
+        package_dirs=PACKAGE_DIRS,
+        source_model="nvhuman",
+    )
+    base_q_size = 7
+    robot_joint_position_names = _get_robot_joint_position_names(kin, base_q_size)
+
+    # Load motion data
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    nvhuman = NVHuman(device=device)
+    motion = nvhuman.load_motion(params_path=motion_params_path)
+    joint_pos = motion["joints"]
+    joint_rot_wxyz = motion["joints_wxyz"]
+    vertices = motion["vertices"]
+    num_frames = motion["num_frames"]
+    if len(object_poses) != num_frames:
+        raise ValueError(
+            f"poses.npy length ({len(object_poses)}) != motion frames ({num_frames})"
+        )
+
+    # Get sequence ID from folder name
+    sequence_id = data_folder.name
+
+    # Get joint indices for head/root tracking
+    head_idx = NVHUMAN_JOINTS_ORDER.index("Head")
+    root_idx = NVHUMAN_JOINTS_ORDER.index("Hips")
+
+    object_name = f"{sequence_id}_object"
+
+    # Pre-load object mesh vertices for ground-plane computation.
+    _obj_verts = []
+    with open(object_mesh_path) as _f:
+        for _line in _f:
+            if _line.startswith("v "):
+                _parts = _line.split()
+                _obj_verts.append([float(_parts[1]), float(_parts[2]), float(_parts[3])])
+    object_mesh_vertices = np.array(_obj_verts, dtype=np.float64)
+
+    # Setup data logger
+    logger_data = None
+    if args.save:
+        params = torch.load(motion_params_path)
+        betas_tensor = params["betas"].cpu().numpy()
+        if betas_tensor.ndim > 1:
+            betas = betas_tensor[0].flatten().tolist()
+        else:
+            betas = betas_tensor.flatten().tolist()
+
+        object_body_names = ["object"]
+        safe_object_body_names = [_usd_safe(name) for name in object_body_names]
+        object_mesh_path = str(Path(object_mesh_path).resolve())
+        object_urdf_path = _build_object_urdf(
+            mesh_path=object_mesh_path,
+            urdf_path=data_folder / "object" / "textured_mesh.urdf",
+        )
+        object_mesh_radius = _compute_mesh_radius(object_mesh_path)
+
+        expected_joint_dim = kin.robot.model.nq - base_q_size
+        if len(robot_joint_position_names) != expected_joint_dim:
+            raise ValueError(
+                "robot_joint_names must align with robot_joint_positions. "
+                f"Expected {expected_joint_dim}, got {len(robot_joint_position_names)}."
+            )
+
+        logger_data = NvhumanG1Data(
+            sequence_id=sequence_id,
+            raw_motion_file=motion_params_path,
+            robot_name="g1",
+            fps=kin.frequency,
+            nvhuman_betas=betas,
+            robot_joint_names=robot_joint_position_names,
+            robot_frame_names=list(kin.robot_frame_names.values()),
+            robot_frame_task_names=list(kin.frame_tasks.keys()),
+            source_to_robot_scale=args.scale,
+            object_name=object_name,
+            safe_object_name=_usd_safe(object_name),
+            object_body_names=object_body_names,
+            safe_object_body_names=safe_object_body_names,
+            object_mesh_paths=[object_mesh_path],
+            object_urdf_paths=[object_urdf_path],
+            object_mesh_radius=[object_mesh_radius],
+        )
+
+    # Visualization frames
+    object_frame = None
+    head_frame = None
+    root_frame = None
+
+    # Setup visualization
+    server = None
+    if args.visualize:
+        server = viser.ViserServer(host="0.0.0.0", port=8080)
+
+        mesh = trimesh.load(object_mesh_path)
+        object_frame = server.scene.add_frame(
+            "/object",
+            wxyz=(1, 0, 0, 0),
+            position=(0, 0, 0),
+            axes_length=0.018,
+            axes_radius=0.0008,
+        )
+        server.scene.add_mesh_trimesh(
+            "/object/mesh", mesh, position=(0, 0, 0), wxyz=(1, 0, 0, 0)
+        )
+
+        head_frame = server.scene.add_frame(
+            "/head",
+            wxyz=(1, 0, 0, 0),
+            position=(0, 0, 0),
+            axes_length=0.1,
+            axes_radius=0.002,
+        )
+
+        root_frame = server.scene.add_frame(
+            "/root",
+            wxyz=(1, 0, 0, 0),
+            position=(0, 0, 0),
+            axes_length=0.1,
+            axes_radius=0.002,
+        )
+
+    # Initialize qpos
+    q = kin.robot.q0.copy()
+
+    # Target visualization handles (created on first frame)
+    target_handles: dict[str, viser.FrameHandle] = {}
+
+    # Ground-plane Z offset: the NVHuman normalization centers the pelvis at
+    # the origin, so foot-level (ground) is at a negative Z in robot coords.
+    # We compute it from source foot joints on frame 0 and shift all
+    # positions so ground = Z=0.
+    ground_z_offset = 0.0
+    object_z_lift = 0.0
+
+    # Source foot joints used for robust ground estimation. Using only feet
+    # avoids noisy non-foot joints pulling the ground estimate down.
+    source_foot_joint_names = [
+        "LeftFoot",
+        "RightFoot",
+        "LeftToeBase",
+        "RightToeBase",
+        "LeftToeEnd",
+        "RightToeEnd",
+    ]
+    source_foot_joint_idxs = [
+        NVHUMAN_JOINTS_ORDER.index(name)
+        for name in source_foot_joint_names
+        if name in NVHUMAN_JOINTS_ORDER
+    ]
+
+    # Frame-0 foot Z reference (in IK frame) used to detect and correct
+    # downward drift from noisy source reconstruction.
+    foot_frame_names = ["left_ankle_roll_link", "right_ankle_roll_link"]
+    foot_frame_idxs = [
+        list(kin.robot_frame_names.values()).index(fn) for fn in foot_frame_names
+    ]
+    foot_z_ref: float | None = None
+
+    # Processing loop
+    for frame_idx in tqdm(range(num_frames), desc="Retargeting"):
+        positions = joint_pos[frame_idx]
+        rotations = joint_rot_wxyz[frame_idx]
+
+        result = kin.compute(
+            source_joints=positions,
+            source_joints_wxyz=rotations,
+            source_to_robot_scale=args.scale,
+            qpos=q,
+        )
+        q_ik = result["q"].copy()
+        q = q_ik.copy()
+
+        # Foot-Z ground clamping: if the lowest ankle frame drifts below
+        # its frame-0 level (reconstruction noise), lift the free-flyer
+        # root so the feet stay on the ground.
+        lowest_foot_z = min(result["frame_pose"][i, 2] for i in foot_frame_idxs)
+        if foot_z_ref is None:
+            foot_z_ref = lowest_foot_z
+        else:
+            drift = lowest_foot_z - foot_z_ref
+            if drift < 0:
+                q[2] -= drift
+
+        # Compute object pose in robot coordinate system.
+        # Object rotation is a world-frame transform (not a body-local joint
+        # rotation), so we left-multiply by the coordinate change matrix
+        # rather than using the similarity transform (R @ M @ R^T) that
+        # transform_source_rotation applies for joint rotations.
+        obj_pose = object_poses[frame_idx]
+        obj_position = kin.transform_source_position(obj_pose[:3, 3])
+        obj_rotation_mat = kin._R_nvhuman_to_robot @ obj_pose[:3, :3]
+        obj_rotation = R.from_matrix(obj_rotation_mat)
+
+        # On frame 0, estimate ground from source feet only and shift into
+        # a ground-relative frame.
+        if frame_idx == 0:
+            foot_joint_z = np.array(
+                [
+                    kin.transform_source_position(positions[i])[2]
+                    for i in source_foot_joint_idxs
+                ]
+            )
+            ground_z_offset = -float(np.min(foot_joint_z))
+
+        obj_position[2] += ground_z_offset
+
+        # Object-specific lift: if the mesh still starts below ground after
+        # foot-based alignment (e.g. mesh origin/orientation mismatch), lift
+        # object trajectories only so the lowest mesh point is at Z=0.
+        # Applied only to saved data, not visualization (where it would float
+        # the object above the aligned skeleton/robot).
+        if frame_idx == 0:
+            obj_pos_for_mesh_check = obj_position.copy()
+            obj_verts_world = (obj_rotation_mat @ object_mesh_vertices.T).T + obj_pos_for_mesh_check
+            object_z_lift = max(0.0, -float(np.min(obj_verts_world[:, 2])))
+
+        # Extract head trajectory in robot coordinate system
+        head_position = kin.transform_source_position(positions[head_idx])
+        head_position[2] += ground_z_offset
+        head_rotation_mat = R.from_quat(
+            rotations[head_idx], scalar_first=True
+        ).as_matrix()
+        head_rotation_mat = kin.transform_source_rotation(head_rotation_mat)
+        head_rotation_wxyz = R.from_matrix(head_rotation_mat).as_quat(scalar_first=True)
+
+        # Extract root trajectory in robot coordinate system
+        root_position = kin.transform_source_position(positions[root_idx])
+        root_position[2] += ground_z_offset
+        root_rotation_mat = R.from_quat(
+            rotations[root_idx], scalar_first=True
+        ).as_matrix()
+        root_rotation_mat = kin.transform_source_rotation(root_rotation_mat)
+        root_rotation_wxyz = R.from_matrix(root_rotation_mat).as_quat(scalar_first=True)
+
+        # Log timestep data
+        if logger_data is not None:
+            # Pinocchio free-flyer: q[:3] = position, q[3:7] = quaternion (xyzw)
+            root_pos_robot = q[:3].copy()
+            root_pos_robot[2] += ground_z_offset
+            root_pos_robot = root_pos_robot.tolist()
+            root_quat_xyzw = q[3:7]
+            root_wxyz = [
+                float(root_quat_xyzw[3]),
+                float(root_quat_xyzw[0]),
+                float(root_quat_xyzw[1]),
+                float(root_quat_xyzw[2]),
+            ]
+            joint_positions = q[base_q_size:].tolist()
+
+            obj_wxyz = obj_rotation.as_quat(scalar_first=True).tolist()
+            logger_data.log_timestep(
+                nvhuman_joints=positions.tolist(),
+                nvhuman_joints_wxyz=rotations.tolist(),
+                nvhuman_head_translation=head_position.tolist(),
+                nvhuman_head_wxyz=head_rotation_wxyz.tolist(),
+                nvhuman_root_translation=root_position.tolist(),
+                nvhuman_root_wxyz=root_rotation_wxyz.tolist(),
+                robot_root_position=root_pos_robot,
+                robot_root_wxyz=root_wxyz,
+                robot_joint_positions=joint_positions,
+                robot_frames=result["frame_pose"].tolist(),
+                robot_frame_task_errors=result["frame_task_errors"],
+                robot_ik_error=float(np.sum(result["frame_task_errors"])),
+                robot_num_optimization_iterations=result["num_optimization_iterations"],
+                object_articulation=0.0,
+                object_root_position=(obj_position + [0, 0, object_z_lift]).tolist(),
+                object_root_axis_angle=obj_rotation.as_rotvec().tolist(),
+                object_body_position=[(obj_position + [0, 0, object_z_lift]).tolist()],
+                object_body_wxyz=[obj_wxyz],
+            )
+
+        # Update visualization
+        if server is not None:
+            vertices_vis = kin.transform_source_position(vertices[frame_idx]).copy()
+            vertices_vis[:, 2] += ground_z_offset
+            nvhuman.visualize(server, vertices=vertices_vis)
+            # Visualize pre-clamp IK pose so source skeleton overlays remain
+            # aligned with robot in debug view.
+            q_vis = q_ik.copy()
+            q_vis[2] += ground_z_offset
+            kin.visualize(server, q_vis)
+
+            # Visualize IK targets
+            for frame_name, task in kin.frame_tasks.items():
+                target_pos = task.transform_target_to_world.translation
+                target_pos_vis = target_pos.copy()
+                target_pos_vis[2] += ground_z_offset
+                target_rot = task.transform_target_to_world.rotation
+                target_wxyz = R.from_matrix(target_rot).as_quat(scalar_first=True)
+                if frame_name not in target_handles:
+                    target_handles[frame_name] = server.scene.add_frame(
+                        f"/targets/{frame_name}",
+                        position=target_pos_vis,
+                        wxyz=target_wxyz,
+                        axes_length=0.05,
+                        axes_radius=0.003,
+                    )
+                else:
+                    target_handles[frame_name].position = target_pos_vis
+                    target_handles[frame_name].wxyz = target_wxyz
+
+            if object_frame is not None:
+                object_frame.position = obj_position
+                object_frame.wxyz = obj_rotation.as_quat(scalar_first=True)
+
+            if head_frame is not None:
+                head_frame.position = head_position
+                head_frame.wxyz = head_rotation_wxyz
+
+            if root_frame is not None:
+                root_frame.position = root_position
+                root_frame.wxyz = root_rotation_wxyz
+
+        if frame_idx == 0 and args.visualize:
+            time.sleep(5)
+
+    # Save data
+    if logger_data is not None:
+        logger_data.save_to_parquet(
+            str(SAVE_DIR),
+            partition_cols=["sequence_id", "robot_name"],
+        )
+        print(f"Saved to {SAVE_DIR}")
+
+    print(f"Retargeting complete. Processed {num_frames} frames.")
+    if args.visualize:
+        print("Visualization server running. Press Ctrl+C to exit.")
+        while True:
+            time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/robotic_grounding/scripts/view_scene.py
+++ b/robotic_grounding/scripts/view_scene.py
@@ -1,8 +1,19 @@
-"""View a scene: spawns object + support surface from a motion file (no RL).
+"""View a scene: spawns object, optional support surface, and robot from Parquet (no RL).
 
-Usage:
+Robot articulation is added when the motion path includes a ``robot_name=...``
+partition and that name exists in ``assets/robot_registry.py`` (e.g. ``g1``).
+
+Usage (Sharpa / Arctic-style Parquet under ``human_motion_data``):
     python scripts/view_scene.py \
-        --motion_file source/.../arctic_processed/sequence_id=arctic_s01_ketchup_use_01/robot_name=sharpa_wave
+        --motion_file source/robotic_grounding/robotic_grounding/assets/human_motion_data/arctic_processed/sequence_id=arctic_s01_ketchup_use_01/robot_name=sharpa_wave
+
+NVHuman→G1 retargeted data (after ``nvhuman_to_g1.py --save``):
+    # Save motion first (writes under HUMAN_MOTION_DATA_DIR/nvhuman_g1_processed/...)
+    python scripts/retarget/nvhuman_to_g1.py <sequence_dir> --save
+
+    # Point at the partition directory (sequence_id=.../robot_name=g1) or use cwd-relative path
+    python scripts/view_scene.py \
+        --motion_file source/robotic_grounding/robotic_grounding/assets/human_motion_data/nvhuman_g1_processed/sequence_id=<your_sequence>/robot_name=g1
 
     # Headless (validate without GUI)
     python scripts/view_scene.py --motion_file <path> --headless

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/robot_registry.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/robot_registry.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 
 from isaaclab.assets.articulation import ArticulationCfg
 
+from robotic_grounding.assets.g1 import G1_CYLINDER_MODEL_12_HANDS_DEX_DELAYED_CFG
 from robotic_grounding.assets.sharpa_wave import (
     FINGER_JOINTS,
     FINGERTIP_BODY_NAME,
@@ -53,6 +54,15 @@ ROBOT_REGISTRY: dict[str, RobotSpec] = {
         wrist_body_name=WRIST_BODY_NAME,
         fingertip_body_name=FINGERTIP_BODY_NAME,
         hand_contact_bodies=HAND_CONTACT_BODIES,
+    ),
+    # Whole-body retarget (nvhuman_to_g1.py) uses main_with_hand.urdf — keep asset in sync.
+    "g1": RobotSpec(
+        robot_cfg=G1_CYLINDER_MODEL_12_HANDS_DEX_DELAYED_CFG,
+        wrist_joint_names=[],
+        finger_joint_names=[],
+        wrist_body_name="",
+        fingertip_body_name="",
+        hand_contact_bodies=[],
     ),
 }
 

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/retarget/data_logger.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/retarget/data_logger.py
@@ -18,6 +18,8 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
 
+from robotic_grounding.retarget.params import G1_WHOLEBODY_TO_NVHUMAN_MAPPING
+
 # Type alias for field specification
 # Format: (field_name, pyarrow_type, python_type, is_time_series)
 FieldSpec = tuple[str, pa.DataType, type, bool]
@@ -367,6 +369,50 @@ DEX3_FIELDS: list[FieldSpec] = [
 ]
 
 #############################################################
+# Whole body robot fields (G1)
+#############################################################
+G1_NUM_FRAME_TASKS = len(G1_WHOLEBODY_TO_NVHUMAN_MAPPING)
+G1_FIELDS: list[FieldSpec] = [
+    ("robot_joint_names", pa.list_(pa.string()), list[str], False),
+    ("robot_frame_names", pa.list_(pa.string()), list[str], False),
+    ("robot_frame_task_names", pa.list_(pa.string()), list[str], False),
+    ("source_to_robot_scale", pa.float32(), float, False),
+    # Time series
+    (
+        "robot_root_position",
+        pa.list_(pa.list_(pa.float32(), 3)),
+        list[list[float]],
+        True,
+    ),
+    (
+        "robot_root_wxyz",
+        pa.list_(pa.list_(pa.float32(), 4)),
+        list[list[float]],
+        True,
+    ),
+    (
+        "robot_joint_positions",
+        pa.list_(pa.list_(pa.float32())),
+        list[list[float]],
+        True,
+    ),
+    (
+        "robot_frames",
+        pa.list_(pa.list_(pa.list_(pa.float32(), 7))),
+        list[list[list[float]]],
+        True,
+    ),
+    (
+        "robot_frame_task_errors",
+        pa.list_(pa.list_(pa.float32(), G1_NUM_FRAME_TASKS)),
+        list[list[float]],
+        True,
+    ),
+    ("robot_ik_error", pa.list_(pa.float32()), list[float], True),
+    ("robot_num_optimization_iterations", pa.list_(pa.int32()), list[int], True),
+]
+
+#############################################################
 # Object fields
 #############################################################
 OBJECT_FIELDS: list[FieldSpec] = [
@@ -604,4 +650,9 @@ ManoSharpaData = create_data_logger_class(
 NvhumanDex3Data = create_data_logger_class(
     "NvhumanDex3Data",
     BASE_FIELDS + NVHUMAN_FIELDS + DEX3_FIELDS + OBJECT_FIELDS,
+)
+
+NvhumanG1Data = create_data_logger_class(
+    "NvhumanG1Data",
+    BASE_FIELDS + NVHUMAN_FIELDS + G1_FIELDS + OBJECT_FIELDS,
 )

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/retarget/params.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/retarget/params.py
@@ -313,6 +313,23 @@ G1_WHOLEBODY_TO_NVHUMAN_MAPPING = {
     "right_ankle_roll_link": ("RightFoot", 5.0, 1.0),
 }
 
+# Foot joints used for ground-plane estimation and foot-Z clamping during
+# whole-body retargeting. Source joints are from NVHUMAN_JOINTS_ORDER; robot
+# frames are the contact links used in G1_WHOLEBODY_TO_NVHUMAN_MAPPING.
+NVHUMAN_FOOT_JOINT_NAMES = [
+    "LeftFoot",
+    "RightFoot",
+    "LeftToeBase",
+    "RightToeBase",
+    "LeftToeEnd",
+    "RightToeEnd",
+]
+
+G1_FOOT_FRAME_NAMES = [
+    "left_ankle_roll_link",
+    "right_ankle_roll_link",
+]
+
 #############################################################
 # MANO hand link definitions
 #############################################################

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/retarget/params.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/retarget/params.py
@@ -287,6 +287,33 @@ R_PALM_CORRECTION_RIGHT = [
 ]
 
 #############################################################
+# IK parameters for G1 whole body
+#############################################################
+
+G1_WHOLEBODY_TO_NVHUMAN_MAPPING = {
+    # Pelvis
+    "pelvis": ("Hips", 1.0, 0.5),
+    # Torso
+    "torso_link": ("Chest", 1.0, 0.5),
+    # Left arm / hand
+    "left_hand_palm_link": ("LeftHand", 2.0, 0.1),
+    "left_hand_thumb_2_link": ("LeftHandThumbEnd", 2.0, 0.0),
+    "left_hand_index_1_link": ("LeftHandIndexEnd", 2.0, 0.0),
+    "left_hand_middle_1_link": ("LeftHandRingEnd", 2.0, 0.0),
+    # Right arm / hand
+    "right_hand_palm_link": ("RightHand", 2.0, 0.1),
+    "right_hand_thumb_2_link": ("RightHandThumbEnd", 2.0, 0.0),
+    "right_hand_index_1_link": ("RightHandIndexEnd", 2.0, 0.0),
+    "right_hand_middle_1_link": ("RightHandRingEnd", 2.0, 0.0),
+    # Left leg / foot
+    "left_knee_link": ("LeftShin", 0.25, 0.0),
+    "left_ankle_roll_link": ("LeftFoot", 5.0, 1.0),
+    # Right leg / foot
+    "right_knee_link": ("RightShin", 0.25, 0.0),
+    "right_ankle_roll_link": ("RightFoot", 5.0, 1.0),
+}
+
+#############################################################
 # MANO hand link definitions
 #############################################################
 

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/retarget/whole_body_kinematics.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/retarget/whole_body_kinematics.py
@@ -1,0 +1,404 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+
+from typing import Any, Literal, Optional
+
+import numpy as np
+import pink
+import pinocchio as pin
+import torch
+import viser
+from loop_rate_limiters import RateLimiter
+from pink import solve_ik
+from pink.limits import ConfigurationLimit, VelocityLimit
+from pink.tasks import FrameTask
+from scipy.spatial.transform import Rotation as R
+
+from robotic_grounding.retarget.params import (
+    G1_WHOLEBODY_TO_NVHUMAN_MAPPING,
+    NVHUMAN_JOINTS_ORDER,
+    R_NVHUMAN_TO_ROBOT,
+    R_PALM_CORRECTION_LEFT,
+    R_PALM_CORRECTION_RIGHT,
+)
+from robotic_grounding.retarget.pinocchio_viser_visualizer import ViserVisualizer
+
+
+class WholeBodyKinematics:
+    """Base class for whole body kinematics retargeting.
+
+    Follows the same patterns as HandKinematics but operates on the full body:
+    pelvis, torso, arms/hands, and legs/feet.
+    """
+
+    def __init__(
+        self,
+        robot_asset_path: str,
+        source_model: Literal["nvhuman", "smplh"],
+        package_dirs: Optional[list[str]] = None,
+        solver: str = "daqp",
+        max_iter: int = 200,
+        frequency: float = 200.0,
+        frame_tasks_converged_threshold: float = 1e-6,
+    ) -> None:
+        """Initialize the whole body kinematics.
+
+        Args:
+            robot_asset_path: Path to the robot URDF/MJCF file.
+            source_model: Source motion model ("nvhuman" or "smplh").
+            package_dirs: Directories to search for package:// mesh URLs.
+            solver: IK solver to use.
+            max_iter: Maximum IK iterations.
+            frequency: IK solve frequency.
+            frame_tasks_converged_threshold: Convergence threshold.
+        """
+        self.robot_asset_path = robot_asset_path
+        self.source_model = source_model
+        self.package_dirs = package_dirs or []
+        self.solver = solver
+        self.max_iter = max_iter
+        self.frequency = frequency
+        self.frame_tasks_converged_threshold = frame_tasks_converged_threshold
+
+        self.robot = self.load_robot_model()
+
+        self.robot_joint_names = {
+            i: str(self.robot.model.names[i])
+            for i in range(1, self.robot.model.njoints)
+        }
+
+        self.robot_frame_names = {
+            i: str(self.robot.model.frames[i].name)
+            for i in range(len(self.robot.model.frames))
+        }
+
+        self.configuration_limits = [
+            ConfigurationLimit(self.robot.model),
+            VelocityLimit(self.robot.model),
+        ]
+
+        self.configuration = pink.Configuration(
+            self.robot.model,
+            self.robot.data,
+            self.robot.q0,
+        )
+
+        rate = RateLimiter(frequency=frequency, warn=False)
+        self.dt = rate.period
+
+        self.source_joint_order = self.get_source_joint_order()
+        self.target_to_source = self.get_target_to_source_mapping()
+        self.frame_tasks = self.setup_frame_tasks()
+
+    def load_robot_model(self) -> pin.RobotWrapper:
+        """Load the robot model. Must be implemented by subclass."""
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must implement this method."
+        )
+
+    def get_source_joint_order(self) -> list[str]:
+        """Get the source joint order based on source model."""
+        if self.source_model == "nvhuman":
+            return NVHUMAN_JOINTS_ORDER
+        elif self.source_model == "smplh":
+            raise NotImplementedError("SMPL-H source model is not yet implemented.")
+        else:
+            raise ValueError(f"Unknown source model: {self.source_model}")
+
+    def get_target_to_source_mapping(self) -> dict[str, tuple[str, float, float]]:
+        """Get the target-to-source mapping.
+
+        Returns:
+            Dictionary of {robot_frame: (source_joint, position_cost, orientation_cost)}.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must implement this method."
+        )
+
+    def get_base_source_joint(self) -> str:
+        """Get the base source joint name for scaling."""
+        if self.source_model == "nvhuman":
+            return "Hips"
+        elif self.source_model == "smplh":
+            raise NotImplementedError("SMPL-H source model is not yet implemented.")
+        else:
+            raise ValueError(f"Unknown source model: {self.source_model}")
+
+    def transform_source_position(self, position: np.ndarray) -> np.ndarray:
+        """Transform source position to robot convention.
+
+        Override in subclass if coordinate system transformation is needed.
+        """
+        return position
+
+    def transform_source_rotation(self, rotation: np.ndarray) -> np.ndarray:
+        """Transform source rotation matrix to robot convention.
+
+        Override in subclass if coordinate system transformation is needed.
+        """
+        return rotation
+
+    def get_frame_rotation_correction(self, frame_name: str) -> np.ndarray:
+        """Get rotation correction for a specific robot frame.
+
+        Override in subclass if per-frame rotation corrections are needed.
+        """
+        return np.eye(3)
+
+    def visualize(
+        self,
+        viser_server: viser.ViserServer,
+        qpos: np.ndarray,
+    ) -> None:
+        """Visualize the robot in viser."""
+        if not hasattr(self, "robot_viser_model"):
+            self.robot_viser_model = ViserVisualizer(
+                viser_server=viser_server,
+                model=self.robot.model,
+                visual_model=self.robot.visual_model,
+                collision_model=self.robot.collision_model,
+            )
+        self.robot_viser_model.display(qpos)
+
+    def get_scale_anchor_position(
+        self,
+        source_joints: np.ndarray,
+    ) -> np.ndarray:
+        """Get the anchor position for scaling (lowest point in vertical axis).
+
+        Scaling is anchored at the lowest joint (feet) so ground contact is
+        preserved. XY is centered on the base joint (hips).
+
+        Args:
+            source_joints: Array of shape (num_joints, 3) with joint positions.
+
+        Returns:
+            Anchor position of shape (3,) in robot coordinates.
+        """
+        all_positions = np.array(
+            [
+                self.transform_source_position(source_joints[i])
+                for i in range(len(source_joints))
+            ]
+        )
+        lowest_idx = np.argmin(all_positions[:, 2])
+        anchor = all_positions[lowest_idx].copy()
+        anchor[:2] = self.transform_source_position(
+            source_joints[self.source_joint_order.index(self.get_base_source_joint())]
+        )[:2]
+        return anchor
+
+    def set_frame_tasks_target(
+        self,
+        source_joints: np.ndarray,
+        source_joints_wxyz: np.ndarray,
+        source_to_robot_scale: float = 1.0,
+    ) -> None:
+        """Set the target for the IK frame tasks.
+
+        Scaling is applied relative to the lowest point (feet) so that
+        ground contact is preserved when scaling down.
+
+        Args:
+            source_joints: Array of shape (num_joints, 3) with joint positions.
+            source_joints_wxyz: Array of shape (num_joints, 4) with joint orientations as wxyz quaternions.
+            source_to_robot_scale: Scale factor for positions relative to ground anchor.
+        """
+        anchor_pos = self.get_scale_anchor_position(source_joints)
+
+        for robot_frame_name, (
+            source_joint_name,
+            _,
+            _,
+        ) in self.target_to_source.items():
+            source_joint_idx = self.source_joint_order.index(source_joint_name)
+            target_pos = self.transform_source_position(source_joints[source_joint_idx])
+            target_pos = anchor_pos + (target_pos - anchor_pos) * source_to_robot_scale
+
+            target_wxyz = source_joints_wxyz[source_joint_idx]
+            target_rot = R.from_quat(target_wxyz, scalar_first=True).as_matrix()
+            target_rot = self.transform_source_rotation(target_rot)
+
+            frame_correction = self.get_frame_rotation_correction(robot_frame_name)
+            target_rot = target_rot @ frame_correction
+
+            self.frame_tasks[robot_frame_name].transform_target_to_world.translation = (
+                target_pos.copy()
+            )
+            self.frame_tasks[robot_frame_name].transform_target_to_world.rotation = (
+                target_rot.copy()
+            )
+
+    def setup_frame_tasks(self) -> dict[str, FrameTask]:
+        """Setup the IK frame tasks."""
+        frame_tasks = {}
+        for robot_frame_name, (
+            _,
+            position_cost,
+            orientation_cost,
+        ) in self.target_to_source.items():
+            frame_tasks[robot_frame_name] = FrameTask(
+                robot_frame_name,
+                position_cost=position_cost,
+                orientation_cost=orientation_cost,
+                lm_damping=1.0,
+            )
+            frame_tasks[robot_frame_name].set_target_from_configuration(
+                self.configuration
+            )
+        return frame_tasks
+
+    def compute(
+        self,
+        source_joints: torch.Tensor | np.ndarray,
+        source_joints_wxyz: torch.Tensor | np.ndarray,
+        source_to_robot_scale: float = 1.0,
+        qpos: Optional[np.ndarray] = None,
+    ) -> dict[str, Any]:
+        """Compute whole body IK.
+
+        Args:
+            source_joints: Joint positions from source model, shape (num_joints, 3).
+            source_joints_wxyz: Joint orientations as wxyz quaternions, shape (num_joints, 4).
+            source_to_robot_scale: Scale factor for positions relative to ground anchor.
+            qpos: Initial joint configuration. Uses q0 if None.
+
+        Returns:
+            Dictionary with keys: q, frame_pose, frame_task_errors, num_optimization_iterations.
+        """
+        if isinstance(source_joints, torch.Tensor):
+            source_joints = source_joints.detach().cpu().numpy()
+        if isinstance(source_joints_wxyz, torch.Tensor):
+            source_joints_wxyz = source_joints_wxyz.detach().cpu().numpy()
+
+        self.set_frame_tasks_target(
+            source_joints=source_joints,
+            source_joints_wxyz=source_joints_wxyz,
+            source_to_robot_scale=source_to_robot_scale,
+        )
+        tasks = list(self.frame_tasks.values())
+
+        self.configuration.q = self.robot.q0.copy() if qpos is None else qpos.copy()
+
+        frame_tasks_pos_error = {
+            task_name: float(np.inf) for task_name in self.frame_tasks
+        }
+        frame_tasks_converged = {task_name: False for task_name in self.frame_tasks}
+
+        num_optimization_iterations = 0
+        for _ in range(self.max_iter):
+            vel = solve_ik(
+                configuration=self.configuration,
+                tasks=tasks,
+                dt=self.dt,
+                solver=self.solver,
+                safety_break=False,
+                limits=self.configuration_limits,
+            )
+            self.configuration.integrate_inplace(vel, self.dt)
+            num_optimization_iterations += 1
+
+            for task_name, task in self.frame_tasks.items():
+                pos_error = float(
+                    np.linalg.norm(task.compute_error(self.configuration)[:3])
+                )
+                last_pos_error = frame_tasks_pos_error[task_name]
+                if (
+                    abs(pos_error - last_pos_error)
+                    < self.frame_tasks_converged_threshold
+                ):
+                    frame_tasks_converged[task_name] = True
+                frame_tasks_pos_error[task_name] = pos_error
+
+            if all(frame_tasks_converged.values()):
+                break
+
+        frame_pose = []
+        for _, frame_name in self.robot_frame_names.items():
+            pos = self.configuration.get_transform_frame_to_world(
+                frame_name
+            ).translation
+            rot_matrix = self.configuration.get_transform_frame_to_world(
+                frame_name
+            ).rotation
+            wxyz = R.from_matrix(rot_matrix).as_quat(scalar_first=True)
+            frame_pose.append(np.hstack([pos, wxyz]).tolist())
+        frame_pose = np.asarray(frame_pose)
+
+        return {
+            "q": self.configuration.q.copy(),
+            "frame_pose": frame_pose,
+            "frame_task_errors": [frame_tasks_pos_error[k] for k in self.frame_tasks],
+            "num_optimization_iterations": num_optimization_iterations,
+        }
+
+
+class G1WholeBodyKinematics(WholeBodyKinematics):
+    """G1 robot whole body kinematics for NVHuman retargeting."""
+
+    def __init__(
+        self,
+        robot_asset_path: str,
+        package_dirs: Optional[list[str]] = None,
+        source_model: Literal["nvhuman", "smplh"] = "nvhuman",
+        solver: str = "daqp",
+        max_iter: int = 200,
+        frequency: float = 200.0,
+        frame_tasks_converged_threshold: float = 1e-6,
+    ) -> None:
+        """Initialize G1 whole body kinematics."""
+        self._R_nvhuman_to_robot = np.array(R_NVHUMAN_TO_ROBOT, dtype=np.float64)
+        self._left_palm_correction = np.array(R_PALM_CORRECTION_LEFT, dtype=np.float64)
+        self._right_palm_correction = np.array(
+            R_PALM_CORRECTION_RIGHT, dtype=np.float64
+        )
+
+        super().__init__(
+            robot_asset_path=robot_asset_path,
+            source_model=source_model,
+            package_dirs=package_dirs,
+            solver=solver,
+            max_iter=max_iter,
+            frequency=frequency,
+            frame_tasks_converged_threshold=frame_tasks_converged_threshold,
+        )
+
+    def load_robot_model(self) -> pin.RobotWrapper:
+        """Load the G1 robot model from URDF with a free-flyer root joint."""
+        return pin.RobotWrapper.BuildFromURDF(
+            filename=self.robot_asset_path,
+            package_dirs=self.package_dirs,
+            root_joint=pin.JointModelFreeFlyer(),
+        )
+
+    def get_target_to_source_mapping(self) -> dict[str, tuple[str, float, float]]:
+        """Get the G1 to NVHuman body mapping."""
+        if self.source_model == "nvhuman":
+            return dict(G1_WHOLEBODY_TO_NVHUMAN_MAPPING)
+        elif self.source_model == "smplh":
+            raise NotImplementedError(
+                "SMPL-H source model is not yet implemented for G1."
+            )
+        else:
+            raise ValueError(f"Unknown source model: {self.source_model}")
+
+    def get_frame_rotation_correction(self, frame_name: str) -> np.ndarray:
+        """Get rotation correction for palm frames to align with human hand."""
+        if "left" in frame_name and "palm" in frame_name:
+            return self._left_palm_correction
+        if "right" in frame_name and "palm" in frame_name:
+            return self._right_palm_correction
+        return np.eye(3)
+
+    def transform_source_position(self, position: np.ndarray) -> np.ndarray:
+        """Transform position from NVHuman to robot convention."""
+        return position @ self._R_nvhuman_to_robot.T
+
+    def transform_source_rotation(self, rotation: np.ndarray) -> np.ndarray:
+        """Transform rotation matrix from NVHuman to robot convention."""
+        return self._R_nvhuman_to_robot @ rotation @ self._R_nvhuman_to_robot.T

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/retarget/whole_body_kinematics.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/retarget/whole_body_kinematics.py
@@ -137,9 +137,22 @@ class WholeBodyKinematics:
         return position
 
     def transform_source_rotation(self, rotation: np.ndarray) -> np.ndarray:
-        """Transform source rotation matrix to robot convention.
+        """Transform a source body-local rotation matrix to robot convention.
 
-        Override in subclass if coordinate system transformation is needed.
+        Uses a similarity transform ``R_src_to_robot @ M @ R_src_to_robot.T``
+        so the rotation remains expressed in the robot's basis while acting on
+        vectors from the body's local frame. Override in subclass if a
+        coordinate system transformation is needed.
+        """
+        return rotation
+
+    def transform_world_rotation(self, rotation: np.ndarray) -> np.ndarray:
+        """Transform a source world-frame rotation matrix to robot convention.
+
+        For world-frame transforms (e.g. an object's global pose, not a
+        body-local joint rotation), only a left-multiply by
+        ``R_src_to_robot`` is needed. Subclasses that rotate source
+        coordinates should override.
         """
         return rotation
 
@@ -400,5 +413,9 @@ class G1WholeBodyKinematics(WholeBodyKinematics):
         return position @ self._R_nvhuman_to_robot.T
 
     def transform_source_rotation(self, rotation: np.ndarray) -> np.ndarray:
-        """Transform rotation matrix from NVHuman to robot convention."""
+        """Transform a body-local rotation from NVHuman to robot convention."""
         return self._R_nvhuman_to_robot @ rotation @ self._R_nvhuman_to_robot.T
+
+    def transform_world_rotation(self, rotation: np.ndarray) -> np.ndarray:
+        """Transform a world-frame rotation from NVHuman to robot convention."""
+        return self._R_nvhuman_to_robot @ rotation

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/replay_data.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/replay_data.py
@@ -1,0 +1,245 @@
+"""Schema-aware replay trajectory loading for scene playback scripts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+import pyarrow.parquet as pq
+from scipy.spatial.transform import Rotation as R
+
+from robotic_grounding.retarget.data_logger import (
+    ManoSharpaData,
+    NvhumanDex3Data,
+    NvhumanG1Data,
+)
+from robotic_grounding.tasks.scene_utils.scene_config import SceneConfig
+
+
+@dataclass
+class ObjectTrajectory:
+    """Object root trajectory in world coordinates."""
+
+    root_position: np.ndarray  # (T, 3)
+    root_wxyz: np.ndarray  # (T, 4)
+
+
+@dataclass
+class SingleRobotTrajectory:
+    """Canonical replay data for a single whole-body robot."""
+
+    schema: Literal["nvhuman_g1"]
+    robot_layout: Literal["single_robot"]
+    fps: float
+    num_frames: int
+    robot_joint_names: list[str]
+    robot_root_position: np.ndarray  # (T, 3)
+    robot_root_wxyz: np.ndarray  # (T, 4)
+    robot_joint_positions: np.ndarray  # (T, N)
+    object_traj: ObjectTrajectory | None
+
+
+@dataclass
+class DualHandTrajectory:
+    """Canonical replay data for dual floating-hand robots."""
+
+    schema: Literal["mano_sharpa", "nvhuman_dex3"]
+    robot_layout: Literal["dual_hand"]
+    fps: float
+    num_frames: int
+    right_joint_names: list[str]
+    left_joint_names: list[str]
+    right_wrist_position: np.ndarray  # (T, 3)
+    left_wrist_position: np.ndarray  # (T, 3)
+    wrist_orientation_format: Literal["wxyz", "euler_xyz"]
+    right_wrist_orientation: np.ndarray  # (T, 4) or (T, 3)
+    left_wrist_orientation: np.ndarray  # (T, 4) or (T, 3)
+    right_finger_joints: np.ndarray
+    left_finger_joints: np.ndarray
+    object_traj: ObjectTrajectory | None
+
+
+ReplayTrajectory = SingleRobotTrajectory | DualHandTrajectory
+
+
+def _resolve_path_and_filters(
+    motion_file: str,
+) -> tuple[str, list[tuple[str, str, str]] | None]:
+    """Resolve path and infer deterministic partition filters."""
+    resolved = SceneConfig._resolve_motion_file(motion_file)
+    partition = SceneConfig._parse_partition_path(resolved)
+    filters = partition.get("motion_filters")
+    # If the resolved path already points to the sequence/robot partition leaf,
+    # partition filters can exclude all rows because partition columns may no
+    # longer be materialized at that scope. In that case, load directly.
+    parts = Path(resolved).parts
+    has_seq_partition = any(p.startswith("sequence_id=") for p in parts)
+    has_robot_partition = any(p.startswith("robot_name=") for p in parts)
+    if has_seq_partition and has_robot_partition:
+        filters = None
+    return resolved, filters
+
+
+def _build_object_traj(
+    object_root_position: list[list[float]] | None,
+    object_root_axis_angle: list[list[float]] | None,
+) -> ObjectTrajectory | None:
+    """Convert object root position + axis-angle arrays to replay trajectory."""
+    if not object_root_position or not object_root_axis_angle:
+        return None
+    pos = np.asarray(object_root_position, dtype=np.float32)
+    aa = np.asarray(object_root_axis_angle, dtype=np.float64)
+    if pos.ndim != 2 or pos.shape[1] != 3:
+        return None
+    if aa.ndim != 2 or aa.shape[1] != 3:
+        return None
+    root_wxyz = np.asarray(
+        [R.from_rotvec(v).as_quat(scalar_first=True) for v in aa],
+        dtype=np.float32,
+    )
+    return ObjectTrajectory(root_position=pos, root_wxyz=root_wxyz)
+
+
+def _is_g1_schema(columns: set[str]) -> bool:
+    return {
+        "robot_root_position",
+        "robot_root_wxyz",
+        "robot_joint_positions",
+    }.issubset(columns)
+
+
+def _is_sharpa_schema(columns: set[str]) -> bool:
+    return {
+        "robot_right_wrist_position",
+        "robot_right_wrist_wxyz",
+        "robot_right_finger_joints",
+        "robot_left_wrist_position",
+        "robot_left_wrist_wxyz",
+        "robot_left_finger_joints",
+    }.issubset(columns)
+
+
+def _is_dex3_schema(columns: set[str]) -> bool:
+    return {
+        "robot_right_wrist_position",
+        "robot_right_wrist_euler_xyz",
+        "robot_right_finger_joints",
+        "robot_left_wrist_position",
+        "robot_left_wrist_euler_xyz",
+        "robot_left_finger_joints",
+    }.issubset(columns)
+
+
+def _to_single_robot(data: Any) -> SingleRobotTrajectory:
+    object_traj = _build_object_traj(
+        object_root_position=getattr(data, "object_root_position", None),
+        object_root_axis_angle=getattr(data, "object_root_axis_angle", None),
+    )
+    root_pos = np.asarray(data.robot_root_position, dtype=np.float32)
+    root_wxyz = np.asarray(data.robot_root_wxyz, dtype=np.float32)
+    joint_pos = np.asarray(data.robot_joint_positions, dtype=np.float32)
+    return SingleRobotTrajectory(
+        schema="nvhuman_g1",
+        robot_layout="single_robot",
+        fps=float(data.fps),
+        num_frames=int(root_pos.shape[0]),
+        robot_joint_names=list(data.robot_joint_names),
+        robot_root_position=root_pos,
+        robot_root_wxyz=root_wxyz,
+        robot_joint_positions=joint_pos,
+        object_traj=object_traj,
+    )
+
+
+def _to_dual_hand_wxyz(data: Any) -> DualHandTrajectory:
+    object_traj = _build_object_traj(
+        object_root_position=getattr(data, "object_root_position", None),
+        object_root_axis_angle=getattr(data, "object_root_axis_angle", None),
+    )
+    right_pos = np.asarray(data.robot_right_wrist_position, dtype=np.float32)
+    left_pos = np.asarray(data.robot_left_wrist_position, dtype=np.float32)
+    return DualHandTrajectory(
+        schema="mano_sharpa",
+        robot_layout="dual_hand",
+        fps=float(data.fps),
+        num_frames=int(right_pos.shape[0]),
+        right_joint_names=list(data.right_robot_finger_joint_names),
+        left_joint_names=list(data.left_robot_finger_joint_names),
+        right_wrist_position=right_pos,
+        left_wrist_position=left_pos,
+        wrist_orientation_format="wxyz",
+        right_wrist_orientation=np.asarray(data.robot_right_wrist_wxyz, dtype=np.float32),
+        left_wrist_orientation=np.asarray(data.robot_left_wrist_wxyz, dtype=np.float32),
+        right_finger_joints=np.asarray(data.robot_right_finger_joints, dtype=np.float32),
+        left_finger_joints=np.asarray(data.robot_left_finger_joints, dtype=np.float32),
+        object_traj=object_traj,
+    )
+
+
+def _to_dual_hand_euler(data: Any) -> DualHandTrajectory:
+    object_traj = _build_object_traj(
+        object_root_position=getattr(data, "object_root_position", None),
+        object_root_axis_angle=getattr(data, "object_root_axis_angle", None),
+    )
+    right_pos = np.asarray(data.robot_right_wrist_position, dtype=np.float32)
+    left_pos = np.asarray(data.robot_left_wrist_position, dtype=np.float32)
+    return DualHandTrajectory(
+        schema="nvhuman_dex3",
+        robot_layout="dual_hand",
+        fps=float(data.fps),
+        num_frames=int(right_pos.shape[0]),
+        right_joint_names=list(data.right_robot_finger_joint_names),
+        left_joint_names=list(data.left_robot_finger_joint_names),
+        right_wrist_position=right_pos,
+        left_wrist_position=left_pos,
+        wrist_orientation_format="euler_xyz",
+        right_wrist_orientation=np.asarray(
+            data.robot_right_wrist_euler_xyz, dtype=np.float32
+        ),
+        left_wrist_orientation=np.asarray(
+            data.robot_left_wrist_euler_xyz, dtype=np.float32
+        ),
+        right_finger_joints=np.asarray(data.robot_right_finger_joints, dtype=np.float32),
+        left_finger_joints=np.asarray(data.robot_left_finger_joints, dtype=np.float32),
+        object_traj=object_traj,
+    )
+
+
+def load_replay_trajectory(
+    motion_file: str,
+    trajectory_id: int = 0,
+) -> ReplayTrajectory:
+    """Load replay trajectory from a motion parquet path for known schemas."""
+    resolved, filters = _resolve_path_and_filters(motion_file)
+    columns = set(pq.read_table(resolved).schema.names)
+
+    if _is_g1_schema(columns):
+        data = NvhumanG1Data.from_parquet(
+            root_path=resolved,
+            filters=filters,
+            trajectory_id=trajectory_id,
+        )
+        return _to_single_robot(data)
+
+    if _is_sharpa_schema(columns):
+        data = ManoSharpaData.from_parquet(
+            root_path=resolved,
+            filters=filters,
+            trajectory_id=trajectory_id,
+        )
+        return _to_dual_hand_wxyz(data)
+
+    if _is_dex3_schema(columns):
+        data = NvhumanDex3Data.from_parquet(
+            root_path=resolved,
+            filters=filters,
+            trajectory_id=trajectory_id,
+        )
+        return _to_dual_hand_euler(data)
+
+    raise ValueError(
+        "Unsupported replay schema. Expected one of: "
+        "{NvhumanG1Data, ManoSharpaData, NvhumanDex3Data}."
+    )

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/replay_data.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/replay_data.py
@@ -170,9 +170,13 @@ def _to_dual_hand_wxyz(data: Any) -> DualHandTrajectory:
         right_wrist_position=right_pos,
         left_wrist_position=left_pos,
         wrist_orientation_format="wxyz",
-        right_wrist_orientation=np.asarray(data.robot_right_wrist_wxyz, dtype=np.float32),
+        right_wrist_orientation=np.asarray(
+            data.robot_right_wrist_wxyz, dtype=np.float32
+        ),
         left_wrist_orientation=np.asarray(data.robot_left_wrist_wxyz, dtype=np.float32),
-        right_finger_joints=np.asarray(data.robot_right_finger_joints, dtype=np.float32),
+        right_finger_joints=np.asarray(
+            data.robot_right_finger_joints, dtype=np.float32
+        ),
         left_finger_joints=np.asarray(data.robot_left_finger_joints, dtype=np.float32),
         object_traj=object_traj,
     )
@@ -201,7 +205,9 @@ def _to_dual_hand_euler(data: Any) -> DualHandTrajectory:
         left_wrist_orientation=np.asarray(
             data.robot_left_wrist_euler_xyz, dtype=np.float32
         ),
-        right_finger_joints=np.asarray(data.robot_right_finger_joints, dtype=np.float32),
+        right_finger_joints=np.asarray(
+            data.robot_right_finger_joints, dtype=np.float32
+        ),
         left_finger_joints=np.asarray(data.robot_left_finger_joints, dtype=np.float32),
         object_traj=object_traj,
     )

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/scene_viewer_env_cfg.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/scene_viewer_env_cfg.py
@@ -7,12 +7,18 @@ import isaaclab.terrains as terrain_gen
 import torch
 from isaaclab.assets import AssetBaseCfg
 from isaaclab.envs import ManagerBasedEnvCfg
+from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.utils import configclass
 
-from robotic_grounding.tasks.scene_utils import SceneConfig, apply_scene_objects
+from robotic_grounding.tasks.scene_utils import (
+    SceneConfig,
+    apply_scene_objects,
+    apply_scene_robot,
+)
+from robotic_grounding.tasks.v2p import mdp
 
 
 def _dummy_obs(env: object) -> torch.Tensor:
@@ -60,12 +66,34 @@ class SceneViewerActionsCfg:
 
 
 @configclass
-class SceneViewerEnvCfg(ManagerBasedEnvCfg):
-    """Spawns object + support surface from a SceneConfig YAML. No robot, no RL."""
+class SceneViewerEventCfg:
+    """Prestartup collision group setup; same contract as ``apply_scene_objects`` expects."""
 
-    scene: SceneViewerSceneCfg = SceneViewerSceneCfg(num_envs=1, env_spacing=3.0)
+    setup_collision_groups = EventTerm(
+        func=mdp.configure_collision_groups,
+        mode="prestartup",
+        params={
+            "robot_names": [],
+            "object_names": [],
+            "fixed_object_names": [],
+            "disable_robot_to_object_collisions": False,
+            "disable_robot_to_fixed_object_collisions": True,
+        },
+    )
+
+
+@configclass
+class SceneViewerEnvCfg(ManagerBasedEnvCfg):
+    """Spawns scene objects, optional support surface, and robot from a motion Parquet."""
+
+    scene: SceneViewerSceneCfg = SceneViewerSceneCfg(
+        num_envs=1,
+        env_spacing=3.0,
+        replicate_physics=False,
+    )
     observations: SceneViewerObsCfg = SceneViewerObsCfg()
     actions: SceneViewerActionsCfg = SceneViewerActionsCfg()
+    events: SceneViewerEventCfg = SceneViewerEventCfg()
 
     motion_file: str | None = None
 
@@ -78,3 +106,6 @@ class SceneViewerEnvCfg(ManagerBasedEnvCfg):
         if self.motion_file is not None:
             scene_config = SceneConfig.from_motion_file(self.motion_file)
             apply_scene_objects(self, scene_config)
+            if scene_config.robot_name is not None:
+                apply_scene_robot(self, scene_config, static=False)
+

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/scene_viewer_env_cfg.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/scene_viewer_env_cfg.py
@@ -108,4 +108,3 @@ class SceneViewerEnvCfg(ManagerBasedEnvCfg):
             apply_scene_objects(self, scene_config)
             if scene_config.robot_name is not None:
                 apply_scene_robot(self, scene_config, static=False)
-

--- a/robotic_grounding/tests/test_nvhuman_g1_parquet_integration.py
+++ b/robotic_grounding/tests/test_nvhuman_g1_parquet_integration.py
@@ -1,0 +1,174 @@
+import importlib.util
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+
+from robotic_grounding.retarget.data_logger import NvhumanG1Data
+from robotic_grounding.retarget.params import G1_WHOLEBODY_TO_NVHUMAN_MAPPING
+
+try:
+    from robotic_grounding.tasks.scene_utils.scene_config import SceneConfig
+except ModuleNotFoundError:
+    # Fallback for environments without IsaacLab/Omniverse modules where
+    # importing robotic_grounding.tasks triggers heavy runtime dependencies.
+    scene_config_path = (
+        Path(__file__).resolve().parents[1]
+        / "source"
+        / "robotic_grounding"
+        / "robotic_grounding"
+        / "tasks"
+        / "scene_utils"
+        / "scene_config.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "scene_config_fallback", scene_config_path
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load SceneConfig from {scene_config_path}")
+    scene_config_module = importlib.util.module_from_spec(spec)
+    # Register module before execution so decorators (e.g., @dataclass) can
+    # resolve cls.__module__ via sys.modules during import-time processing.
+    sys.modules[spec.name] = scene_config_module
+    spec.loader.exec_module(scene_config_module)
+    SceneConfig = scene_config_module.SceneConfig
+
+
+def _write_test_mesh(mesh_path: Path) -> None:
+    mesh_path.parent.mkdir(parents=True, exist_ok=True)
+    mesh_path.write_text(
+        "\n".join(
+            [
+                "o object",
+                "v 0.0 0.0 0.0",
+                "v 0.1 0.0 0.0",
+                "v 0.0 0.1 0.0",
+                "f 1 2 3",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_test_urdf(urdf_path: Path, mesh_path: Path) -> None:
+    urdf_path.write_text(
+        f"""<?xml version="1.0"?>
+<robot name="test_object">
+  <link name="object">
+    <visual>
+      <geometry>
+        <mesh filename="{mesh_path.resolve()}"/>
+      </geometry>
+    </visual>
+    <collision>
+      <geometry>
+        <mesh filename="{mesh_path.resolve()}"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>
+""",
+        encoding="utf-8",
+    )
+
+
+def test_nvhuman_g1_parquet_roundtrip_scene_config_and_loader(tmp_path: Path) -> None:
+    """Write NvhumanG1 parquet, then load via scene config and data loader API."""
+    mesh_path = tmp_path / "object" / "textured_mesh.obj"
+    urdf_path = tmp_path / "object" / "textured_mesh.urdf"
+    _write_test_mesh(mesh_path)
+    _write_test_urdf(urdf_path, mesh_path)
+
+    sequence_id = "seq_test_001"
+    robot_name = "g1"
+    frame_task_errors = [0.0] * len(G1_WHOLEBODY_TO_NVHUMAN_MAPPING)
+
+    logger_data = NvhumanG1Data(
+        sequence_id=sequence_id,
+        raw_motion_file=str(tmp_path / "nova_params_opt.pt"),
+        robot_name=robot_name,
+        fps=30.0,
+        nvhuman_betas=[0.0] * 10,
+        robot_joint_names=["left_knee_joint", "right_knee_joint"],
+        robot_frame_names=["pelvis"],
+        robot_frame_task_names=list(G1_WHOLEBODY_TO_NVHUMAN_MAPPING.keys()),
+        source_to_robot_scale=1.0,
+        object_name="seq_test_object",
+        safe_object_name="seq_test_object",
+        object_body_names=["object"],
+        safe_object_body_names=["object"],
+        object_mesh_paths=[str(mesh_path.resolve())],
+        object_urdf_paths=[str(urdf_path.resolve())],
+        object_mesh_radius=[0.1],
+    )
+
+    logger_data.log_timestep(
+        nvhuman_joints=[[0.0, 0.0, 0.0] for _ in range(93)],
+        nvhuman_joints_wxyz=[[1.0, 0.0, 0.0, 0.0] for _ in range(93)],
+        nvhuman_head_translation=[0.0, 0.0, 1.0],
+        nvhuman_head_wxyz=[1.0, 0.0, 0.0, 0.0],
+        nvhuman_root_translation=[0.0, 0.0, 0.8],
+        nvhuman_root_wxyz=[1.0, 0.0, 0.0, 0.0],
+        robot_root_position=[0.0, 0.0, 0.8],
+        robot_root_wxyz=[1.0, 0.0, 0.0, 0.0],
+        robot_joint_positions=[0.1, -0.1],
+        robot_frames=[[0.0, 0.0, 0.8, 1.0, 0.0, 0.0, 0.0]],
+        robot_frame_task_errors=frame_task_errors,
+        robot_ik_error=0.0,
+        robot_num_optimization_iterations=1,
+        object_articulation=0.0,
+        object_root_axis_angle=[0.0, 0.0, 0.0],
+        object_root_position=[0.2, 0.3, 0.4],
+        object_body_position=[[0.2, 0.3, 0.4]],
+        object_body_wxyz=[[1.0, 0.0, 0.0, 0.0]],
+    )
+
+    output_dir = tmp_path / "nvhuman_g1_processed"
+    logger_data.save_to_parquet(
+        root_path=str(output_dir),
+        partition_cols=["sequence_id", "robot_name"],
+    )
+
+    loaded = NvhumanG1Data.from_parquet(
+        root_path=str(output_dir),
+        filters=[("sequence_id", "=", sequence_id), ("robot_name", "=", robot_name)],
+    )
+    assert loaded.object_body_names == ["object"]
+    assert loaded.object_mesh_paths == [str(mesh_path.resolve())]
+    assert loaded.object_urdf_paths == [str(urdf_path.resolve())]
+    assert len(loaded.robot_joint_names) == len(loaded.robot_joint_positions[0])
+
+    partition_dir = output_dir / f"sequence_id={sequence_id}" / f"robot_name={robot_name}"
+    scene_cfg = SceneConfig.from_motion_file(str(partition_dir))
+    assert scene_cfg.object_body_names == ["object"]
+    assert len(scene_cfg.scene_objects) == 1
+    assert getattr(scene_cfg.scene_objects[0], "name", None) == "object"
+    assert getattr(scene_cfg.scene_objects[0], "usd_path", None) == str(
+        urdf_path.resolve()
+    )
+
+
+def _run_as_script() -> int:
+    """Run this test file directly without pytest."""
+    test_name = "test_nvhuman_g1_parquet_roundtrip_scene_config_and_loader"
+    print("=" * 72, flush=True)
+    print("Running NVHuman->G1 parquet integration test", flush=True)
+    print(f"Test: {test_name}", flush=True)
+    print("=" * 72, flush=True)
+    try:
+        with tempfile.TemporaryDirectory(prefix="nvhuman_g1_test_") as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            print(f"[SETUP] Temporary directory: {tmp_path}", flush=True)
+            test_nvhuman_g1_parquet_roundtrip_scene_config_and_loader(tmp_path)
+        print(f"[PASS] {test_name}", flush=True)
+        return 0
+    except Exception:
+        print(f"[FAIL] {test_name}", flush=True)
+        print("-" * 72, flush=True)
+        traceback.print_exc()
+        print("-" * 72, flush=True)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run_as_script())

--- a/robotic_grounding/tests/test_nvhuman_g1_parquet_integration.py
+++ b/robotic_grounding/tests/test_nvhuman_g1_parquet_integration.py
@@ -25,7 +25,9 @@ except ModuleNotFoundError:
         "scene_config_fallback", scene_config_path
     )
     if spec is None or spec.loader is None:
-        raise ImportError(f"Could not load SceneConfig from {scene_config_path}")
+        raise ImportError(
+            f"Could not load SceneConfig from {scene_config_path}"
+        ) from None
     scene_config_module = importlib.util.module_from_spec(spec)
     # Register module before execution so decorators (e.g., @dataclass) can
     # resolve cls.__module__ via sys.modules during import-time processing.
@@ -138,7 +140,9 @@ def test_nvhuman_g1_parquet_roundtrip_scene_config_and_loader(tmp_path: Path) ->
     assert loaded.object_urdf_paths == [str(urdf_path.resolve())]
     assert len(loaded.robot_joint_names) == len(loaded.robot_joint_positions[0])
 
-    partition_dir = output_dir / f"sequence_id={sequence_id}" / f"robot_name={robot_name}"
+    partition_dir = (
+        output_dir / f"sequence_id={sequence_id}" / f"robot_name={robot_name}"
+    )
     scene_cfg = SceneConfig.from_motion_file(str(partition_dir))
     assert scene_cfg.object_body_names == ["object"]
     assert len(scene_cfg.scene_objects) == 1

--- a/robotic_grounding/tests/test_replay_data.py
+++ b/robotic_grounding/tests/test_replay_data.py
@@ -23,6 +23,7 @@ import inspect
 import sys
 import tempfile
 import traceback
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -46,6 +47,7 @@ _SCENE_UTILS_DIR = (
     / "scene_utils"
 )
 
+
 def _load_module_directly(name: str, path: Path) -> Any:
     """Load a single .py module without triggering __init__ chains."""
     spec = importlib.util.spec_from_file_location(name, path)
@@ -55,6 +57,7 @@ def _load_module_directly(name: str, path: Path) -> Any:
     sys.modules[name] = mod
     spec.loader.exec_module(mod)
     return mod
+
 
 # scene_config must be loaded first because replay_data imports it.
 _scene_config_mod = _load_module_directly(
@@ -90,6 +93,7 @@ def _build_joint_reorder(
             )
         indices.append(sim_name_to_idx[pq_name])
     return torch.tensor(indices, dtype=torch.long)
+
 
 # ============================================================
 # Schema detection
@@ -192,9 +196,7 @@ def _write_g1_parquet(output_dir: Path) -> Path:
             object_body_wxyz=[[1.0, 0.0, 0.0, 0.0]],
         )
 
-    data.save_to_parquet(
-        str(output_dir), partition_cols=["sequence_id", "robot_name"]
-    )
+    data.save_to_parquet(str(output_dir), partition_cols=["sequence_id", "robot_name"])
     return output_dir / f"sequence_id={seq_id}" / f"robot_name={robot_name}"
 
 
@@ -284,9 +286,7 @@ def _write_sharpa_parquet(output_dir: Path) -> Path:
             object_root_position=[0.0, 0.0, 0.5],
         )
 
-    data.save_to_parquet(
-        str(output_dir), partition_cols=["sequence_id", "robot_name"]
-    )
+    data.save_to_parquet(str(output_dir), partition_cols=["sequence_id", "robot_name"])
     return output_dir / f"sequence_id={seq_id}" / f"robot_name={robot_name}"
 
 
@@ -336,7 +336,7 @@ def test_build_joint_reorder_permutation() -> None:
 # Script runner (no pytest)
 # ============================================================
 
-_ALL_TESTS = [
+_ALL_TESTS: list[Callable[..., Any]] = [
     test_schema_detection_g1,
     test_schema_detection_sharpa,
     test_schema_detection_dex3,

--- a/robotic_grounding/tests/test_replay_data.py
+++ b/robotic_grounding/tests/test_replay_data.py
@@ -1,0 +1,378 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+
+"""Tests for the replay data adapter (schema detection, trajectory loading, joint reorder).
+
+These tests run without Isaac Lab / Omniverse — they only exercise the Parquet
+adapter and joint-reorder logic.
+
+Usage (pytest):
+    pytest tests/test_replay_data.py -v
+
+Usage (direct):
+    python tests/test_replay_data.py
+"""
+
+import importlib.util
+import inspect
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from robotic_grounding.retarget.data_logger import (
+    ManoSharpaData,
+    NvhumanG1Data,
+)
+from robotic_grounding.retarget.params import G1_WHOLEBODY_TO_NVHUMAN_MAPPING
+
+# replay_data lives under robotic_grounding.tasks which transitively imports
+# Isaac Lab / Omniverse.  Use the same importlib fallback as the existing
+# test_nvhuman_g1_parquet_integration.py so the test runs without Omniverse.
+_SCENE_UTILS_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "source"
+    / "robotic_grounding"
+    / "robotic_grounding"
+    / "tasks"
+    / "scene_utils"
+)
+
+def _load_module_directly(name: str, path: Path) -> Any:
+    """Load a single .py module without triggering __init__ chains."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load {name} from {path}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+# scene_config must be loaded first because replay_data imports it.
+_scene_config_mod = _load_module_directly(
+    "robotic_grounding.tasks.scene_utils.scene_config",
+    _SCENE_UTILS_DIR / "scene_config.py",
+)
+_replay_data_mod = _load_module_directly(
+    "robotic_grounding.tasks.scene_utils.replay_data",
+    _SCENE_UTILS_DIR / "replay_data.py",
+)
+
+DualHandTrajectory = _replay_data_mod.DualHandTrajectory
+SingleRobotTrajectory = _replay_data_mod.SingleRobotTrajectory
+_is_dex3_schema = _replay_data_mod._is_dex3_schema
+_is_g1_schema = _replay_data_mod._is_g1_schema
+_is_sharpa_schema = _replay_data_mod._is_sharpa_schema
+load_replay_trajectory = _replay_data_mod.load_replay_trajectory
+
+
+def _build_joint_reorder(
+    parquet_names: list[str], sim_names: list[str]
+) -> torch.Tensor | None:
+    """Inline copy of the reorder helper (avoids importing replay_motion which needs Isaac Lab)."""
+    if parquet_names == sim_names:
+        return None
+    sim_name_to_idx = {n: i for i, n in enumerate(sim_names)}
+    indices: list[int] = []
+    for pq_name in parquet_names:
+        if pq_name not in sim_name_to_idx:
+            raise ValueError(
+                f"Parquet joint '{pq_name}' not found in spawned robot joints: "
+                f"{sim_names}"
+            )
+        indices.append(sim_name_to_idx[pq_name])
+    return torch.tensor(indices, dtype=torch.long)
+
+# ============================================================
+# Schema detection
+# ============================================================
+
+
+def test_schema_detection_g1() -> None:
+    """G1 schema detected from required columns."""
+    cols = {
+        "robot_root_position",
+        "robot_root_wxyz",
+        "robot_joint_positions",
+        "fps",
+    }
+    assert _is_g1_schema(cols)
+    assert not _is_sharpa_schema(cols)
+    assert not _is_dex3_schema(cols)
+
+
+def test_schema_detection_sharpa() -> None:
+    """Sharpa schema detected from required columns."""
+    cols = {
+        "robot_right_wrist_position",
+        "robot_right_wrist_wxyz",
+        "robot_right_finger_joints",
+        "robot_left_wrist_position",
+        "robot_left_wrist_wxyz",
+        "robot_left_finger_joints",
+    }
+    assert _is_sharpa_schema(cols)
+    assert not _is_g1_schema(cols)
+    assert not _is_dex3_schema(cols)
+
+
+def test_schema_detection_dex3() -> None:
+    """Dex3 schema detected from required columns."""
+    cols = {
+        "robot_right_wrist_position",
+        "robot_right_wrist_euler_xyz",
+        "robot_right_finger_joints",
+        "robot_left_wrist_position",
+        "robot_left_wrist_euler_xyz",
+        "robot_left_finger_joints",
+    }
+    assert _is_dex3_schema(cols)
+    assert not _is_g1_schema(cols)
+    assert not _is_sharpa_schema(cols)
+
+
+# ============================================================
+# G1 trajectory round-trip
+# ============================================================
+
+
+def _write_g1_parquet(output_dir: Path) -> Path:
+    """Write a minimal NvhumanG1Data parquet and return the partition dir."""
+    seq_id = "replay_test_seq"
+    robot_name = "g1"
+    frame_task_errors = [0.0] * len(G1_WHOLEBODY_TO_NVHUMAN_MAPPING)
+    joint_names = ["joint_a", "joint_b"]
+
+    data = NvhumanG1Data(
+        sequence_id=seq_id,
+        raw_motion_file="fake.pt",
+        robot_name=robot_name,
+        fps=30.0,
+        nvhuman_betas=[0.0] * 10,
+        robot_joint_names=joint_names,
+        robot_frame_names=["pelvis"],
+        robot_frame_task_names=list(G1_WHOLEBODY_TO_NVHUMAN_MAPPING.keys()),
+        source_to_robot_scale=1.0,
+        object_name="test_obj",
+        safe_object_name="test_obj",
+        object_body_names=[],
+        safe_object_body_names=[],
+        object_mesh_paths=[],
+        object_urdf_paths=[],
+        object_mesh_radius=[],
+    )
+
+    for i in range(5):
+        data.log_timestep(
+            nvhuman_joints=[[0.0, 0.0, 0.0] for _ in range(93)],
+            nvhuman_joints_wxyz=[[1.0, 0.0, 0.0, 0.0] for _ in range(93)],
+            nvhuman_head_translation=[0.0, 0.0, 1.0 + i * 0.01],
+            nvhuman_head_wxyz=[1.0, 0.0, 0.0, 0.0],
+            nvhuman_root_translation=[0.0, 0.0, 0.8 + i * 0.01],
+            nvhuman_root_wxyz=[1.0, 0.0, 0.0, 0.0],
+            robot_root_position=[0.0, 0.0, 0.1 * i],
+            robot_root_wxyz=[1.0, 0.0, 0.0, 0.0],
+            robot_joint_positions=[0.1 * i, -0.1 * i],
+            robot_frames=[[0.0, 0.0, 0.8, 1.0, 0.0, 0.0, 0.0]],
+            robot_frame_task_errors=frame_task_errors,
+            robot_ik_error=0.0,
+            robot_num_optimization_iterations=1,
+            object_articulation=0.0,
+            object_root_axis_angle=[0.0, 0.0, 0.1 * i],
+            object_root_position=[0.2, 0.3, 0.4 + 0.01 * i],
+            object_body_position=[[0.2, 0.3, 0.4 + 0.01 * i]],
+            object_body_wxyz=[[1.0, 0.0, 0.0, 0.0]],
+        )
+
+    data.save_to_parquet(
+        str(output_dir), partition_cols=["sequence_id", "robot_name"]
+    )
+    return output_dir / f"sequence_id={seq_id}" / f"robot_name={robot_name}"
+
+
+def test_load_g1_trajectory(tmp_path: Path) -> None:
+    """Load G1 parquet via replay adapter and verify canonical structure."""
+    partition_dir = _write_g1_parquet(tmp_path / "g1_data")
+    traj = load_replay_trajectory(str(partition_dir))
+
+    assert isinstance(traj, SingleRobotTrajectory)
+    assert traj.schema == "nvhuman_g1"
+    assert traj.robot_layout == "single_robot"
+    assert traj.num_frames == 5
+    assert traj.fps == 30.0
+    assert traj.robot_joint_names == ["joint_a", "joint_b"]
+    assert traj.robot_root_position.shape == (5, 3)
+    assert traj.robot_root_wxyz.shape == (5, 4)
+    assert traj.robot_joint_positions.shape == (5, 2)
+    assert traj.object_traj is not None
+    assert traj.object_traj.root_position.shape == (5, 3)
+    assert traj.object_traj.root_wxyz.shape == (5, 4)
+    np.testing.assert_allclose(traj.robot_root_position[0, 2], 0.0, atol=1e-6)
+    np.testing.assert_allclose(traj.robot_root_position[4, 2], 0.4, atol=1e-6)
+
+
+# ============================================================
+# Sharpa trajectory round-trip
+# ============================================================
+
+
+def _write_sharpa_parquet(output_dir: Path) -> Path:
+    """Write a minimal ManoSharpaData parquet and return the partition dir."""
+    seq_id = "sharpa_test_seq"
+    robot_name = "sharpa_wave"
+
+    data = ManoSharpaData(
+        sequence_id=seq_id,
+        raw_motion_file="fake.pt",
+        robot_name=robot_name,
+        fps=120.0,
+        mano_flat_hand_mean=True,
+        mano_center_idx=0,
+        mano_to_robot_scale=1.0,
+        mano_right_betas=[0.0] * 10,
+        mano_left_betas=[0.0] * 10,
+        mano_link_names=["palm"],
+        right_robot_finger_joint_names=["r_j0", "r_j1"],
+        right_robot_frame_names=["r_frame"],
+        right_robot_frame_task_names=["r_task"],
+        left_robot_finger_joint_names=["l_j0", "l_j1"],
+        left_robot_frame_names=["l_frame"],
+        left_robot_frame_task_names=["l_task"],
+        object_name="sharpa_obj",
+        safe_object_name="sharpa_obj",
+        object_body_names=[],
+        safe_object_body_names=[],
+        object_mesh_paths=[],
+        object_urdf_paths=[],
+        object_mesh_radius=[],
+    )
+
+    for i in range(3):
+        data.log_timestep(
+            mano_right_trans=[0.1 * i, 0.0, 0.0],
+            mano_right_global_orient=[0.0, 0.0, 0.0],
+            mano_right_finger_pose=[0.0] * 45,
+            mano_right_joints=[[0.0, 0.0, 0.0]] * 21,
+            mano_right_joints_wxyz=[[1.0, 0.0, 0.0, 0.0]] * 21,
+            mano_left_trans=[-0.1 * i, 0.0, 0.0],
+            mano_left_global_orient=[0.0, 0.0, 0.0],
+            mano_left_finger_pose=[0.0] * 45,
+            mano_left_joints=[[0.0, 0.0, 0.0]] * 21,
+            mano_left_joints_wxyz=[[1.0, 0.0, 0.0, 0.0]] * 21,
+            robot_right_wrist_position=[0.1 * i, 0.0, 0.3],
+            robot_right_wrist_wxyz=[1.0, 0.0, 0.0, 0.0],
+            robot_right_finger_joints=[0.0] * 22,
+            robot_right_frames=[[0.0] * 7] * 67,
+            robot_right_frame_task_errors=[0.0] * 11,
+            robot_right_num_optimization_iterations=1,
+            robot_left_wrist_position=[-0.1 * i, 0.0, 0.3],
+            robot_left_wrist_wxyz=[1.0, 0.0, 0.0, 0.0],
+            robot_left_finger_joints=[0.0] * 22,
+            robot_left_frames=[[0.0] * 7] * 67,
+            robot_left_frame_task_errors=[0.0] * 11,
+            robot_left_num_optimization_iterations=1,
+            object_articulation=0.0,
+            object_root_axis_angle=[0.0, 0.0, 0.0],
+            object_root_position=[0.0, 0.0, 0.5],
+        )
+
+    data.save_to_parquet(
+        str(output_dir), partition_cols=["sequence_id", "robot_name"]
+    )
+    return output_dir / f"sequence_id={seq_id}" / f"robot_name={robot_name}"
+
+
+def test_load_sharpa_trajectory(tmp_path: Path) -> None:
+    """Load Sharpa parquet via replay adapter and verify dual-hand structure."""
+    partition_dir = _write_sharpa_parquet(tmp_path / "sharpa_data")
+    traj = load_replay_trajectory(str(partition_dir))
+
+    assert isinstance(traj, DualHandTrajectory)
+    assert traj.schema == "mano_sharpa"
+    assert traj.robot_layout == "dual_hand"
+    assert traj.num_frames == 3
+    assert traj.fps == 120.0
+    assert traj.wrist_orientation_format == "wxyz"
+    assert traj.right_joint_names == ["r_j0", "r_j1"]
+    assert traj.left_joint_names == ["l_j0", "l_j1"]
+    assert traj.right_wrist_position.shape == (3, 3)
+    assert traj.left_wrist_position.shape == (3, 3)
+    assert traj.right_wrist_orientation.shape == (3, 4)
+    assert traj.right_finger_joints.shape == (3, 22)
+    assert traj.object_traj is not None
+    assert traj.object_traj.root_position.shape == (3, 3)
+
+
+# ============================================================
+# Joint reorder
+# ============================================================
+
+
+def test_build_joint_reorder_identity() -> None:
+    """Identical ordering returns None (no reorder needed)."""
+    names = ["a", "b", "c"]
+    assert _build_joint_reorder(names, names) is None
+
+
+def test_build_joint_reorder_permutation() -> None:
+    """Permuted ordering returns correct index mapping."""
+    parquet = ["c", "a", "b"]
+    sim = ["a", "b", "c"]
+    reorder = _build_joint_reorder(parquet, sim)
+    assert reorder is not None
+    expected = torch.tensor([2, 0, 1], dtype=torch.long)
+    assert torch.equal(reorder, expected)
+
+
+# ============================================================
+# Script runner (no pytest)
+# ============================================================
+
+_ALL_TESTS = [
+    test_schema_detection_g1,
+    test_schema_detection_sharpa,
+    test_schema_detection_dex3,
+    test_load_g1_trajectory,
+    test_load_sharpa_trajectory,
+    test_build_joint_reorder_identity,
+    test_build_joint_reorder_permutation,
+]
+
+
+def _run_as_script() -> int:
+    """Run all tests directly without pytest."""
+    print("=" * 72, flush=True)
+    print("Running replay_data adapter tests", flush=True)
+    print("=" * 72, flush=True)
+    passed = 0
+    failed = 0
+    for test_fn in _ALL_TESTS:
+        name = test_fn.__name__
+        try:
+            with tempfile.TemporaryDirectory(prefix="replay_test_") as tmp_dir:
+                sig = inspect.signature(test_fn)
+                if "tmp_path" in sig.parameters:
+                    test_fn(tmp_path=Path(tmp_dir))
+                else:
+                    test_fn()
+            print(f"  [PASS] {name}", flush=True)
+            passed += 1
+        except Exception:
+            print(f"  [FAIL] {name}", flush=True)
+            traceback.print_exc()
+            failed += 1
+    print("-" * 72, flush=True)
+    print(f"Results: {passed} passed, {failed} failed", flush=True)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run_as_script())


### PR DESCRIPTION
## Changes:

- New retarget pipeline (nvhuman_to_g1.py, whole_body_kinematics.py) with ground-plane alignment, foot-Z clamping, and object-specific lift
- Kinematic replay script (replay_motion.py) supporting both single-robot and dual-hand schemas with auto-detect for legacy vs grounded data
- Support surface reconstruction extended for NvhumanG1 schema
- Parquet replay adapter (replay_data.py) with schema auto-detection
- Scene viewer updated to support robot articulation spawning
- README updated with retargeting, replay, and reconstruction docs
- Integration and unit tests for replay data and parquet output

## Tests
tested locally with two different types of whole body tasks.

https://github.com/user-attachments/assets/282aafbf-ae4c-4bd4-825a-9cd2f058691d


https://github.com/user-attachments/assets/62189dd7-a503-473d-9c2c-25e6b046f066

