### PR TITLE
[task lib] Update documentation and improve the dummy_agent on egocentric sequence

### DIFF
--- a/robotic_grounding/scripts/rsl_rl/dummy_agent.py
+++ b/robotic_grounding/scripts/rsl_rl/dummy_agent.py
@@ -191,9 +191,6 @@ def main():
             env_cfg.viewer.env_index, env_cfg.scene.num_envs - 1
         )
 
-    # Disable terminations so trajectory plays through
-    env_cfg.terminations = None
-
     # V2P dual-hands specific config (skip for whole-body envs)
     if hasattr(env_cfg, "commands") and hasattr(
         env_cfg.commands, "dual_hands_object_tracking_command"

--- a/robotic_grounding/workflow/README.md
+++ b/robotic_grounding/workflow/README.md
@@ -1,286 +1,91 @@
 # OSMO Workflows
 
-This directory contains workflow definitions for running training and development environments on OSMO. See
-[OSMO Wikipage](https://isaac-infrastructure.gitlab-master-pages.nvidia.com/osmo/release-6.0.x/user_guide/index.html) for more detail on OSMO.
+Workflow definitions for running training, retargeting, and development environments on OSMO. See the [OSMO user guide](https://isaac-infrastructure.gitlab-master-pages.nvidia.com/osmo/release-6.0.x/user_guide/index.html) for platform details.
+
+**See also:** [data_pipeline.md](data_pipeline.md) for the end-to-end data flow (raw → retargeted → trained), [data_storage.md](data_storage.md) for storage layout and output-download commands.
 
 ## Prerequisites
 
-### 1. Get access to isaac-amr NGC group and OSMO DLs.
+### 1. Access
 
-1. Submit a ticket in the `#swngc-help` Slack channel by sending a message. They will send you an email giving you access to `isaac-amr` NGC group.
-2. In [DLRequest](https://dlrequest/), request to join fto `access-osmo` and `access-osmo-isaac-dev`.
-   - **Note:** you will likely need to ping in the `#osmo-support` channel to get your request approved.
+- `isaac-amr` NGC group — open a ticket in `#swngc-help`.
+- OSMO DLs `access-osmo` and `access-osmo-isaac-dev` via [DLRequest](https://dlrequest/) (ping `#osmo-support` to get approved).
 
 ### 2. Configure NGC
-1. Download and install the [NGC CLI](https://docs.ngc.nvidia.com/cli/cmd.html).
-2. Login to NGC [here](https://ngc.nvidia.com/signin).
-3. Select `nvstaging` > `isaac-amr`
-4. Under your profile dropdown, go to **Setup** > **Create API Key**
-5. In terminal, configure NGC:
+
+1. Install the [NGC CLI](https://docs.ngc.nvidia.com/cli/cmd.html) and [sign in](https://ngc.nvidia.com/signin).
+2. Select `nvstaging` > `isaac-amr`, then **Setup** > **Create API Key**.
+3. Configure and verify:
    ```bash
-   ngc config set
-   # Use the API key generated above
-   ```
-6. Login to Docker registry:
-   ```bash
-   docker login nvcr.io
-   # Username: $oauthtoken
-   # Password: <your_api_key>
-   ```
-7. Verify access:
-   ```bash
-   ngc user who
-   # Check you have read and write access
+   ngc config set              # use the API key
+   docker login nvcr.io        # user: $oauthtoken, pass: <api_key>
+   ngc user who                # confirm read+write
    ```
 
 ### 3. Configure OSMO
 
-1. Install the [OSMO CLI](https://isaac-infrastructure.gitlab-master-pages.nvidia.com/osmo/release-6.0.x/user_guide/getting_started/install/index.html)
-2. Setup OSMO Credentials, follow the instructions [here](https://isaac-infrastructure.gitlab-master-pages.nvidia.com/osmo/release-6.0.x/user_guide/getting_started/credentials.html) to setup credentials
-   - **Important:** Make sure to complete the [NVIDIA CSS setup](https://isaac-infrastructure.gitlab-master-pages.nvidia.com/osmo/release-6.0.x/user_guide/appendix/css/index.html#data-credentials-css) for storage access (required for workflows that use storage).
+Install the [OSMO CLI](https://isaac-infrastructure.gitlab-master-pages.nvidia.com/osmo/release-6.0.x/user_guide/getting_started/install/index.html) and set up [credentials](https://isaac-infrastructure.gitlab-master-pages.nvidia.com/osmo/release-6.0.x/user_guide/getting_started/credentials.html), including the [CSS setup](https://isaac-infrastructure.gitlab-master-pages.nvidia.com/osmo/release-6.0.x/user_guide/appendix/css/index.html#data-credentials-css) for storage access.
 
-### 4. Omni Auth (Optional)
+Omni-auth credentials are generally not needed; if a workflow complains about them, remove the credentials block from the yaml or follow the [token guide](https://docs.omniverse.nvidia.com/nucleus/latest/config-and-info/api_tokens.html#token-generation).
 
-The current workflows may not require omni-auth credentials. If you are running into missing credentials errors, you can likely remove them from the workflow yaml.
+## Submitting a Job
 
-If needed, follow the OSMO documentation for omni-auth setup: https://docs.omniverse.nvidia.com/nucleus/latest/config-and-info/api_tokens.html#token-generation.
+`run_osmo.py` builds + pushes + submits in one command. Add `--image <tag>` to skip rebuilding with an existing image, or `--dry-run` to preview.
 
-## Submitting a Job to OSMO
-
-Use the `run_osmo.py` script to build, push, and submit workflows in one command.
-
-### Remote Development
-Launch a remote development environment on OSMO cluster:
+### Remote development
 
 ```bash
-# Build, push Docker image, and submit OSMO workflow
 python scripts/run_osmo.py --experiment-name <your-name> --workflow-yaml workflow/dev_env.yaml
-```
 
-Once the workflow is running:
-```bash
-# Port-forwarding
+# Once running:
 osmo workflow port-forward <workflow-name> dev-env --port 6000:22
-
-# SSH into the remote
 ssh root@localhost -p 6000
 ```
 
-You can now develop remotely inside the OSMO container with full GPU access.
-
-### Submit a Training Job
+### Training
 
 ```bash
-python scripts/run_osmo.py --experiment-name test --workflow-yaml workflow/train.yaml
+python scripts/run_osmo.py --experiment-name <name> --workflow-yaml workflow/train.yaml
 ```
 
-This will:
-1. Build a Docker image tagged `test`
-2. Push the image to NGC registry
-3. Submit the `train.yaml` workflow to OSMO
+### Retargeting
 
-### Using an Existing Image
-
-If you already have an image built and pushed:
-```bash
-python scripts/run_osmo.py --experiment-name test --workflow-yaml workflow/train.yaml \
-  --image nvcr.io/nvstaging/isaac-amr/robotic-grounding:test
-```
-
-### Dry Run
-
-Preview commands without executing:
-```bash
-python scripts/run_osmo.py --experiment-name test --workflow-yaml workflow/train.yaml --dry-run
-```
-
-## Task Library Data Storage (CSS / PDX)
-
-Datasets for robot grounding Task Library are stored on NVIDIA CSS (PDX). Workflows download
-inputs before the task starts and upload outputs after the task completes.
-
-Object meshes are baked into the Docker image under `assets/meshes/`.
-
-### Storage Location
-
-```
-swift://pdx.s8k.io/AUTH_team-isaac/datasets/v2d/
-  human_motion_data/
-    taco/
-      dataset/               # Raw TACO data (Object_Poses, Hand_Poses)
-      taco_loaded/            # taco_loader.py output (Parquet)
-      taco_processed/         # taco_to_sharpa.py output (Parquet, retargeted)
-      support_surfaces/       # reconstruct_support_surfaces.py output (USD)
-    arctic/
-      dataset/               # Raw ARCTIC data (.mano.npy, .object.npy)
-      arctic_loaded/          # arctic_loader.py output (Parquet)
-      arctic_processed/       # arctic_to_sharpa.py output (Parquet, retargeted)
-      support_surfaces/       # reconstruct_support_surfaces.py output (USD)
-    oakink2/
-      dataset/               # Raw OakInk2 data
-      oakink2_loaded/         # oakink2_loader.py output (Parquet)
-      oakink2_processed/      # oakink2_to_sharpa.py output (Parquet, retargeted)
-      support_surfaces/       # reconstruct_support_surfaces.py output (USD)
-    hot3d/
-      dataset/              # Raw Hot3D data
-      hot3d_loaded/           # hot3d_loader.py output (Parquet)
-      hot3d_processed/        # hot3d_to_sharpa.py output (Parquet, retargeted)
-      support_surfaces/       # reconstruct_support_surfaces.py output (USD)
-```
-
-### Browsing Available Sequences
-
-Use `list_css_sequences.py` to list sequences stored on CSS (PDX). First configure
-credentials, then run the script:
+See [data_pipeline.md](data_pipeline.md) for what each stage does. Stages (`load`, `process`, `reconstruct`, `visualize`, `video`) can run together or individually. Outputs from one run are published as a single new version of the `v2d_{dataset}_retarget_exp_200` OSMO dataset — see [data_storage.md](data_storage.md) to pull them locally.
 
 ```bash
-# Set CSS credentials
-source scripts/setup_css_env.sh
+# Full pipeline (works for any registered dataset: taco, arctic, oakink2, hot3d, h2o, grab, dexycb)
+python scripts/run_osmo.py --experiment-name retarget-<dataset> \
+  --image nvcr.io/nvstaging/isaac-amr/robotic-grounding:<your-tag> \
+  --workflow-yaml workflow/retarget.yaml \
+  --set dataset=<dataset>
 
-# List all datasets and stages
-python scripts/list_css_sequences.py
-
-# List a specific dataset
-python scripts/list_css_sequences.py --dataset taco
-
-# List a specific dataset and stage
-python scripts/list_css_sequences.py --dataset arctic --stage loaded
-
-# Filter sequences by regex pattern
-python scripts/list_css_sequences.py --dataset taco --pattern '.*screw.*'
+# Run only one stage
+python scripts/run_osmo.py --experiment-name retarget-<dataset>-<stage> \
+  --image nvcr.io/nvstaging/isaac-amr/robotic-grounding:<your-tag> \
+  --workflow-yaml workflow/retarget.yaml \
+  --set dataset=<dataset> --set stages=<stage>
 ```
 
-## Retargeting Sequences
+#### Filtering sequences
 
-The retargeting pipeline converts raw hand-object motion data into retargeted robot trajectories.
-It runs in three stages:
-
-1. **Load** — raw data (`.npy`, `.pkl`) to Parquet with MANO hand + object data
-2. **Process** — loaded Parquet through IK retargeting to produce robot joint trajectories
-3. **Reconstruct** — build support surface USD meshes from object still-poses in the loaded data
-
-All workflows use the `HUMAN_MOTION_DATA_DIR` env var to resolve input paths from the
-downloaded CSS data. Always pass `--image` to `run_osmo.py` to use an existing Docker image and skip rebuilding.
-Replace `<your-tag>` in the examples below with the tag of your most recent image build/push (e.g. :latest).
-
-### Full Pipeline (Load + Process + Reconstruct)
-
-Use `retarget.yaml` to run all three stages in a single workflow:
+Use `sequence_pattern` (regex), `sequence_id` (exact), or `max_sequences` to pick a subset. `sequence_pattern` is applied as both an OSMO-input download regex and a Python-level filter.
 
 ```bash
-# TACO
-python scripts/run_osmo.py --experiment-name retarget-taco \
-  --image nvcr.io/nvstaging/isaac-amr/robotic-grounding:<your-tag> \
-  --workflow-yaml workflow/retarget.yaml \
-  --set dataset=taco
-
-# ARCTIC
-python scripts/run_osmo.py --experiment-name retarget-arctic \
-  --image nvcr.io/nvstaging/isaac-amr/robotic-grounding:<your-tag> \
-  --workflow-yaml workflow/retarget.yaml \
-  --set dataset=arctic
-
-# OakInk2
-python scripts/run_osmo.py --experiment-name retarget-oakink2 \
-  --image nvcr.io/nvstaging/isaac-amr/robotic-grounding:<your-tag> \
-  --workflow-yaml workflow/retarget.yaml \
-  --set dataset=oakink2
-
-# HOT3D
-python scripts/run_osmo.py --experiment-name retarget-hot3d \
-  --image nvcr.io/nvstaging/isaac-amr/robotic-grounding:<your-tag> \
-  --workflow-yaml workflow/retarget.yaml \
-  --set dataset=hot3d
-```
-
-### Single Stage Only
-
-Use `--set stages=<stage>` to run just one stage (`load`, `process`, or `reconstruct`):
-
-```bash
-# Load only (raw data -> Parquet)
-python scripts/run_osmo.py --experiment-name retarget-taco-load \
-  --image nvcr.io/nvstaging/isaac-amr/robotic-grounding:<your-tag> \
-  --workflow-yaml workflow/retarget.yaml \
-  --set dataset=taco --set stages=load
-
-# Process only (IK retargeting)
-python scripts/run_osmo.py --experiment-name retarget-arctic-process \
-  --image nvcr.io/nvstaging/isaac-amr/robotic-grounding:<your-tag> \
-  --workflow-yaml workflow/retarget.yaml \
-  --set dataset=arctic --set stages=process
-
-# Reconstruct only (support surfaces)
-python scripts/run_osmo.py --experiment-name retarget-oakink2-reconstruct \
-  --image nvcr.io/nvstaging/isaac-amr/robotic-grounding:<your-tag> \
-  --workflow-yaml workflow/retarget.yaml \
-  --set dataset=oakink2 --set stages=reconstruct
-```
-
-### Filtering Sequences
-
-Filter which sequences to download and process using regex patterns, exact IDs, or a max count.
-The `sequence_pattern` is used both as an OSMO input `regex` (to limit downloads) and as
-a Python-level `--sequence_pattern` filter.
-
-```bash
-# Process only sequences matching a pattern
 python scripts/run_osmo.py --experiment-name retarget-taco-screw \
   --image nvcr.io/nvstaging/isaac-amr/robotic-grounding:<your-tag> \
   --workflow-yaml workflow/retarget.yaml \
   --set dataset=taco \
   --set 'sequence_pattern=.*(screw|skim_off|smear|stir).*'
 
-# Process a single sequence by exact ID
-python scripts/run_osmo.py --experiment-name retarget-taco-one \
-  --image nvcr.io/nvstaging/isaac-amr/robotic-grounding:<your-tag> \
-  --workflow-yaml workflow/retarget.yaml \
-  --set dataset=taco \
-  --set sequence_id=taco_screw__screwdriver__toy_20231102_063
-
-# Limit to first 10 sequences
-python scripts/run_osmo.py --experiment-name retarget-taco-small \
-  --image nvcr.io/nvstaging/isaac-amr/robotic-grounding:<your-tag> \
-  --workflow-yaml workflow/retarget.yaml \
-  --set dataset=taco \
-  --set max_sequences=10
-```
-
-### Pulling Processed Data Locally
-
-After workflows complete, use `sync_css_data.py` to download results to your local repo.
-First configure credentials, then run the script:
-
-```bash
-# Set CSS credentials
-source scripts/setup_css_env.sh
-
-# Pull all outputs (loaded, processed, support_surfaces) for a dataset
-python scripts/sync_css_data.py --dataset taco
-
-# Pull only processed data
-python scripts/sync_css_data.py --dataset taco --component processed
-
-# Pull all outputs for all datasets
-python scripts/sync_css_data.py --dataset all
-
-# Pull only loaded (pre-retarget) data
-python scripts/sync_css_data.py --dataset arctic --component loaded
-
-# Pull only reconstructed support surfaces
-python scripts/sync_css_data.py --dataset taco --component support_surfaces
-
-# Filter sequences by regex pattern
-python scripts/sync_css_data.py --dataset taco --component processed --pattern '.*screw.*'
-
-# Preview what would be downloaded without downloading
-python scripts/sync_css_data.py --dataset all --dry-run
+# Equivalent alternatives:
+#   --set sequence_id=taco_screw__screwdriver__toy_20231102_063
+#   --set max_sequences=10
 ```
 
 ## Managing Workflows
 
-### List Running Workflows
-
 ```bash
 osmo workflow list
+osmo workflow logs <workflow-name>
+osmo workflow cancel <workflow-name>
 ```

--- a/robotic_grounding/workflow/data_pipeline.md
+++ b/robotic_grounding/workflow/data_pipeline.md
@@ -6,25 +6,31 @@ robotic_grounding pipeline, from raw dataset files to a trained RL policy.
 ## Pipeline Overview
 
 ```
-Raw Data (pkl/jsonl/csv/npy/...)
+Raw Data on CSS (pkl/jsonl/csv/npy/...)
     |
     v  Stage 1: Load
 ManoSharpaData Parquet (MANO hands + object poses)
     |
-    |-- Stage 1.5: Generate URDFs         --> urdfs/{dataset}/*.urdf
+    |-- Stage 1.5: Generate URDFs         --> {dataset}_urdfs/*.urdf
     |
     v  Stage 2: Retarget (IK)
 ManoSharpaData Parquet (+ robot joint trajectories)
     |
-    |-- Stage 3:   Support surfaces        --> reconstructed_stage/*.usda
-    |-- Stage 3.5: Visualization (opt.)    --> {dataset}_html/recordings/{seq}.viser + .mp4
+    |-- Stage 3: Support surfaces         --> reconstructed_stage/*.usda
+    |-- Stage 4: Visualize (optional)     --> {dataset}_html/recordings/{seq}.viser (+ .mp4)
+    |-- Stage 5: Record video (optional)  --> {dataset}_videos/{seq}.mp4 (Isaac Sim)
     |
-    v  Stage 4: Sync from CSS (after OSMO)
-Local assets/human_motion_data/
+    v  (All stages' outputs published as one OSMO dataset version)
+v2d_{dataset}_retarget_exp_200:<version>
     |
-    v  Stage 5: RL Training (Isaac Sim)
+    v  Stage 6: osmo dataset download
+Local assets/human_motion_data/{dataset}/
+    |
+    v  Stage 7: RL Training (Isaac Sim)
 Trained policy checkpoint
 ```
+
+Stages 1–5 are the OSMO `retarget.yaml` workflow; any subset can run via `--set stages=<stage>`. All artifacts from one run are published as a single versioned OSMO dataset (see [data_storage.md](data_storage.md)).
 
 ## Stage 1: Load
 
@@ -74,9 +80,12 @@ converts raw object meshes (OBJ, GLB) into single-link rigid URDFs:
 3. Generate a URDF with visual + collision geometry and default inertia.
 
 The mesh scale comes from the dataset registry (`mesh_vertex_scale`). This
-stage is idempotent -- it skips objects that already have URDFs.
+stage is idempotent -- it skips objects that already have URDFs. Runs
+automatically inside the `process` stage on OSMO.
 
-**Output:** `assets/urdfs/{dataset}/{object_id}_rigid.urdf`
+**Output:** `assets/urdfs/{dataset}/{object_id}_rigid.urdf` locally; in the
+OSMO workflow these are copied to `{dataset}_urdfs/` in the published
+dataset version.
 
 **Command:**
 ```bash
@@ -132,13 +141,13 @@ python scripts/reconstruct_support_surfaces.py \
   --input_dir <loaded_dir> --dataset <name>
 ```
 
-## Stage 3.5: Visualization (optional, OSMO-side)
+## Stage 4: Visualize (optional)
 
 **Purpose:** Produce inspection artifacts alongside the retargeted data —
 both interactive (`.viser`) and offline video (`.mp4`). Drives quality
 reviews without downloading the full parquets locally.
 
-**Scripts:** `scripts/retarget/vis_retargeted.py`
+**Script:** `scripts/retarget/vis_retargeted.py`
 
 Running with `--save_html --save_mp4` writes, for every sequence:
 
@@ -148,32 +157,53 @@ Running with `--save_html --save_mp4` writes, for every sequence:
   the object trajectory. No browser or Isaac Sim required. Useful for
   quick QA at scale, embedding in reviews, or sanity-checking new datasets.
 
-The OSMO workflow produces both under `{dataset}_html/recordings/` (see
-`workflow/retarget.yaml` Stage 4). For local iteration see the
-`/add-dataset` skill.
+Pyrender MP4s are skipped for OakInk2 (120 FPS × long sequences OOMs the
+pod); Stage 5 already produces Isaac Sim MP4s for those.
 
-## Stage 4: Sync Results
+**Output:** `{dataset}_html/recordings/{seq}.viser` (+ `.mp4` where not
+skipped) in the OSMO dataset.
 
-**Purpose:** Pull processed data from cloud storage to the local machine.
+## Stage 5: Record Isaac Sim Video (optional)
 
-**Scripts:** `scripts/sync_css_data.py`, `scripts/list_css_sequences.py`
+**Purpose:** Record a playback MP4 of each retargeted sequence in Isaac Sim
+with the Sharpa robot physically grasping the object — the closest thing
+to a training-time render without actually training. Used for catching
+regressions that don't show up in the MANO-only pyrender output (e.g.
+collision-group misconfigurations, self-penetrations, physics blow-ups).
 
-When stages 1-3 run on OSMO (GPU cluster), the outputs are stored on CSS
-(S3-compatible cloud storage). This stage downloads them to the local
-`assets/human_motion_data/` directory for training.
+**Script:** `scripts/rsl_rl/dummy_agent.py` (driven by the workflow's
+`video` stage, not typically invoked directly)
 
-**Output:** Local copy of processed Parquets, URDFs, and support surfaces.
+For each processed sequence the workflow spawns a single-env Isaac Sim
+instance with `dummy_agent.py --record_video`, steps 300 frames of the
+motion, and saves the MP4. Runs sequentially on one GPU — parallel Isaac
+Sim startup contention (shader cache, EGL drivers, VRAM) made the sharded
+version strictly slower in practice.
 
-**Commands:**
+**Output:** `{dataset}_videos/{sequence_id}.mp4` in the OSMO dataset.
+
+## Stage 6: Sync Results Locally
+
+**Purpose:** Pull the published OSMO dataset to the local repo so training
+and local visualization scripts can read it.
+
+**Command:** `osmo dataset download` — full details, component-filter
+examples, and the legacy CSS-swift fallback are in
+[data_storage.md](data_storage.md#pulling-retarget-outputs-locally).
+
+Quick version:
+
 ```bash
-# Browse available data
-python scripts/list_css_sequences.py --dataset <name>
+# Pick a published version
+osmo dataset info v2d_<dataset>_retarget_exp_200 --order desc
 
-# Download processed data
-python scripts/sync_css_data.py --dataset <name> --component processed
+# Pull just the pieces training needs
+osmo dataset download v2d_<dataset>_retarget_exp_200:<version> \
+  source/robotic_grounding/robotic_grounding/assets/human_motion_data/<dataset>/ \
+  --regex '(<dataset>_processed|<dataset>_urdfs|reconstructed_stage)/.*'
 ```
 
-## Stage 5: RL Training
+## Stage 7: RL Training
 
 **Purpose:** Train a reinforcement learning policy to control the robot hand.
 
@@ -233,15 +263,19 @@ python scripts/rsl_rl/train.py \
 
 ## OSMO Workflow
 
-Stages 1 through 3 can be submitted as a single OSMO workflow that runs on
-the GPU cluster. See `workflow/retarget.yaml` for the workflow definition and
-the `/osmo-retarget` skill for usage instructions.
+Stages 1 through 5 are submitted as a single OSMO workflow (`workflow/retarget.yaml`) running on the GPU cluster. All artifacts from one run are snapshotted into a new version of the `v2d_{dataset}_retarget_exp_200` OSMO dataset. See [README.md](README.md) for submission options and [data_storage.md](data_storage.md) for the output layout; `/osmo-retarget` skill covers usage patterns.
 
 ```bash
 python scripts/run_osmo.py \
   --experiment-name retarget-<dataset> \
   --workflow-yaml workflow/retarget.yaml \
   --set dataset=<name>
+
+# Run a subset — e.g. skip the expensive video stage
+python scripts/run_osmo.py \
+  --experiment-name retarget-<dataset>-fast \
+  --workflow-yaml workflow/retarget.yaml \
+  --set dataset=<name> --set stages=process
 ```
 
 ## Dataset Inventory
@@ -251,15 +285,17 @@ Candidates considered for Robot Grounding Task Library. Source:
 
 ### In the pipeline
 
-| Dataset | Sequences | GT Fidelity | Hands | Status |
-|---------|-----------|-------------|-------|--------|
-| **TACO** | 2,317 | High (NOKOV MoCap) | Bimanual | Retargeted on CSS |
-| **Arctic** | 554 | Very High (Vicon MoCap) | Bimanual, articulated objects | Retargeted on CSS |
-| **OakInk2** | 627 | High (OptiTrack MoCap) | Bimanual | Retargeted on CSS |
-| **HOT3D** | 294 | Very High (OptiTrack MoCap) | Bimanual | Retargeted on CSS |
-| **H2O** | 137 | Medium-High (RGB-D opt.) | Bimanual | Retargeted on CSS (cam4 egocentric) |
-| **GRAB** | 1,335 | Very High (Vicon MoCap) | Bimanual + SMPL-X full body | Retargeted on CSS |
-| **DexYCB** | 1,000 | Medium-High (multi-view RGB-D) | Single (per-session) | Retargeted on CSS (cam `932122062010`) |
+Outputs live under `v2d_<name>_retarget_exp_200` OSMO datasets.
+
+| Dataset | Sequences | GT Fidelity | Hands | Notes |
+|---------|-----------|-------------|-------|-------|
+| **TACO** | 2,317 | High (NOKOV MoCap) | Bimanual | — |
+| **Arctic** | 554 | Very High (Vicon MoCap) | Bimanual, articulated objects | — |
+| **OakInk2** | 627 | High (OptiTrack MoCap) | Bimanual | Stage 4 MP4s skipped (long sequences OOM pyrender) |
+| **HOT3D** | 294 | Very High (OptiTrack MoCap) | Bimanual | — |
+| **H2O** | 137 | Medium-High (RGB-D opt.) | Bimanual | cam4 egocentric; known ~45° pitch (initial head tilt baked into PnP world frame) |
+| **GRAB** | 1,335 | Very High (Vicon MoCap) | Bimanual + SMPL-X full body | — |
+| **DexYCB** | 1,000 | Medium-High (multi-view RGB-D) | Single (per-session) | cam `932122062010`; master-frame gravity inferred per session |
 
 Current total: **~6,264 retargeted sequences** across 7 datasets and 150+ unique objects.
 
@@ -292,8 +328,8 @@ See the `/add-dataset` skill or run through these steps:
 2. Write a loader script at `scripts/retarget/<name>_loader.py`.
 3. Write a retarget script at `scripts/retarget/<name>_to_sharpa.py`.
 
-Everything else (workflow dispatch, CSS sync, URDF generation, training
-validation) is driven by the dataset registry automatically.
+Everything else (workflow dispatch, OSMO dataset publish, URDF generation,
+training validation) is driven by the dataset registry automatically.
 
 ## Validating Before Training
 
@@ -304,9 +340,9 @@ starts (saves the 45-second startup wait):
 python scripts/validate_training_assets.py --dataset <name>
 ```
 
-## Planned Refactor: Consolidate URDFs + Meshes on CSS
+## Planned Refactor: Consolidate URDFs + Meshes
 
-Today the pipeline is inconsistent about where per-dataset object assets live:
+Object assets still live in inconsistent places between datasets:
 
 | Dataset | Meshes location | URDFs location |
 |---------|-----------------|----------------|
@@ -314,21 +350,19 @@ Today the pipeline is inconsistent about where per-dataset object assets live:
 | arctic, taco, oakink2 | committed `assets/meshes/{name}/` | committed `assets/urdfs/{name}/` |
 | grab, dexycb | CSS only (mounted at run time) | regenerated per workflow run from CSS meshes |
 
-This bakes ~2.7 GB of meshes into every Docker image and drifts between
-committed and on-CSS artifacts.  Unify on a single pattern:
+This bakes ~2.7 GB of meshes into every Docker image. Progress so far:
 
-1. **Write URDFs to CSS in the workflow** — add a `{dataset}_urdfs` output
-   in `workflow/retarget.yaml` (or fold it into `{dataset}_processed`).
-   Update `scripts/generate_rigid_urdfs.py` to write under
-   `${OUTPUT}/{dataset}_urdfs/` instead of `assets/urdfs/`.
-2. **Sync on demand** — add `--component urdfs` to `scripts/sync_css_data.py`.
-   Training flow becomes `sync_css_data.py --dataset X --component urdfs`.
-3. **Prefer local → CSS fallback** at read time — update
-   `SceneConfig` path resolution to check `assets/urdfs/{name}/` first and
-   hit CSS if missing.
-4. **Phase out committed meshes** — once the CSS path is the source of
-   truth, stop committing `assets/meshes/{name}/` for hot3d/h2o/arctic/
-   taco/oakink2 and trim ~2.7 GB from the image.
-
-OSMO dataset versioning (already enabled via the `dataset:` output in
-`retarget.yaml`) will then cover URDF regeneration out of the box.
+- [x] **URDFs published with retarget outputs** — the `process` stage
+  generates URDFs into `assets/urdfs/{dataset}/` and the workflow copies
+  them to `{dataset}_urdfs/` inside the OSMO dataset version, so every
+  versioned run carries a regenerated URDF tree.
+- [ ] **Local sync for URDFs** — `scripts/sync_css_data.py` still only
+  knows about `loaded`/`processed`/`support_surfaces`; `osmo dataset
+  download --regex '{dataset}_urdfs/.*'` is the current workaround. Adding
+  `--component urdfs` to `sync_css_data.py` would close the gap for anyone
+  still pulling from CSS.
+- [ ] **Read-time fallback** — update `SceneConfig` path resolution to
+  check `assets/urdfs/{name}/` first, then the per-dataset download dir.
+- [ ] **Phase out committed meshes** — once the runtime URDF/mesh path is
+  the source of truth, stop committing `assets/meshes/{name}/` for
+  hot3d/h2o/arctic/taco/oakink2 and trim the image size.

--- a/robotic_grounding/workflow/data_storage.md
+++ b/robotic_grounding/workflow/data_storage.md
@@ -1,0 +1,109 @@
+# Task Library Data Storage
+
+Input data and retarget outputs live in two different places:
+
+| | Where | How it's accessed |
+|---|---|---|
+| **Raw inputs** (`dataset/`) | NVIDIA CSS (PDX) swift bucket | Auto-downloaded by the workflow; browsable from the host via `list_css_sequences.py` |
+| **Retarget outputs** (`*_loaded/`, `*_processed/`, `reconstructed_stage/`, `*_urdfs/`, `*_videos/`, `*_html/`) | **OSMO dataset** `v2d_{dataset}_retarget_exp_200` | One new version per workflow run; pull with `osmo dataset download` |
+
+Object meshes are baked into the Docker image under `assets/meshes/` — they're committed to the repo via git-lfs and available at build time.
+
+## Why OSMO datasets for outputs
+
+Outputs used to be uploaded back to CSS at sibling prefixes (`{dataset}_loaded/`, `{dataset}_processed/`, etc.). Switching to an OSMO dataset gives us:
+
+- **Versioning** — every workflow run bumps the dataset version, so regressions are rollback-able by version rather than overwriting production data.
+- **Atomic publishes** — the whole run snapshot uploads as one manifest; partial uploads don't leave the CSS prefix in a half-written state.
+- **Experiment isolation** — the `_exp_200` suffix (see `retarget.yaml:97`) keeps experimental small-sample runs out of the production `v2d_{dataset}_retarget` history. Flip the suffix back for full-dataset production runs.
+
+The Swift output uploads in `retarget.yaml` are intentionally commented out while the `_exp_200` experiment is active (`retarget.yaml:73–90`). Re-enable them for production runs if you also want the swift mirror.
+
+## Raw-input storage layout (CSS)
+
+```
+swift://pdx.s8k.io/AUTH_team-isaac/datasets/v2d/
+  human_motion_data/
+    {dataset}/
+      dataset/              # Raw data (downloaded into each workflow run)
+```
+
+Supported datasets include `taco`, `arctic`, `oakink2`, `hot3d`, `h2o`, `dexycb`, `grab`.
+
+## Retarget-output storage layout (OSMO dataset)
+
+Each workflow run writes a single OSMO dataset version containing:
+
+```
+v2d_{dataset}_retarget_exp_200:<version>
+  {dataset}_loaded/          # Stage 1 output (Parquet: MANO + object poses)
+  {dataset}_urdfs/           # Stage 1.5 output (per-object rigid URDFs)
+  {dataset}_processed/       # Stage 2 output (Parquet: IK-retargeted robot trajectories)
+  reconstructed_stage/       # Stage 3 output (support surface USDs; may be absent for datasets where every object is held)
+  {dataset}_html/            # Stage 4 output (Viser recordings + pyrender MP4s)
+  {dataset}_videos/          # Stage 5 output (Isaac Sim MP4s via dummy_agent)
+```
+
+## Browsing available raw sequences on CSS
+
+`list_css_sequences.py` lists what's on the CSS input prefix — useful for picking a sequence to target with `sequence_id` or `sequence_pattern`:
+
+```bash
+# Set CSS credentials
+source scripts/setup_css_env.sh
+
+# List all datasets
+python scripts/list_css_sequences.py
+
+# List a specific dataset
+python scripts/list_css_sequences.py --dataset taco
+
+# Filter by regex
+python scripts/list_css_sequences.py --dataset taco --pattern '.*screw.*'
+```
+
+## Browsing OSMO dataset versions (outputs)
+
+```bash
+# List all versions of a retarget output dataset (most recent first)
+osmo dataset info v2d_taco_retarget_exp_200 --order desc
+
+# Inspect the file tree of a specific version
+osmo dataset inspect v2d_taco_retarget_exp_200:<version>
+```
+
+## Pulling retarget outputs locally
+
+After a workflow completes, pull its OSMO dataset version to the local repo so training / visualization scripts can find it under `source/robotic_grounding/robotic_grounding/assets/human_motion_data/{dataset}/`.
+
+```bash
+# Pick the version you want from:
+osmo dataset info v2d_taco_retarget_exp_200 --order desc
+
+# Download it (regex limits bandwidth to the components you need)
+osmo dataset download v2d_taco_retarget_exp_200:<version> \
+  source/robotic_grounding/robotic_grounding/assets/human_motion_data/taco/
+
+# Just the processed Parquets (skip videos/html/etc. to save bandwidth)
+osmo dataset download v2d_taco_retarget_exp_200:<version> \
+  source/robotic_grounding/robotic_grounding/assets/human_motion_data/taco/ \
+  --regex 'taco_processed/.*'
+
+# Processed + URDFs + support surfaces (everything training needs)
+osmo dataset download v2d_taco_retarget_exp_200:<version> \
+  source/robotic_grounding/robotic_grounding/assets/human_motion_data/taco/ \
+  --regex '(taco_processed|taco_urdfs|reconstructed_stage)/.*'
+```
+
+The downloaded layout matches what the training scripts expect — the `motion_file` arg to `scripts/rsl_rl/train.py` resolves as `{dataset}/{dataset}_processed/{sequence_id}/sharpa_wave` relative to `HUMAN_MOTION_DATA_DIR`.
+
+### Legacy CSS outputs (pre-OSMO-dataset migration)
+
+`sync_css_data.py` still works for pulling older outputs from the CSS swift prefix if you're looking at a run that pre-dates the OSMO-dataset switch (or a production run where the swift uploads were re-enabled in `retarget.yaml`):
+
+```bash
+source scripts/setup_css_env.sh
+python scripts/sync_css_data.py --dataset taco --component processed
+```
+
+For current experiment runs the CSS output prefix will be stale — prefer `osmo dataset download` above.

--- a/robotic_grounding/workflow/retarget.yaml
+++ b/robotic_grounding/workflow/retarget.yaml
@@ -71,30 +71,13 @@ workflow:
     - url: {{input_url}}
       regex: dataset/.*
     outputs:
-    # # Swift uploads keep list_css_sequences.py, sync_css_data.py, and
-    # # training's HUMAN_MOTION_DATA_DIR path resolution working unchanged.
-    # # Leave these off during experiments; re-enable for production runs.
-    # - url: {{output_url}}
-    #   regex: {{dataset}}_loaded/.*
-    # - url: {{output_url}}
-    #   regex: {{dataset}}_processed/.*
-    # - url: {{output_url}}
-    #   regex: {{dataset}}_urdfs/.*
-    # - url: {{output_url}}
-    #   regex: reconstructed_stage/.*
-    # - url: {{output_url}}
-    #   regex: {{dataset}}_html/.*
-    # - url: {{output_url}}
-    #   regex: {{dataset}}_videos/.*
-    # - url: {{output_url}}
-    #   regex: {{dataset}}_metrics.*
     # Snapshot the whole {{output}} folder as a versioned OSMO dataset so
     # every run is rollback-able by version.  Using an `_exp_200` suffix
     # during small-sample experiments keeps the production
     # `v2d_{{dataset}}_retarget` history clean — flip back when running the
     # full dataset.
     - dataset:
-        name: v2d_{{dataset}}_retarget_exp_200
+        name: retargeted_{{dataset}}_exp_50
     files:
     - path: /tmp/entry.sh
       contents: |-
@@ -256,50 +239,75 @@ workflow:
         fi
 
         # Stage 5: Isaac Lab MP4s via dummy_agent (robot + object).
-        # Intentionally run sequentially on one GPU — the earlier 8-shard
-        # fan-out triggered heavy Isaac Sim startup contention (shader cache,
-        # EGL drivers, VRAM), making the stage much slower than sequential.
+        # Experiment: shard across all GPUs to parallelize sequence rendering.
+        # A prior attempt went slower than sequential due to Isaac Sim startup
+        # contention (shader cache, EGL drivers, VRAM); revisit with current
+        # image + drivers and re-measure.  Fall back to sequential by setting
+        # SHARDS=1 at the workflow level.
         if [ "${STAGES}" = "all" ] || [ "${STAGES}" = "video" ]; then
-          echo "=== Stage 5: Recording scene videos for {{dataset}} (sequential) ==="
+          echo "=== Stage 5: Recording scene videos for {{dataset}} (${SHARDS} shards) ==="
           VIDEO_DIR=${OUTPUT}/{{dataset}}_videos
           mkdir -p ${VIDEO_DIR}
-          export CUDA_VISIBLE_DEVICES=0
-          for SEQ_DIR in ${PROCESSED_DIR}/sequence_id=*/robot_name=*; do
-            [ -d "${SEQ_DIR}" ] || continue
-            # URL-decode the partition-directory name so oakink2's
-            # `++`-encoded IDs (sequence_id=scene_01__A007%2B%2Bseq__…)
-            # don't end up in file paths as literal `%2B`.  `%2` in any
-            # path breaks gymnasium's RecordVideo wrapper, which does
-            # `msg % args` over its own log lines and treats `%2` as a
-            # format placeholder.
-            #
-            # We *don't* call out to `python -c` for this — in this image
-            # `python` is a wrapper around `isaaclab.sh -p` that prints
-            # `[INFO] Using python from: …` plus tset escape sequences on
-            # stdout before the real interpreter runs, so $(python -c …)
-            # captures that banner and poisons SEQ_ID.  Pure-bash
-            # parameter expansion + `printf '%b'` does the decode without
-            # a subprocess.
-            RAW_ID=$(basename $(dirname "${SEQ_DIR}") | sed 's|sequence_id=||')
-            # shellcheck disable=SC2059  # intentional: %b interprets \xHH
-            SEQ_ID=$(printf '%b' "${RAW_ID//%/\\x}")
-            # Idempotent: skip sequences already rendered (partial resume).
-            [ -f "${VIDEO_DIR}/${SEQ_ID}.mp4" ] && continue
-            TMP_VID=/tmp/scene_video_${SEQ_ID}
-            rm -rf ${TMP_VID}
-            # Wrap in `timeout --signal=KILL` — when Isaac Sim hits a CUDA
-            # assertion its Omniverse shutdown can deadlock, so `|| true`
-            # alone would leave the bash loop waiting forever.  5 min is
-            # plenty of headroom for ~1 min expected per-sequence work.
-            timeout --signal=KILL 300 python scripts/rsl_rl/dummy_agent.py \
-              --motion_file ${SEQ_DIR} \
-              --num_envs 1 --headless \
-              --record_video --output_dir ${TMP_VID} --video_length 300 || true
-            if [ -f "${TMP_VID}/rl-video-step-0.mp4" ]; then
-              mv ${TMP_VID}/rl-video-step-0.mp4 ${VIDEO_DIR}/${SEQ_ID}.mp4
-            fi
-            rm -rf ${TMP_VID}
+
+          # Enumerate sequences once, then distribute across shards by index
+          # mod SHARDS so the work is roughly balanced.  The per-sequence body
+          # is the same as the old sequential path — only the surrounding
+          # shard fan-out is new.
+          SEQ_DIRS=(${PROCESSED_DIR}/sequence_id=*/robot_name=*)
+
+          PIDS=()
+          for shard in $(seq 0 $((SHARDS-1))); do
+            (
+              export CUDA_VISIBLE_DEVICES=$shard
+              for idx in "${!SEQ_DIRS[@]}"; do
+                if [ $((idx % SHARDS)) -ne $shard ]; then
+                  continue
+                fi
+                SEQ_DIR="${SEQ_DIRS[$idx]}"
+                [ -d "${SEQ_DIR}" ] || continue
+                # URL-decode the partition-directory name so oakink2's
+                # `++`-encoded IDs (sequence_id=scene_01__A007%2B%2Bseq__…)
+                # don't end up in file paths as literal `%2B`.  `%2` in any
+                # path breaks gymnasium's RecordVideo wrapper, which does
+                # `msg % args` over its own log lines and treats `%2` as a
+                # format placeholder.
+                #
+                # We *don't* call out to `python -c` for this — in this image
+                # `python` is a wrapper around `isaaclab.sh -p` that prints
+                # `[INFO] Using python from: …` plus tset escape sequences on
+                # stdout before the real interpreter runs, so $(python -c …)
+                # captures that banner and poisons SEQ_ID.  Pure-bash
+                # parameter expansion + `printf '%b'` does the decode without
+                # a subprocess.
+                RAW_ID=$(basename $(dirname "${SEQ_DIR}") | sed 's|sequence_id=||')
+                # shellcheck disable=SC2059  # intentional: %b interprets \xHH
+                SEQ_ID=$(printf '%b' "${RAW_ID//%/\\x}")
+                # Idempotent: skip sequences already rendered (partial resume).
+                [ -f "${VIDEO_DIR}/${SEQ_ID}.mp4" ] && continue
+                # Shard-scoped TMP dir avoids collisions when two shards pick
+                # up the same SEQ_ID by accident (shouldn't happen with modulo
+                # distribution, but cheap insurance if the array ever grows
+                # duplicates).
+                TMP_VID=/tmp/scene_video_shard${shard}_${SEQ_ID}
+                rm -rf ${TMP_VID}
+                # Wrap in `timeout --signal=KILL` — when Isaac Sim hits a CUDA
+                # assertion its Omniverse shutdown can deadlock, so `|| true`
+                # alone would leave the bash loop waiting forever.  5 min is
+                # plenty of headroom for ~1 min expected per-sequence work.
+                timeout --signal=KILL 300 python scripts/rsl_rl/dummy_agent.py \
+                  --task Sharpa-V2P-v0-Play \
+                  --motion_file ${SEQ_DIR} \
+                  --num_envs 1 --headless \
+                  --record_video --output_dir ${TMP_VID} --video_length 300 || true
+                if [ -f "${TMP_VID}/rl-video-step-0.mp4" ]; then
+                  mv ${TMP_VID}/rl-video-step-0.mp4 ${VIDEO_DIR}/${SEQ_ID}.mp4
+                fi
+                rm -rf ${TMP_VID}
+              done
+            ) &
+            PIDS+=($!)
           done
+          wait_shards "${PIDS[@]}"
         fi
 
         echo "=== Done ==="


### PR DESCRIPTION
- Update the documentations on task library to reflect the current usage of osmo dataet
- Re-enable the termination on dummy_agent to fix the egocentric motion sequence, which would crash if it runs out of the sequence. 
- Parallelize the dummy_agent execution 