### PR TITLE
fix(osmo): forward training args, make wandb entity configurable

### DIFF
--- a/robotic_grounding/experiments/example_param_sweep/workflow.py
+++ b/robotic_grounding/experiments/example_param_sweep/workflow.py
@@ -15,7 +15,10 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
-from experiments.utils import make_entry_script  # noqa: E402
+from experiments.utils import (  # noqa: E402
+    DEFAULT_OSMO_IMAGE_LATEST,
+    make_entry_script,
+)
 
 
 def _fmt(val: str | float) -> str:
@@ -107,5 +110,5 @@ workflow:
 
 default-values:
   workflow_name: robotic_grounding_{exp_id}
-  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:latest
+  image: {DEFAULT_OSMO_IMAGE_LATEST}
 """

--- a/robotic_grounding/experiments/example_sequence_list/workflow.py
+++ b/robotic_grounding/experiments/example_sequence_list/workflow.py
@@ -12,7 +12,10 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
-from experiments.utils import make_entry_script  # noqa: E402
+from experiments.utils import (  # noqa: E402
+    DEFAULT_OSMO_IMAGE_LATEST,
+    make_entry_script,
+)
 
 
 def _sequence_to_short_name(sequence_id: str) -> str:
@@ -88,5 +91,5 @@ workflow:
 
 default-values:
   workflow_name: robotic_grounding_{exp_id}
-  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:latest
+  image: {DEFAULT_OSMO_IMAGE_LATEST}
 """

--- a/robotic_grounding/experiments/example_stage1_nocoll/workflow.py
+++ b/robotic_grounding/experiments/example_stage1_nocoll/workflow.py
@@ -17,6 +17,8 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 from experiments.utils import (  # noqa: E402
+    DEFAULT_OSMO_IMAGE_LATEST,
+    DEFAULT_WANDB_ENTITY,
     overrides_to_cli,
     sequence_to_object,
 )
@@ -92,7 +94,7 @@ artifact.add_file(checkpoint, name="model_final.pt")
 # separate upload runs. Fall back to a new run if the training run isn't found.
 api = wandb.Api()
 training_runs = api.runs(
-    f"nvidia-isaac/{{project}}",
+    f"{{os.environ['WANDB_ENTITY']}}/{{project}}",
     filters={{"display_name": {{"$regex": "{run_name}"}}}},
 )
 training_runs = sorted(training_runs, key=lambda r: r.created_at, reverse=True)
@@ -124,6 +126,7 @@ def generate_workflow(exp_id: str, config: dict) -> str:
     wandb_api_key = os.environ.get("WANDB_API_KEY", "")
     if not wandb_api_key:
         print("[WARNING] WANDB_API_KEY not set — wandb will fail in the container")
+    wandb_entity = config.get("wandb_entity", DEFAULT_WANDB_ENTITY)
 
     tasks_yaml = []
     for seq_id in sequence_ids:
@@ -161,6 +164,7 @@ python scripts/rsl_rl/train.py \\
       ACCEPT_EULA: Y
       OMNI_SERVER: omniverse://isaac-dev.ov.nvidia.com
       WANDB_API_KEY: {wandb_api_key}
+      WANDB_ENTITY: {wandb_entity}
     files:
     - path: /tmp/entry.sh
       contents: |-
@@ -185,5 +189,5 @@ workflow:
 
 default-values:
   workflow_name: robotic_grounding_{exp_id}
-  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:latest
+  image: {DEFAULT_OSMO_IMAGE_LATEST}
 """

--- a/robotic_grounding/experiments/launch_stage2.py
+++ b/robotic_grounding/experiments/launch_stage2.py
@@ -30,6 +30,13 @@ import yaml
 _ROBOTIC_GROUNDING_DIR = Path(__file__).resolve().parent.parent
 _EXPERIMENTS_DIR = _ROBOTIC_GROUNDING_DIR / "experiments"
 
+if str(_ROBOTIC_GROUNDING_DIR) not in sys.path:
+    sys.path.insert(0, str(_ROBOTIC_GROUNDING_DIR))
+from experiments.utils import (  # noqa: E402
+    DEFAULT_OSMO_IMAGE_LATEST,
+    DEFAULT_WANDB_ENTITY,
+)
+
 
 def _load_registry() -> dict[str, str]:
     registry: dict[str, str] = {}
@@ -66,6 +73,7 @@ def fetch_crashed_checkpoints(outdir: Path, config: dict) -> dict[str, Path]:
     """Download latest checkpoints from crashed stage2 W&B runs. Returns {seq_key: local_path}."""
     api = wandb.Api()
     project = config.get("wandb_project", "v2p_hands")
+    wandb_entity = config.get("wandb_entity", DEFAULT_WANDB_ENTITY)
     # crashed_run_name_suffix allows looking for checkpoints in a *different* run
     # (e.g. the original 10k run) while still submitting under run_name_suffix.
     search_suffix = config.get("crashed_run_name_suffix") or config.get(
@@ -78,7 +86,7 @@ def fetch_crashed_checkpoints(outdir: Path, config: dict) -> dict[str, Path]:
         seq_key = _sequence_to_seq_key(seq_id)
         run_name = f"{search_suffix}_{seq_key}"
         runs = api.runs(
-            f"nvidia-isaac/{project}",
+            f"{wandb_entity}/{project}",
             filters={"display_name": {"$regex": run_name}},
         )
         runs = sorted(runs, key=lambda r: r.created_at, reverse=True)
@@ -119,6 +127,11 @@ def fetch_checkpoints(outdir: Path, config: dict) -> dict[str, Path]:
     # the one stage2 training runs are logged to (e.g. stage1 uploads to v2p_hands but
     # stage2 trains in v2p_hands).
     artifact_project = config.get("stage1_wandb_project", "v2p_hands")
+    # stage1_wandb_entity mirrors stage1_wandb_project for cases where stage1 artifacts
+    # live in a different W&B workspace than stage2 runs. Fall back to the stage2 entity.
+    artifact_entity = config.get(
+        "stage1_wandb_entity", config.get("wandb_entity", DEFAULT_WANDB_ENTITY)
+    )
     artifact_prefix = config.get("stage1_artifact_prefix", "checkpoint_stage1_nocoll_")
     sequences = config["sequences"]
     checkpoints: dict[str, Path] = {}
@@ -134,7 +147,7 @@ def fetch_checkpoints(outdir: Path, config: dict) -> dict[str, Path]:
         ]
         artifact = None
         for artifact_name in candidates:
-            full_name = f"{artifact_project}/{artifact_name}:latest"
+            full_name = f"{artifact_entity}/{artifact_project}/{artifact_name}:latest"
             print(f"  Fetching {full_name} ...", end=" ", flush=True)
             try:
                 artifact = api.artifact(full_name)
@@ -193,6 +206,7 @@ python scripts/rsl_rl/train.py \\
   {overrides_str}"""
 
     entry_indent = "\n".join("        " + line for line in entry.split("\n"))
+    wandb_entity = config.get("wandb_entity", DEFAULT_WANDB_ENTITY)
     return f"""  - name: train-{seq_key.replace("_", "-")}
     image: {{{{image}}}}
     command: [/bin/bash]
@@ -201,6 +215,7 @@ python scripts/rsl_rl/train.py \\
       ACCEPT_EULA: Y
       OMNI_SERVER: omniverse://isaac-dev.ov.nvidia.com
       WANDB_API_KEY: {wandb_api_key}
+      WANDB_ENTITY: {wandb_entity}
     inputs:
     - dataset:
         name: ckpt_{obj}
@@ -250,7 +265,7 @@ workflow:
 
 default-values:
   workflow_name: robotic_grounding_{exp_id}
-  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:latest
+  image: {DEFAULT_OSMO_IMAGE_LATEST}
 """
 
 

--- a/robotic_grounding/experiments/monitor_two_stage.py
+++ b/robotic_grounding/experiments/monitor_two_stage.py
@@ -42,13 +42,18 @@ _RG_ROOT = Path(__file__).resolve().parent.parent
 _EXPERIMENTS_DIR = _RG_ROOT / "experiments"
 _WANDB_PROJECT = "v2p_hands"
 _DEFAULT_STATE_FILE = _RG_ROOT / "scripts" / "monitor_state.json"
-_DEFAULT_IMAGE = "nvcr.io/nvstaging/isaac-amr/robotic-grounding:v2d"
 _DEFAULT_POOL = "isaac-dev-l40s-04"
 
 if str(_RG_ROOT) not in sys.path:
     sys.path.insert(0, str(_RG_ROOT))
 
-from experiments.utils import overrides_to_cli  # noqa: E402
+from experiments.utils import (  # noqa: E402
+    DEFAULT_OSMO_PIPELINE_IMAGE as _DEFAULT_IMAGE,
+)
+from experiments.utils import (  # noqa: E402
+    DEFAULT_WANDB_ENTITY,
+    overrides_to_cli,
+)
 
 # ---------------------------------------------------------------------------
 # Utilities
@@ -155,7 +160,7 @@ artifact = wandb.Artifact(artifact_name, type="model")
 artifact.add_file(checkpoint, name="model_final.pt")
 api = wandb.Api()
 training_runs = api.runs(
-    f"nvidia-isaac/{{project}}",
+    f"{{os.environ['WANDB_ENTITY']}}/{{project}}",
     filters={{"display_name": {{"$regex": "{run_name}"}}}},
 )
 training_runs = sorted(training_runs, key=lambda r: r.created_at, reverse=True)
@@ -192,6 +197,7 @@ def _generate_stage1_resume_yaml(
     overrides_cli = " \\\n  ".join(overrides_to_cli(overrides))
     ckpt_filename = ckpt_path.name
     wandb_api_key = os.environ.get("WANDB_API_KEY", "")
+    wandb_entity = stage1_config.get("wandb_entity", DEFAULT_WANDB_ENTITY)
     upload_snippet = _checkpoint_upload_snippet(seq_key, run_name)
 
     entry = f"""set -ex
@@ -229,6 +235,7 @@ workflow:
       ACCEPT_EULA: Y
       OMNI_SERVER: omniverse://isaac-dev.ov.nvidia.com
       WANDB_API_KEY: {wandb_api_key}
+      WANDB_ENTITY: {wandb_entity}
     inputs:
     - dataset:
         name: ckpt_{seq_key}
@@ -257,6 +264,7 @@ def _generate_stage1_fresh_yaml(
     overrides = dict(stage1_config.get("train_overrides", {}))
     overrides_cli = " \\\n  ".join(overrides_to_cli(overrides))
     wandb_api_key = os.environ.get("WANDB_API_KEY", "")
+    wandb_entity = stage1_config.get("wandb_entity", DEFAULT_WANDB_ENTITY)
     upload_snippet = _checkpoint_upload_snippet(seq_key, run_name)
 
     entry = f"""set -ex
@@ -293,6 +301,7 @@ workflow:
       ACCEPT_EULA: Y
       OMNI_SERVER: omniverse://isaac-dev.ov.nvidia.com
       WANDB_API_KEY: {wandb_api_key}
+      WANDB_ENTITY: {wandb_entity}
     files:
     - path: /tmp/entry.sh
       contents: |-
@@ -304,7 +313,11 @@ default-values:
 """
 
 
-def _download_stage1_checkpoint(seq_key: str, outdir: Path) -> Path | None:
+def _download_stage1_checkpoint(
+    seq_key: str,
+    outdir: Path,
+    wandb_entity: str = DEFAULT_WANDB_ENTITY,
+) -> Path | None:
     """Download the stage1 checkpoint for seq_key from W&B artifacts.
 
     Returns the local path to the .pt file, or None if no artifact exists.
@@ -317,7 +330,7 @@ def _download_stage1_checkpoint(seq_key: str, outdir: Path) -> Path | None:
     candidates = [artifact_name, f"checkpoint_stage1_nocoll_{seq_key.split('_')[0]}"]
     api = wandb.Api()
     for name in candidates:
-        full_name = f"nvidia-isaac/{_WANDB_PROJECT}/{name}:latest"
+        full_name = f"{wandb_entity}/{_WANDB_PROJECT}/{name}:latest"
         print(f"  Fetching artifact {full_name} ...", end=" ", flush=True)
         try:
             artifact = api.artifact(full_name)
@@ -400,10 +413,13 @@ def relaunch_stage1_task(
     """
     seq_key = _sequence_to_seq_key(seq_id)
     steps = crashed_run.summary.get("_step", 0) or 0
+    wandb_entity = stage1_config.get("wandb_entity", DEFAULT_WANDB_ENTITY)
     _log(f"Relaunching stage1 {exp_id}/{seq_key} (crashed at step {steps})")
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        ckpt_path = _download_stage1_checkpoint(seq_key, Path(tmpdir))
+        ckpt_path = _download_stage1_checkpoint(
+            seq_key, Path(tmpdir), wandb_entity=wandb_entity
+        )
 
         if ckpt_path is not None:
             _log(f"  Found checkpoint {ckpt_path.name} — resuming from it")
@@ -583,6 +599,9 @@ def monitor_once(state: dict, dry_run: bool = False) -> dict:
         try:
             stage1_config = _load_config(stage1_exp_id)
             sequences = stage1_config["osmo_multi_task"]["sequence_ids"]
+            stage1_wandb_entity = stage1_config.get(
+                "wandb_entity", DEFAULT_WANDB_ENTITY
+            )
         except Exception as e:
             _log(f"  ERROR loading stage1 config for {exp_id}: {e}")
             continue
@@ -608,7 +627,7 @@ def monitor_once(state: dict, dry_run: bool = False) -> dict:
             try:
                 stage1_runs_all = list(
                     api.runs(
-                        f"nvidia-isaac/{_WANDB_PROJECT}",
+                        f"{stage1_wandb_entity}/{_WANDB_PROJECT}",
                         filters={
                             "display_name": {"$regex": f"{re.escape(exp_id)}_stage1_"}
                         },
@@ -724,13 +743,17 @@ def monitor_once(state: dict, dry_run: bool = False) -> dict:
             try:
                 stage2_config = _load_config(stage2_config_id)
                 stage2_suffix = stage2_config.get("run_name_suffix", f"{exp_id}_stage2")
+                stage2_wandb_entity = stage2_config.get(
+                    "wandb_entity", DEFAULT_WANDB_ENTITY
+                )
             except Exception:
                 stage2_suffix = f"{exp_id}_stage2"
+                stage2_wandb_entity = DEFAULT_WANDB_ENTITY
 
             try:
                 stage2_runs_all = list(
                     api.runs(
-                        f"nvidia-isaac/{_WANDB_PROJECT}",
+                        f"{stage2_wandb_entity}/{_WANDB_PROJECT}",
                         filters={
                             "display_name": {"$regex": f"{re.escape(stage2_suffix)}_"}
                         },

--- a/robotic_grounding/experiments/recon_body_apple_pick/config.yaml
+++ b/robotic_grounding/experiments/recon_body_apple_pick/config.yaml
@@ -6,13 +6,13 @@ id: recon_body_apple_pick
 description: "ReconBody apple pick-and-place with SONIC JOINT_RESIDUAL"
 run_name: recon_body_apple_pick
 task: SonicG1-ReconBody-v0
-motion_file: whole_body/mhr/sequence_id=apple_pick_optimized/robot_name=g1
+motion_file: whole_body/mhr/apple_pick_optimized/g1
 video: true
-num_envs: 1024
+num_envs: 4096
 max_iterations: 20000
 zero_actor: true
 logger: wandb
-log_project_name: v2p-whole-body
+log_project_name: v2d-whole-body-tpv
 
 train_overrides:
   env.commands.motion.reset_freeze_steps: 50
@@ -23,3 +23,7 @@ train_overrides:
 
 osmo:
   build_image: false
+  # Pin the pre-built image that contains the v2p_whole_body tasks so submits don't
+  # fall back to :latest (which predates this branch). Rebuild via --build-image when
+  # you change source code the image depends on.
+  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple

--- a/robotic_grounding/experiments/run_experiment.py
+++ b/robotic_grounding/experiments/run_experiment.py
@@ -39,6 +39,10 @@ WORKFLOW_DIR = REPO_ROOT / "workflow"
 if str(RG_ROOT) not in sys.path:
     sys.path.insert(0, str(RG_ROOT))
 from experiments.utils import (  # noqa: E402
+    DEFAULT_OSMO_IMAGE_LATEST,
+    DEFAULT_OSMO_IMAGE_REPO,
+    DEFAULT_OSMO_PIPELINE_IMAGE,
+    DEFAULT_WANDB_ENTITY,
     build_train_command,
     make_entry_script,
     overrides_to_cli,
@@ -213,6 +217,11 @@ def generate_single_task_workflow(
     video = config.get("video", True)
     motion_file = config.get("motion_file")
     num_envs = config.get("num_envs")
+    max_iterations = config.get("max_iterations")
+    task = config.get("task", "Sharpa-V2P-v0")
+    zero_actor = config.get("zero_actor", False)
+    logger = config.get("logger", "wandb")
+    log_project_name = config.get("log_project_name", "v2p_hands")
     entry = make_entry_script(
         run_name,
         overrides,
@@ -220,7 +229,12 @@ def generate_single_task_workflow(
         seed=seed,
         motion_file=motion_file,
         num_envs=num_envs,
+        max_iterations=max_iterations,
         video=video,
+        task=task,
+        logger=logger,
+        log_project_name=log_project_name,
+        zero_actor=zero_actor,
         use_timestamp=True,
     )
     # Escape for YAML literal block
@@ -238,6 +252,9 @@ def generate_single_task_workflow(
         print(
             "[WARNING] WANDB_API_KEY not set in local environment — wandb will fail in the container"
         )
+    # Default to the shared NVIDIA team entity so OSMO runs don't land in a submitter's
+    # personal workspace. Individual experiments can override via config `wandb_entity`.
+    wandb_entity = config.get("wandb_entity", DEFAULT_WANDB_ENTITY)
     return f"""# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # Generated from experiments/ for {exp_id}
@@ -261,6 +278,7 @@ workflow:
       ACCEPT_EULA: Y
       OMNI_SERVER: omniverse://isaac-dev.ov.nvidia.com
       WANDB_API_KEY: {wandb_api_key}
+      WANDB_ENTITY: {wandb_entity}
 {inputs_block}    files:
     - path: /tmp/entry.sh
       contents: |-
@@ -268,7 +286,7 @@ workflow:
 
 default-values:
   workflow_name: robotic_grounding_{exp_id}
-  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:latest
+  image: {DEFAULT_OSMO_IMAGE_LATEST}
 """
 
 
@@ -302,6 +320,11 @@ def _print_workflow(exp_id: str, config: dict) -> None:
     video = config.get("video", True)
     motion_file = config.get("motion_file")
     num_envs = config.get("num_envs")
+    max_iterations = config.get("max_iterations")
+    task = config.get("task", "Sharpa-V2P-v0")
+    zero_actor = config.get("zero_actor", False)
+    logger = config.get("logger", "wandb")
+    log_project_name = config.get("log_project_name", "v2p_hands")
     if "run_name_overrides" in osmo_cfg:
         overrides = {**overrides, **osmo_cfg["run_name_overrides"]}
     entry = make_entry_script(
@@ -311,7 +334,12 @@ def _print_workflow(exp_id: str, config: dict) -> None:
         seed=seed,
         motion_file=motion_file,
         num_envs=num_envs,
+        max_iterations=max_iterations,
         video=video,
+        task=task,
+        logger=logger,
+        log_project_name=log_project_name,
+        zero_actor=zero_actor,
         use_timestamp=True,
     )
     print("# OSMO entry script (train command) for", exp_id)
@@ -346,6 +374,15 @@ def run_osmo(
     """Generate workflow YAML and submit to OSMO via run_osmo.py."""
     if not dry_run:
         _check_osmo_login()
+
+    # When the user asks to build but doesn't pin an explicit image tag, derive one from
+    # exp_id so the tag produced by run_osmo.py matches the tag baked into the workflow
+    # YAML below. Without this, --build-image silently builds and pushes a new tag while
+    # the submitted workflow still references :latest, which causes OSMO to run a stale
+    # image and e.g. miss newly-registered gym task IDs (see SonicG1-ReconBody-v0).
+    if build_image and image is None:
+        image = f"{DEFAULT_OSMO_IMAGE_REPO}:{exp_id}"
+        print(f"[INFO] --build-image without --image: pinning to {image}")
 
     if "osmo_multi_task" in config:
         exp_dir = EXPERIMENTS_DIR / load_registry()[exp_id]
@@ -672,11 +709,7 @@ def run_pipeline(exp_id: str, config: dict, args: argparse.Namespace) -> None:
     # Build and push the image once before any submissions so both stages use
     # the same freshly built image and we don't redundantly rebuild mid-pipeline.
     if build_image and not dry_run:
-        build_target = (
-            stage1_image
-            or stage2_image
-            or "nvcr.io/nvstaging/isaac-amr/robotic-grounding:v2d"
-        )
+        build_target = stage1_image or stage2_image or DEFAULT_OSMO_PIPELINE_IMAGE
         image_version = build_target.split(":")[-1]
         print(f"\n[pipeline] Building and pushing Docker image: {build_target} ...")
         result = subprocess.run(
@@ -832,15 +865,17 @@ def main() -> None:
         )
     elif args.osmo:
         # Use --build-image from CLI, or osmo.build_image from config (e.g. exp9 needs it for contact_force)
-        build_image = args.build_image or config.get("osmo", {}).get(
-            "build_image", False
-        )
+        osmo_cfg = config.get("osmo", {})
+        build_image = args.build_image or osmo_cfg.get("build_image", False)
+        # Image precedence: CLI --image > config osmo.image > (auto-derived from exp_id
+        # when --build-image and nothing else is set, see run_osmo) > workflow YAML default.
+        image = args.image or osmo_cfg.get("image")
         run_osmo(
             args.exp_id,
             config,
             pool=args.pool,
             build_image=build_image,
-            image=args.image,
+            image=image,
             priority=args.priority,
             dry_run=args.dry_run,
         )

--- a/robotic_grounding/experiments/utils.py
+++ b/robotic_grounding/experiments/utils.py
@@ -10,6 +10,21 @@ from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
+# Default W&B team entity for all OSMO-submitted runs. Overridable per experiment via
+# `wandb_entity:` in config.yaml (see generators in run_experiment.py, launch_stage2.py,
+# monitor_two_stage.py, and example_stage1_nocoll/workflow.py).
+DEFAULT_WANDB_ENTITY = "nvidia-isaac"
+
+# Container registry repo for the robotic-grounding Docker image. Individual experiments
+# pin a specific tag via `osmo.image` in their config.yaml; this constant is used when
+# deriving tags (e.g. `<repo>:<exp_id>` when --build-image is passed without --image)
+# and as the default ":latest" fallback for generated OSMO workflow YAMLs.
+DEFAULT_OSMO_IMAGE_REPO = "nvcr.io/nvstaging/isaac-amr/robotic-grounding"
+DEFAULT_OSMO_IMAGE_LATEST = f"{DEFAULT_OSMO_IMAGE_REPO}:latest"
+# Pipeline fallback tag used when neither stage pins an image explicitly. Historical
+# default — kept stable so existing two-stage experiments keep working.
+DEFAULT_OSMO_PIPELINE_IMAGE = f"{DEFAULT_OSMO_IMAGE_REPO}:v2d"
+
 
 def sequence_to_object(sequence_id: str) -> str:
     """e.g. arctic_s01_capsulemachine_grab_01 -> capsulemachine."""
@@ -101,8 +116,10 @@ def make_entry_script(
     max_iterations: int | None = None,
     use_timestamp: bool = True,
     video: bool = True,
+    task: str = "Sharpa-V2P-v0",
     logger: str = "wandb",
     log_project_name: str = "v2p_hands",
+    zero_actor: bool = False,
 ) -> str:
     """Generate /tmp/entry.sh content for OSMO."""
     # Pass run_name (suffix only) to train; train.py adds its own timestamp to avoid duplication.
@@ -119,8 +136,10 @@ def make_entry_script(
         num_envs=num_envs,
         max_iterations=max_iterations,
         video=video,
+        task=task,
         logger=logger,
         log_project_name=log_project_name,
+        zero_actor=zero_actor,
     )
     cmd_str = " \\\n  ".join(cmd)
     lines.append(cmd_str)


### PR DESCRIPTION
- Centralize OSMO image repo and W&B entity defaults in experiments/utils.py.
- Forward task, zero_actor, max_iterations, logger, log_project_name through generate_single_task_workflow / _print_workflow so single-task OSMO submits no longer silently drop them and fall back to task defaults.
- Replace hardcoded "nvidia-isaac" refs with config-driven wandb_entity in launch_stage2.py, monitor_two_stage.py, and example_stage1_nocoll/workflow.py, and inject WANDB_ENTITY env var into all generated OSMO workflow YAMLs.
- Auto-pin image tag to <repo>:<exp_id> when --build-image is passed without --image, so the submitted YAML matches the freshly pushed image instead of running against stale :latest.
- Add --run-name CLI flag to override config.run_name without editing YAML.
- Update recon_body_apple_pick config: simpler motion_file path, num_envs 4096, v2d-whole-body-tpv project, pinned :recon_body_apple image.

Made-with: Cursor

Here is a osmo trial run: https://us-west-2-aws.osmo.nvidia.com/workflows/robotic_grounding_recon_body_apple-11