### PR TITLE
Add aarch64 Docker image support (Dockerfile.aarch64, run.sh arch-suf…

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,11 @@
+# Source CSS/PDX credentials. Sets CSS_ENDPOINT_URL, CSS_ACCESS_KEY,
+# CSS_SECRET_KEY, CSS_REGION. Does NOT set HTTPS_PROXY/HTTP_PROXY — those
+# break botocore and osmo. Use proxychains4 for routing instead.
+source_up_if_exists
+source "$(pwd)/robotic_grounding/scripts/setup_css_env.sh"
+
+# Local overrides (gitignored) — put per-machine or secret values here.
+# e.g. export CSS_SECRET_KEY="your-real-key"
+if [ -f "$(pwd)/.envrc.local" ]; then
+  source "$(pwd)/.envrc.local"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ CLAUDE.md
 
 # Auto-generated no-collision URDFs (created at pipeline runtime from *_rigid.urdf)
 **/*_no_collision.urdf
+
+# Local direnv overrides
+.envrc.local

--- a/robotic_grounding/workflow/Dockerfile.aarch64
+++ b/robotic_grounding/workflow/Dockerfile.aarch64
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# aarch64 variant — three packages removed vs Dockerfile:
+#   dearpygui     : no Linux aarch64 wheel on PyPI; not used in scripts/ or source/
+#   usd-core      : no Linux aarch64 wheel on PyPI; base image ships nvidia-srl-usd 2.0.0 (provides pxr)
+#   onnxruntime-gpu: no aarch64 wheel on PyPI; base image ships onnxruntime 1.24.4 with CUDAExecutionProvider
+
+##############################################################
+# Base Stage
+##############################################################
+
+FROM nvcr.io/nvidia/isaac-lab:2.3.1 AS base
+
+# Set working directory
+WORKDIR /workspace/video_to_data/robotic_grounding
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    tmux \
+    htop \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+##############################################################
+# Install Python Dependencies (before source copy for caching)
+##############################################################
+
+# Install general dependencies
+# (dearpygui omitted — no aarch64 wheel; not used anywhere)
+RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --upgrade pip
+RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-cache-dir \
+    tensordict==0.8.3 \
+    datasets==2.19.0 \
+    wandb==0.22.2 \
+    importlib_metadata \
+    plotly \
+    viser==1.0.15 \
+    scipy \
+    scikit-learn
+
+# Install chumpy and manotorch (using --no-build-isolation to avoid pip module issues in old setup.py)
+RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-cache-dir --no-build-isolation \
+    git+https://github.com/mattloper/chumpy.git \
+    git+https://github.com/lixiny/manotorch.git
+
+# Install Retargeting dependencies
+# (usd-core omitted — no aarch64 wheel; base image ships nvidia-srl-usd 2.0.0 which provides pxr)
+RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-cache-dir \
+    mujoco \
+    judo-rai>=0.0.5 \
+    "pin-pink>=4.0.0" \
+    pin==3.7.0 \
+    deprecation
+
+# Install QPSolvers
+RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-cache-dir --upgrade \
+    osqp \
+    qpsolvers[clarabel,daqp,proxqp,scs,osqp]==4.9.0
+
+# FIXME: pytorch3d is not installed with cuda, making the retarget distance_utils module not importable
+# # Install pytorch3d (required for retarget distance_utils; --no-build-isolation so build sees Isaac Lab's torch)
+# RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-cache-dir --no-build-isolation \
+#     "git+https://github.com/facebookresearch/pytorch3d.git"
+
+# Install Robotic Grounding dependencies
+# onnxruntime-gpu has no aarch64 wheel. We install onnxruntime (CPU build) here so the package is
+# explicitly present. The base image ships onnxruntime 1.24.4 with CUDAExecutionProvider built in,
+# so pip will see it as already satisfied and skip the download — GPU inference still works.
+# If the base image ever drops onnxruntime, this installs the CPU fallback instead.
+RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-cache-dir \
+    onnxruntime \
+    imageio \
+    imageio-ffmpeg \
+    pytorch-ignite \
+    pytest \
+    boto3
+
+# Install numpy < 2.0.0 to avoid compatibility issues in Isaac Lab
+RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-cache-dir \
+    "numpy<2.0.0"
+
+##############################################################
+# Copy source code and scripts
+##############################################################
+
+COPY pyproject.toml ./
+COPY README.md ./
+
+COPY source/ ./source/
+COPY scripts/ ./scripts/
+
+# Install the project in editable mode
+RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install --no-cache-dir \
+    -e ./source/robotic_grounding
+
+# Create wrapper script for python (for convenience in container shell)
+RUN echo '#!/bin/bash' > /usr/local/bin/python && \
+    echo "exec ${ISAACLAB_PATH}/isaaclab.sh -p \"\$@\"" >> /usr/local/bin/python && \
+    chmod +x /usr/local/bin/python && \
+    echo "alias python='${ISAACLAB_PATH}/isaaclab.sh -p'" >> /etc/skel/.bashrc && \
+    echo "alias python='${ISAACLAB_PATH}/isaaclab.sh -p'" >> /root/.bashrc
+
+# # Verify pytorch3d is installed (build fails if not importable)
+# RUN ${ISAACLAB_PATH}/isaaclab.sh -p -c "import pytorch3d; print('pytorch3d', pytorch3d.__version__)"
+
+# Set the default command
+CMD ["/bin/bash"]

--- a/robotic_grounding/workflow/run.sh
+++ b/robotic_grounding/workflow/run.sh
@@ -2,33 +2,88 @@
 
 # Script to manage robotic-grounding Docker container
 # Usage:
-#   ./run.sh build [version]         - Build the Docker image (default: latest)
-#   ./run.sh push [version]          - Push the Docker image to NVIDIA registry (default: latest)
-#   ./run.sh pull [version]          - Pull the Docker image from NVIDIA registry (default: latest)
-#   ./run.sh start [version] [gpu]   - Run the container and enter the shell (default version: latest, gpu: 0)
-#   ./run.sh shell [version] [gpu]   - Enter the shell of a running container with specific version and GPU
+#   ./run.sh build [version]              - Build x86_64 image (default version: latest)
+#   ./run.sh build-aarch64 [version]      - Build aarch64 image (default version: latest)
+#   ./run.sh push [version]               - Push x86_64 image to NVIDIA registry
+#   ./run.sh push-aarch64 [version]       - Push aarch64 image to NVIDIA registry
+#   ./run.sh pull [version]               - Pull x86_64 image from NVIDIA registry
+#   ./run.sh pull-aarch64 [version]       - Pull aarch64 image from NVIDIA registry
+#   ./run.sh start [version] [gpu]        - Start x86_64 container (default version: latest, gpu: 0)
+#   ./run.sh start-aarch64 [version] [gpu] - Start aarch64 container
+#   ./run.sh shell [version] [gpu]        - Enter shell of a running container
+#   ./run.sh shell-aarch64 [version] [gpu] - Enter shell of a running aarch64 container
 #   ./run.sh exec [version] [gpu] -- <cmd>  - Run a command in a running container
-#   ./run.sh stop [version] [gpu]    - Stop the running container
+#   ./run.sh stop [version] [gpu]         - Stop the running container
+#   ./run.sh stop-aarch64 [version] [gpu] - Stop the running aarch64 container
 
 set -e
 
+# Detect arch suffix from the subcommand — affects IMAGE_NAME and CONTAINER_NAME.
+# e.g. start-aarch64 uses robotic-grounding:latest-aarch64 and a distinct container name.
+ARCH_SUFFIX=""
+CMD="$1"
+if [[ "$CMD" == *-aarch64 ]]; then
+    ARCH_SUFFIX="-aarch64"
+    CMD="${CMD%-aarch64}"
+fi
+
 VERSION=${2:-latest}
 GPU_DEVICE=${3:-0}
-IMAGE_NAME="robotic-grounding:${VERSION}"
-CONTAINER_NAME="robotic-grounding-${VERSION}-gpu${GPU_DEVICE}"
+IMAGE_NAME="robotic-grounding${ARCH_SUFFIX}:${VERSION}"
+CONTAINER_NAME="robotic-grounding${ARCH_SUFFIX}-${VERSION}-gpu${GPU_DEVICE}"
 NGC_LOCATION="nvcr.io/nvstaging/isaac-amr"
 
-case "$1" in
+case "$CMD" in
     build)
         echo "Building Docker image: ${IMAGE_NAME}"
         cd "$(dirname "$0")/.."
-        docker build -t ${IMAGE_NAME} -f workflow/Dockerfile .
-        echo "Build complete!"
+
+        if [ -n "$ARCH_SUFFIX" ]; then
+            SETUP_OK=true
+
+            if ! docker buildx version &>/dev/null; then
+                echo ""
+                echo "ERROR: docker buildx plugin is not installed."
+                echo "  Fix:  sudo apt-get install -y docker-buildx-plugin"
+                SETUP_OK=false
+            fi
+
+            if ${SETUP_OK} && ! docker buildx ls 2>/dev/null | grep -q "multiarch"; then
+                echo ""
+                echo "WARNING: 'multiarch' buildx builder not found."
+                echo "  Fix:  docker buildx create --name multiarch --use"
+                echo "        docker buildx inspect --bootstrap"
+                SETUP_OK=false
+            fi
+
+            if ${SETUP_OK} && ! docker buildx ls 2>/dev/null | grep -q "linux/arm64"; then
+                echo ""
+                echo "WARNING: arm64 platform not available in buildx."
+                echo "  Fix:  docker run --privileged --rm tonistiigi/binfmt --install arm64"
+                SETUP_OK=false
+            fi
+
+            if ! ${SETUP_OK}; then
+                echo ""
+                echo "One-time setup (run in order):"
+                echo "  1. sudo apt-get install -y docker-buildx-plugin"
+                echo "  2. docker run --privileged --rm tonistiigi/binfmt --install arm64"
+                echo "  3. docker buildx create --name multiarch --use"
+                echo "  4. docker buildx inspect --bootstrap"
+                exit 1
+            fi
+
+            docker buildx build --platform linux/arm64 --load \
+                -t ${IMAGE_NAME} -f workflow/Dockerfile.aarch64 .
+        else
+            docker build -t ${IMAGE_NAME} -f workflow/Dockerfile .
+        fi
+
+        echo "Build complete: ${IMAGE_NAME}"
         ;;
 
     push)
-        echo "Pushing Docker image to NVIDIA registry (version: ${VERSION})..."
-        echo "Tagging ${IMAGE_NAME} for registry..."
+        echo "Pushing ${IMAGE_NAME} to NVIDIA registry..."
         docker tag ${IMAGE_NAME} ${NGC_LOCATION}/${IMAGE_NAME}
         docker push ${NGC_LOCATION}/${IMAGE_NAME}
         echo "Push complete!"
@@ -37,23 +92,20 @@ case "$1" in
         ;;
 
     pull)
-        echo "Pulling Docker image from NVIDIA registry (version: ${VERSION})..."
+        echo "Pulling ${NGC_LOCATION}/${IMAGE_NAME}..."
         docker pull ${NGC_LOCATION}/${IMAGE_NAME}
-        echo "Tagging as ${IMAGE_NAME}..."
         docker tag ${NGC_LOCATION}/${IMAGE_NAME} ${IMAGE_NAME}
-        echo "Pull complete!"
+        echo "Pull complete: ${IMAGE_NAME}"
         ;;
 
     start)
-        echo "Starting container: ${CONTAINER_NAME}"
+        echo "Starting container: ${CONTAINER_NAME} (image: ${IMAGE_NAME})"
 
-        # Check if container is running
         if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
             echo "Container is already running. Entering shell..."
         else
             echo "Creating and starting new container..."
             cd "$(dirname "$0")/.."
-            # Allow X11 forwarding from Docker containers
             xhost +local:docker > /dev/null 2>&1 || true
 
             SSH_AGENT_MOUNT=""
@@ -75,12 +127,23 @@ case "$1" in
                 WANDB_API_KEY_ENV="-e WANDB_API_KEY=${WANDB_API_KEY_VALUE}"
             fi
 
+            # Optional: overlay an external human_motion_data directory (e.g. from another repo).
+            # Set HUMAN_MOTION_DATA_DIR on the host to an absolute path before calling run.sh:
+            #   HUMAN_MOTION_DATA_DIR=/path/to/human_motion_data ./workflow/run.sh start
+            DATA_MOUNT=""
+            CONTAINER_DATA_DIR="/workspace/video_to_data/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data"
+            if [ -n "${HUMAN_MOTION_DATA_DIR}" ]; then
+                DATA_MOUNT="-v ${HUMAN_MOTION_DATA_DIR}:${CONTAINER_DATA_DIR}"
+                echo "Mounting external data: ${HUMAN_MOTION_DATA_DIR} → ${CONTAINER_DATA_DIR}"
+            fi
+
             docker run --rm -it \
                 --runtime=nvidia \
                 --gpus device=${GPU_DEVICE} \
                 --network host \
                 --name ${CONTAINER_NAME} \
                 -v $(pwd)/..:/workspace/video_to_data \
+                ${DATA_MOUNT} \
                 -v ~/.ssh:/root/.ssh:ro \
                 -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
                 -e DISPLAY=${DISPLAY} \
@@ -93,17 +156,15 @@ case "$1" in
                 ${IMAGE_NAME}
         fi
 
-        # Enter the shell
         docker exec -it ${CONTAINER_NAME} /bin/bash
         ;;
 
     shell)
         echo "Entering shell of container: ${CONTAINER_NAME}"
 
-        # Check if container is running
         if ! docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
             echo "Error: Container ${CONTAINER_NAME} is not running."
-            echo "Use './run.sh start' to start the container first."
+            echo "Use './run.sh start${ARCH_SUFFIX}' to start the container first."
             exit 1
         fi
 
@@ -111,18 +172,16 @@ case "$1" in
         ;;
 
     exec)
-        # Shift past the subcommand, version, and gpu args to find "--"
         shift 3 2>/dev/null || true
-        # Skip the "--" separator if present
         [ "$1" = "--" ] && shift
         if [ $# -eq 0 ]; then
-            echo "Usage: $0 exec [version] [gpu] -- <command>"
+            echo "Usage: $0 exec${ARCH_SUFFIX} [version] [gpu] -- <command>"
             exit 1
         fi
 
         if ! docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
             echo "Error: Container ${CONTAINER_NAME} is not running."
-            echo "Use './run.sh start' to start the container first."
+            echo "Use './run.sh start${ARCH_SUFFIX}' to start the container first."
             exit 1
         fi
 
@@ -132,7 +191,6 @@ case "$1" in
     stop)
         echo "Stopping container: ${CONTAINER_NAME}"
 
-        # Check if container is running
         if ! docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
             echo "Container ${CONTAINER_NAME} is not running."
             exit 0
@@ -143,15 +201,21 @@ case "$1" in
         ;;
 
     *)
-        echo "Usage: $0 {build|pull|push|start|shell|exec|stop} [version] [gpu]"
+        echo "Usage: $0 {build|push|pull|start|shell|exec|stop}[-aarch64] [version] [gpu]"
         echo ""
-        echo "  build [version]         - Build the Docker image (default: latest)"
-        echo "  pull [version]          - Pull the Docker image from NVIDIA registry (default: latest)"
-        echo "  push [version]          - Push the Docker image to NVIDIA registry (default: latest)"
-        echo "  start [version] [gpu]   - Run the container and enter the shell (default version: latest, gpu: 0)"
-        echo "  shell                   - Enter the shell of a running container"
+        echo "  build [version]               - Build x86_64 image (default: latest)"
+        echo "  build-aarch64 [version]        - Build aarch64 image (default: latest-aarch64)"
+        echo "  push [version]                - Push x86_64 image to NGC"
+        echo "  push-aarch64 [version]         - Push aarch64 image to NGC"
+        echo "  pull [version]                - Pull x86_64 image from NGC"
+        echo "  pull-aarch64 [version]         - Pull aarch64 image from NGC"
+        echo "  start [version] [gpu]         - Start x86_64 container (default gpu: 0)"
+        echo "  start-aarch64 [version] [gpu]  - Start aarch64 container"
+        echo "  shell [version] [gpu]         - Enter shell of a running container"
+        echo "  shell-aarch64 [version] [gpu]  - Enter shell of a running aarch64 container"
         echo "  exec [version] [gpu] -- <cmd> - Run a command in a running container"
-        echo "  stop                    - Stop the running container"
+        echo "  stop [version] [gpu]          - Stop the running container"
+        echo "  stop-aarch64 [version] [gpu]   - Stop the running aarch64 container"
         exit 1
         ;;
 esac


### PR DESCRIPTION
Add aarch64 Docker image support

Dockerfile.aarch64: x86 Dockerfile minus dearpygui, usd-core, onnxruntime-gpu(no aarch64 wheels); onnxruntime CPU build used instead (base image provides GPU EP)

run.sh: build/push/pull/start/shell/stop all support -aarch64 suffix variant; aarch64 image named robotic-grounding-aarch64:<version>; build-aarch64 checks for docker buildx + QEMU setup with actionable fix instructions

.envrc: auto-sources setup_css_env.sh on cd; supports .envrc.local for local overrides (if direnv enabled)