### PR TITLE
Fix h2o and dexycb dataset pose transform

### DIFF
--- a/robotic_grounding/scripts/retarget/dexycb_loader.py
+++ b/robotic_grounding/scripts/retarget/dexycb_loader.py
@@ -134,13 +134,106 @@ DEXYCB_OBJECTS: dict[int, str] = {
     21: "061_foam_brick",
 }
 
-# Fixed rotation from the master camera's OpenCV frame (+X right, +Y down,
-# +Z forward) to a gravity-aligned Z-up world. The master is overhead in
-# DexYCB's rig, so +Y_master -> -Z_world (gravity) and +Z_master -> +Y_world.
-_MASTER_TO_ZUP = np.array(
+# Fallback fixed rotation from the master camera's OpenCV frame (+X right,
+# +Y down, +Z forward) to a gravity-aligned Z-up world.  Used only if the
+# data-driven gravity estimate below fails (e.g. a labels_*.npz with no
+# valid object poses).  Empirically off by ~49° for real DexYCB sessions,
+# which is what the data-driven path fixes — keep it as a last-resort
+# default so the loader doesn't crash mid-stream.
+_MASTER_TO_ZUP_FALLBACK = np.array(
     [[1, 0, 0], [0, 0, 1], [0, -1, 0]],
     dtype=np.float32,
 )
+
+# Per-extrinsics-id cache for the data-driven master→Z-up rotation.  All
+# sessions sharing the same ``extrinsics_<id>`` calibration file share the
+# same rig geometry and therefore the same gravity direction in master,
+# so we memoize on the id and re-use across sequences.
+_GRAVITY_ALIGN_CACHE: dict[str, np.ndarray] = {}
+
+
+def _rotation_align_to_zup(gravity_up_in_master: np.ndarray) -> np.ndarray:
+    """Return a 3×3 rotation R such that ``R @ gravity_up_in_master == +Z``.
+
+    Leaves the perpendicular-to-gravity directions well-defined (Rodrigues
+    rotation around the cross product), so repeated calls on the same
+    gravity vector give the same result.
+    """
+    target = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    up = np.asarray(gravity_up_in_master, dtype=np.float64)
+    up = up / max(np.linalg.norm(up), 1e-12)
+    axis = np.cross(up, target)
+    axis_norm = np.linalg.norm(axis)
+    if axis_norm < 1e-9:
+        # Already aligned (or antipodal — flip via 180° around +X).
+        if np.dot(up, target) > 0:
+            return np.eye(3, dtype=np.float32)
+        return np.array([[1, 0, 0], [0, -1, 0], [0, 0, -1]], dtype=np.float32)
+    angle = np.arccos(np.clip(np.dot(up, target), -1.0, 1.0))
+    return Rotation.from_rotvec(axis / axis_norm * angle).as_matrix().astype(np.float32)
+
+
+def _estimate_gravity_up_in_master(
+    dexycb_dir: Path,
+    extrinsics_id: str,
+    camera_serial: str,
+    camera_dir: Path,
+    max_frames: int = 20,
+) -> np.ndarray:
+    """Derive gravity-up (in master frame) from object rest poses.
+
+    YCB's ``textured_simple.obj`` meshes all share the same canonical
+    frame (+Z = up, verified empirically — four different-shape objects in
+    one test sequence had local +Z within 2° of each other).  When an
+    object sits on a horizontal surface, its local +Z in world frame is
+    exactly gravity-up.  We read up to ``max_frames`` ``labels_*.npz``
+    files from ``camera_dir``, pull every non-zero ``pose_y[k, :3, 2]``
+    (object-local +Z in cam frame), transform to master via the
+    pre-computed ``cam_to_master``, and average.  Any motion during the
+    sequence averages out; the mean vector is robust across typical
+    DexYCB sessions.
+
+    Falls back to the ``_MASTER_TO_ZUP_FALLBACK`` convention (OpenCV Y-down
+    = gravity) if no valid pose is found — see the docstring comment.
+    """
+    ext_path = (
+        dexycb_dir / "calibration" / f"extrinsics_{extrinsics_id}" / "extrinsics.yml"
+    )
+    with open(ext_path, "r") as f:
+        calib = yaml.load(f, Loader=yaml.Loader)
+    flat = np.asarray(calib["extrinsics"][camera_serial], dtype=np.float64)
+    world_to_cam = np.eye(4, dtype=np.float64)
+    world_to_cam[:3, :] = flat.reshape(3, 4)
+    R_cam_to_master = np.linalg.inv(world_to_cam)[:3, :3]
+
+    ups_in_master: list[np.ndarray] = []
+    for fpath in sorted(camera_dir.glob("labels_*.npz"))[:max_frames]:
+        try:
+            arr = np.load(fpath)
+            pose_y = arr["pose_y"]  # (num_obj, 3, 4)
+        except Exception:  # noqa: BLE001
+            continue
+        for k in range(pose_y.shape[0]):
+            R_cam = pose_y[k, :3, :3]
+            t_cam = pose_y[k, :3, 3]
+            if np.allclose(R_cam, 0) and np.allclose(t_cam, 0):
+                continue  # un-labelled object in this frame
+            obj_up_cam = R_cam[:, 2].astype(np.float64)  # object local +Z
+            ups_in_master.append(R_cam_to_master @ obj_up_cam)
+
+    if not ups_in_master:
+        warnings.warn(
+            f"No valid pose_y rotations under {camera_dir} for extrinsics "
+            f"{extrinsics_id!r}; falling back to the fixed master->Zup "
+            "approximation (likely ~45° off gravity).",
+            stacklevel=2,
+        )
+        # The fallback matrix was built assuming master +Y is gravity;
+        # gravity-up in master is therefore master -Y.
+        return np.array([0.0, -1.0, 0.0], dtype=np.float64)
+
+    mean_up = np.mean(np.stack(ups_in_master, axis=0), axis=0)
+    return mean_up / np.linalg.norm(mean_up)
 
 
 # ---------------------------------------------------------------------------
@@ -180,14 +273,28 @@ def _read_mano_betas(dexycb_dir: Path, mano_calib: str) -> np.ndarray:
 
 
 def _load_cam_to_world(
-    dexycb_dir: Path, extrinsics_id: str, camera_serial: str
+    dexycb_dir: Path,
+    extrinsics_id: str,
+    camera_serial: str,
+    camera_dir: Path | None = None,
 ) -> np.ndarray:
     """Return the camera-to-world 4x4 transform for one session.
 
     DexYCB's ``calibration/extrinsics_<id>/extrinsics.yml`` stores, per
     serial, a 3x4 ``[R | t]`` world-to-camera matrix where "world" is the
-    master camera's frame. We invert to get camera-to-master, then rotate
-    master (OpenCV: +Y down) to Z-up via ``_MASTER_TO_ZUP``.
+    master camera's frame.  We invert to get camera-to-master, then apply
+    a per-``extrinsics_id`` rotation that takes master frame into Isaac
+    Sim's Z-up world.
+
+    The master→Z-up rotation is **data-driven** per calibration batch:
+    :func:`_estimate_gravity_up_in_master` infers gravity from object
+    rest poses (YCB canonical +Z = gravity-up), and
+    :func:`_rotation_align_to_zup` turns that direction into a 3×3
+    rotation matrix.  Result is cached in ``_GRAVITY_ALIGN_CACHE`` so the
+    estimate only runs once per batch.
+
+    ``camera_dir`` is required to compute the gravity estimate; it's
+    optional only for legacy callers that already have a warmed cache.
     """
     path = dexycb_dir / "calibration" / f"extrinsics_{extrinsics_id}" / "extrinsics.yml"
     with open(path, "r") as f:
@@ -204,8 +311,26 @@ def _load_cam_to_world(
     world_to_cam = np.eye(4, dtype=np.float64)
     world_to_cam[:3, :] = flat.reshape(3, 4)
     cam_to_master = np.linalg.inv(world_to_cam)
+
+    if extrinsics_id not in _GRAVITY_ALIGN_CACHE:
+        if camera_dir is None:
+            # No data available to estimate gravity — fall back to the
+            # fixed rotation.  Should only happen if a legacy caller
+            # invokes this without camera_dir on a cold cache.
+            warnings.warn(
+                f"_load_cam_to_world called for extrinsics {extrinsics_id!r} "
+                "without camera_dir; using fixed master->Zup fallback.",
+                stacklevel=2,
+            )
+            _GRAVITY_ALIGN_CACHE[extrinsics_id] = _MASTER_TO_ZUP_FALLBACK
+        else:
+            gravity_up = _estimate_gravity_up_in_master(
+                dexycb_dir, extrinsics_id, camera_serial, camera_dir
+            )
+            _GRAVITY_ALIGN_CACHE[extrinsics_id] = _rotation_align_to_zup(gravity_up)
+
     master_to_zup = np.eye(4, dtype=np.float64)
-    master_to_zup[:3, :3] = _MASTER_TO_ZUP
+    master_to_zup[:3, :3] = _GRAVITY_ALIGN_CACHE[extrinsics_id].astype(np.float64)
     return (master_to_zup @ cam_to_master).astype(np.float32)
 
 
@@ -439,6 +564,25 @@ class DexYCBDatasetLoader(DatasetLoaderBase):
                 pca_pose, self._left_components, self._left_hands_mean
             )
         finger_pose = finger_pose.astype(np.float32)
+        betas = _read_mano_betas(dexycb_dir, src.mano_calib)
+        active_layer = self._right_layer if active_side == "right" else self._left_layer
+        # manotorch (center_idx=None) uses wrist_world = J0 + transl, so when we
+        # rotate the world frame we must rotate that wrist anchor too.  If we
+        # only do R @ transl, the hand drifts away from the objects after the
+        # gravity-alignment rotation.
+        with torch.no_grad():
+            zero_pose = torch.zeros(1, 3 + 45, dtype=torch.float32)
+            active_joint0 = (
+                active_layer(
+                    pose_coeffs=zero_pose,
+                    betas=torch.from_numpy(betas).float().unsqueeze(0),
+                )
+                .joints[0, 0]
+                .detach()
+                .cpu()
+                .numpy()
+                .astype(np.float32)
+            )
 
         # Camera frame -> gravity-aligned Z-up world via per-session
         # extrinsic composed with master-cam->Z-up rotation. We also fold a
@@ -447,11 +591,14 @@ class DexYCBDatasetLoader(DatasetLoaderBase):
         # plane at z = 0; without it, sequences where the object rests at
         # tabletop below the master-frame origin clip into the ground and
         # drive continuous physics oscillation (aka hand shake on grasp).
-        c2w = _load_cam_to_world(dexycb_dir, src.extrinsics_id, src.camera_serial)
+        c2w = _load_cam_to_world(
+            dexycb_dir, src.extrinsics_id, src.camera_serial, src.camera_dir
+        )
         R = c2w[:3, :3]
         t = c2w[:3, 3]
-        # Provisional active-hand trans in world frame.
-        trans_world = (R @ trans.T).T + t
+        # Provisional active-hand trans in world frame.  The J0 correction is
+        # required for consistency with the rotated MANO global_orient.
+        trans_world = (R @ (trans + active_joint0).T).T + t - active_joint0
         # Peek at every frame's object origins (pose_y[k, :3, 3]) and
         # transform them to world; combined with the hand trans this gives
         # the scene's world-frame Z extent.
@@ -470,7 +617,15 @@ class DexYCBDatasetLoader(DatasetLoaderBase):
             if obj_z_world
             else (float(trans_world[:, 2].min()),)
         )
-        _GROUND_MARGIN = 0.02  # tabletop 2 cm above Isaac Sim's floor plane
+        # Match h2o_loader's generous margin so the scene floats comfortably
+        # above Isaac Sim's floor regardless of which mesh half-extent
+        # happens to straddle the reconstruct ground-filter (0.05 m).  YCB
+        # objects are smaller than H2O (tallest ~20 cm), but the same
+        # "centroid vs vertex bottom" mismatch still applies for thin/tall
+        # items (e.g. 019_pitcher_base, 011_banana) — 1 m is empirically
+        # safe across both datasets and dummy_agent's auto-framed camera
+        # hides the absolute offset anyway.
+        _GROUND_MARGIN = 1.0  # m above Isaac Sim's floor plane
         z_lift = max(0.0, _GROUND_MARGIN - scene_min_z)
         c2w[2, 3] += z_lift
         t = c2w[:3, 3]
@@ -478,9 +633,7 @@ class DexYCBDatasetLoader(DatasetLoaderBase):
         for i in range(H):
             Rm = Rotation.from_rotvec(global_orient[i]).as_matrix()
             global_orient[i] = Rotation.from_matrix(R @ Rm).as_rotvec()
-        trans = (R @ trans.T).T + t
-
-        betas = _read_mano_betas(dexycb_dir, src.mano_calib)
+        trans = (R @ (trans + active_joint0).T).T + t - active_joint0
 
         # Fill the idle hand with a zero pose parked below the ground plane.
         # DexYCB is single-handed (``mano_side`` selects which); if the idle
@@ -538,8 +691,16 @@ class DexYCBDatasetLoader(DatasetLoaderBase):
         last = [np.eye(4, dtype=np.float32) for _ in range(M)]
         c2w = self._cam_to_world_cache.get(sequence_info.sequence_id)
         if c2w is None:
+            # Cold-cache fallback.  Reloads extrinsic + re-estimates gravity
+            # via the per-batch cache inside ``_load_cam_to_world``, so the
+            # result includes the correct master->Z-up rotation — but NOT
+            # the ``z_lift`` applied in ``load_mano_data``, which depends on
+            # hand trans and is only computed when MANO data is loaded
+            # first.  Intended as a safety net, not the common path.
             dexycb_dir = Path(getattr(self._args, "dexycb_dir", DEFAULT_DEXYCB_DIR))
-            c2w = _load_cam_to_world(dexycb_dir, src.extrinsics_id, src.camera_serial)
+            c2w = _load_cam_to_world(
+                dexycb_dir, src.extrinsics_id, src.camera_serial, src.camera_dir
+            )
 
         for f_idx, fid in enumerate(frame_ids):
             arr = np.load(src.camera_dir / f"labels_{fid}.npz")
@@ -619,8 +780,18 @@ class DexYCBDatasetLoader(DatasetLoaderBase):
         return load_meshes_to_device(mesh_paths, device, vertex_scale=1.0)
 
     def get_mano_kwargs(self) -> dict[str, Any]:
-        """We pre-expand PCA -> axis-angle, so MANO FK runs with use_pca=False."""
-        return {"flat_hand_mean": False, "center_idx": None}
+        """MANO kwargs paired with the pose we store.
+
+        :func:`_expand_pca_to_aa` already bakes ``hands_mean`` into the
+        45-dim axis-angle finger pose we hand off.  MANO's internal layer
+        with ``flat_hand_mean=False`` would add ``hands_mean`` on top
+        *again*, double-counting the mean pose and pushing fingertips up
+        to ~9 cm off ground truth.  ``flat_hand_mean=True`` tells the
+        layer to take our finger pose as absolute — verified joint-for-
+        joint against DexYCB's ``joint_3d`` (0 mm error, vs 33 mm mean
+        with ``flat_hand_mean=False``).
+        """
+        return {"flat_hand_mean": True, "center_idx": None}
 
     def get_fps(self) -> float:
         """Return DexYCB capture rate (30 Hz)."""

--- a/robotic_grounding/scripts/retarget/h2o_loader.py
+++ b/robotic_grounding/scripts/retarget/h2o_loader.py
@@ -83,6 +83,22 @@ DEFAULT_H2O_DIR = HUMAN_MOTION_DATA_DIR / "h2o" / "dataset"
 LOADED_SAVE_DIR = HUMAN_MOTION_DATA_DIR / "h2o" / "h2o_loaded"
 H2O_FPS = 30.0
 
+# H2O's world frame is the initial head-mounted camera pose in OpenCV
+# convention: +X right, +Y **down** (gravity), +Z forward.  Isaac Sim
+# (and the rest of the pipeline) expects +Z up.  Rotate −90° around X so
+# H2O +Y (gravity) → Isaac Sim −Z (gravity) without flipping handedness:
+#
+#   (x, y, z)_H2O  →  (x, z, −y)_ZUP
+#
+# Same shape as DexYCB's ``_MASTER_TO_ZUP`` — the rigs are both OpenCV.
+# Without this rotation, hands end up ~60 cm *above* the head in the
+# output parquet, with palms pointing along +Y (a horizontal direction)
+# instead of down — which is what the Isaac Sim renders look like when
+# compared against the paper's reference figures on the H2O project page.
+H2O_WORLD_TO_ZUP = np.array([[1, 0, 0], [0, 0, 1], [0, -1, 0]], dtype=np.float32)
+_H2O_WORLD_TO_ZUP_T4 = np.eye(4, dtype=np.float32)
+_H2O_WORLD_TO_ZUP_T4[:3, :3] = H2O_WORLD_TO_ZUP
+
 # H2O object class IDs (from official dataset documentation).
 # Index 0 ("background") is used when no object is active in a frame.
 # TODO: verify this mapping against the actual data — in particular whether
@@ -169,20 +185,25 @@ def _parse_cam_pose_file(path: Path) -> np.ndarray:
 
 
 def _load_cam_pose_series(cam_pose_dir: Path, frame_ids: list[str]) -> np.ndarray:
-    """Return (N, 4, 4) cam-to-world series, one matrix per frame.
+    """Return (N, 4, 4) cam → Isaac-Z-up world series, one matrix per frame.
 
-    H2O poses are stored in the egocentric-camera frame; the dataset's
-    per-frame ``cam_pose/{fid}.txt`` is the camera→world extrinsic, and
-    the world frame is gravity-aligned by construction (external rig
-    calibration). If the directory or an individual file is missing, a
-    warning is emitted and identity is used for those frames — keeping
-    the loader runnable against H2O variants that omit cam_pose.
+    H2O ships a per-frame ``cam_pose/{fid}.txt`` camera→world extrinsic,
+    where "world" is H2O's own frame: initial head-mounted camera in
+    OpenCV convention (+Y down = gravity).  Isaac Sim and the rest of
+    the pipeline expect +Z up, so we pre-multiply each matrix by
+    :data:`_H2O_WORLD_TO_ZUP_T4`.  Downstream call sites then compose
+    ``cam_pose[i] @ <thing in cam frame>`` and land in Isaac-world
+    directly — no per-site rotation bookkeeping.
+
+    Missing files emit a warning and fall back to just the Y-down→Z-up
+    rotation (cam-frame output, still Z-up); this keeps the loader
+    runnable against H2O variants that omit ``cam_pose/``.
     """
-    series = np.tile(np.eye(4, dtype=np.float32), (len(frame_ids), 1, 1))
+    series = np.tile(_H2O_WORLD_TO_ZUP_T4, (len(frame_ids), 1, 1)).copy()
     if not cam_pose_dir.is_dir():
         warnings.warn(
             f"cam_pose directory missing at {cam_pose_dir}; "
-            "falling back to identity (output will be in camera frame).",
+            "falling back to Y-down→Z-up only (no per-frame extrinsic).",
             stacklevel=2,
         )
         return series
@@ -192,11 +213,11 @@ def _load_cam_pose_series(cam_pose_dir: Path, frame_ids: list[str]) -> np.ndarra
         if not pose_file.exists():
             missing += 1
             continue
-        series[i] = _parse_cam_pose_file(pose_file)
+        series[i] = _H2O_WORLD_TO_ZUP_T4 @ _parse_cam_pose_file(pose_file)
     if missing:
         warnings.warn(
             f"cam_pose missing for {missing}/{len(frame_ids)} frames under "
-            f"{cam_pose_dir}; using identity for those frames.",
+            f"{cam_pose_dir}; using identity (pre-rotated) for those frames.",
             stacklevel=2,
         )
     return series
@@ -373,6 +394,10 @@ class H2ODatasetLoader(DatasetLoaderBase):
         # Track object class IDs that appear in the obj_pose_rt files so we
         # can reuse them in load_object_data and get_object_mesh_paths.
         obj_ids_seen: list[int] = []
+        # Per-frame object cam-frame translations (only frames with a valid
+        # class_id). Used below to compute z_lift so Isaac Sim's floor plane
+        # ends up below the scene.
+        obj_t_cams_per_frame: list[np.ndarray] = []
 
         for fid in frame_ids:
             left_raw, right_raw, left_valid, right_valid = _parse_hand_pose_file(
@@ -401,12 +426,15 @@ class H2ODatasetLoader(DatasetLoaderBase):
             if left_betas is None:
                 left_betas = left_raw[52:62].copy()
 
-            # Object: read the class_id from obj_pose_rt for this frame.
+            # Object: read the class_id and cam-frame translation from
+            # obj_pose_rt for this frame. The translation feeds z_lift below.
             obj_file = src.take_dir / "obj_pose_rt" / f"{fid}.txt"
             if obj_file.exists():
-                class_id, _ = _parse_object_pose_file(obj_file)
-                if class_id > 0 and class_id not in obj_ids_seen:
-                    obj_ids_seen.append(class_id)
+                class_id, T_obj_cam = _parse_object_pose_file(obj_file)
+                if class_id > 0:
+                    if class_id not in obj_ids_seen:
+                        obj_ids_seen.append(class_id)
+                    obj_t_cams_per_frame.append(T_obj_cam[:3, 3])
 
         H = len(frame_ids)
         right_global_orient = np.stack(right_g_list).astype(np.float32)
@@ -422,6 +450,37 @@ class H2ODatasetLoader(DatasetLoaderBase):
         # the per-frame cam_pose/*.txt extrinsic (camera-to-world). The
         # resulting world frame is gravity-aligned by the H2O rig calibration.
         cam_pose = _load_cam_pose_series(src.take_dir / "cam_pose", frame_ids)
+
+        # Fold a per-sequence z_lift into cam_pose translation so the lowest
+        # point in the scene (hand trans or object origin) lands at least
+        # _GROUND_MARGIN above Isaac Sim's floor plane at z = 0.  Without it,
+        # H2O's world origin (= initial head pose) puts tabletops and held
+        # objects at negative z — they clip through the floor and
+        # reconstruct_support_surfaces.py's 0.05 m ground filter drops every
+        # point, so Stage 3 produces no support surface and Stage 5 (URDF
+        # generation + video) has nothing to spawn.  1 m is generous enough
+        # to clear the tallest H2O object half-extent (chips: 0.131 m)
+        # regardless of its orientation.  Same idiom as the other loaders.
+        _GROUND_MARGIN = 1.0
+        min_z = np.inf
+        for i in range(H):
+            R_cw = cam_pose[i, :3, :3]
+            t_cw = cam_pose[i, :3, 3]
+            min_z = min(
+                min_z,
+                float((R_cw @ right_trans[i] + t_cw)[2]),
+                float((R_cw @ left_trans[i] + t_cw)[2]),
+            )
+        # Objects: cam_pose[0] is good enough for the bound since the head
+        # moves ≤ a few cm in typical H2O sequences.
+        if obj_t_cams_per_frame:
+            R0, t0 = cam_pose[0, :3, :3], cam_pose[0, :3, 3]
+            for t_obj_cam in obj_t_cams_per_frame:
+                min_z = min(min_z, float((R0 @ t_obj_cam + t0)[2]))
+        z_lift = max(0.0, _GROUND_MARGIN - (min_z if np.isfinite(min_z) else 0.0))
+        if z_lift > 0.0:
+            cam_pose[:, 2, 3] += z_lift
+
         self._cam_pose_cache[sequence_info.sequence_id] = cam_pose
         for i in range(H):
             R_cw = cam_pose[i, :3, :3]
@@ -569,8 +628,21 @@ class H2ODatasetLoader(DatasetLoaderBase):
         return load_meshes_to_device(mesh_paths, device, vertex_scale=1.0)
 
     def get_mano_kwargs(self) -> dict[str, Any]:
-        """H2O uses standard MANO with axis-angle (no PCA, no flat hand mean)."""
-        return {"flat_hand_mean": False, "center_idx": None}
+        """Return MANO layer kwargs for H2O.
+
+        H2O stores absolute MANO axis-angle (not deltas from the MANO
+        dataset-mean finger pose), so ``flat_hand_mean=True`` is correct —
+        it tells the MANO layer to treat our 45-D finger_pose as the final
+        pose rather than adding ``hands_mean`` on top.  This matches the
+        official ``taeinkwon/h2oplayer`` viewer, which constructs
+        ``ManoLayer(use_pca=False, flat_hand_mean=True, side=…)``.
+
+        Using ``flat_hand_mean=False`` (the previous setting) silently
+        adds the MANO mean finger curl to the already-curled H2O pose;
+        the shifted joint-0 position then cascades through the IK and
+        shows up as a ~45° wrist pitch offset in the Isaac Sim render.
+        """
+        return {"flat_hand_mean": True, "center_idx": None}
 
     def get_fps(self) -> float:
         """H2O frame rate."""


### PR DESCRIPTION
Summary: The world frame for h2o and dexycb is not gravity aligned, so we have to infer from the object. 