### PR TITLE
Add visualizer gallery server with OSMO sync script

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,10 +2,11 @@
 # CSS_SECRET_KEY, CSS_REGION. Does NOT set HTTPS_PROXY/HTTP_PROXY — those
 # break botocore and osmo. Use proxychains4 for routing instead.
 source_up_if_exists
-source "$(pwd)/robotic_grounding/scripts/setup_css_env.sh"
 
 # Local overrides (gitignored) — put per-machine or secret values here.
 # e.g. export CSS_SECRET_KEY="your-real-key"
 if [ -f "$(pwd)/.envrc.local" ]; then
   source "$(pwd)/.envrc.local"
 fi
+
+source "$(pwd)/robotic_grounding/scripts/setup_css_env.sh"

--- a/README.md
+++ b/README.md
@@ -24,49 +24,6 @@ Monorepo for **Video to Data (V2D)** — an end-to-end pipeline that converts hu
 | [`reconstruction/`](reconstruction/) | Video → depth, masks, meshes, 6D poses, human body. 18 containerized modules + multi-view pipelines. | Docker (per-module images) |
 | [`robotic_grounding/`](robotic_grounding/) | RL training on NVIDIA Isaac Lab 2.3.1 with RSL-RL (PPO); motion retargeting utilities. | Docker (`nvcr.io/nvstaging/isaac-amr`) |
 
-## Environment & Credentials
-
-Retrieve your CSS/PDX keys from `~/.config/osmo/config.yaml` under `swift://pdx.s8k.io/AUTH_team-isaac`.
-
-**Option A — Edit the credentials file directly (simple)**
-
-Fill in your keys in `robotic_grounding/scripts/setup_css_env.sh`:
-
-```bash
-export CSS_ACCESS_KEY="<your-access-key-id>"
-export CSS_SECRET_KEY="<your-secret-key>"
-```
-
-Then source it manually when needed:
-```bash
-source robotic_grounding/scripts/setup_css_env.sh
-```
-
-**Option B — direnv (automatic, recommended)**
-
-[direnv](https://direnv.net/) auto-loads credentials whenever you `cd` into the repo.
-
-Install:
-```bash
-sudo apt-get install direnv        # Ubuntu/Debian
-# then add to ~/.bashrc:
-eval "$(direnv hook bash)"
-```
-
-Create a **gitignored** `.envrc.local` in the repo root:
-```bash
-# .envrc.local
-export CSS_ACCESS_KEY="<your-access-key-id>"
-export CSS_SECRET_KEY="<your-secret-key>"
-```
-
-Allow direnv to load it (one-time, per clone):
-```bash
-direnv allow
-```
-
-Credentials are then injected automatically on every `cd` into the repo.
-
 ## Prerequisites
 
 - Docker with GPU support ([install](https://docs.docker.com/engine/install/ubuntu/))
@@ -128,14 +85,9 @@ See [robotic_grounding/README.md](robotic_grounding/README.md) for retargeting, 
 
 ### Visualizer (retargeting gallery)
 
-Browse retargeted sequences as 3D animations in a browser:
+Browse retargeted sequences as 3D animations at **http://10.111.83.14:8080/**
 
-```bash
-python robotic_grounding/visualizer/sync_visualizer_data.py   # download datasets
-python robotic_grounding/visualizer/serve.py                   # http://<server-ip>:8080
-```
-
-See [robotic_grounding/visualizer/README.md](robotic_grounding/visualizer/README.md) for setup, data layout, and how to generate `.viser` files from processed Parquets.
+See [robotic_grounding/README.md#visualizer](robotic_grounding/README.md#visualizer) for setup instructions.
 
 ## Design Philosophy
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,49 @@ Monorepo for **Video to Data (V2D)** — an end-to-end pipeline that converts hu
 | [`reconstruction/`](reconstruction/) | Video → depth, masks, meshes, 6D poses, human body. 18 containerized modules + multi-view pipelines. | Docker (per-module images) |
 | [`robotic_grounding/`](robotic_grounding/) | RL training on NVIDIA Isaac Lab 2.3.1 with RSL-RL (PPO); motion retargeting utilities. | Docker (`nvcr.io/nvstaging/isaac-amr`) |
 
+## Environment & Credentials
+
+Retrieve your CSS/PDX keys from `~/.config/osmo/config.yaml` under `swift://pdx.s8k.io/AUTH_team-isaac`.
+
+**Option A — Edit the credentials file directly (simple)**
+
+Fill in your keys in `robotic_grounding/scripts/setup_css_env.sh`:
+
+```bash
+export CSS_ACCESS_KEY="<your-access-key-id>"
+export CSS_SECRET_KEY="<your-secret-key>"
+```
+
+Then source it manually when needed:
+```bash
+source robotic_grounding/scripts/setup_css_env.sh
+```
+
+**Option B — direnv (automatic, recommended)**
+
+[direnv](https://direnv.net/) auto-loads credentials whenever you `cd` into the repo.
+
+Install:
+```bash
+sudo apt-get install direnv        # Ubuntu/Debian
+# then add to ~/.bashrc:
+eval "$(direnv hook bash)"
+```
+
+Create a **gitignored** `.envrc.local` in the repo root:
+```bash
+# .envrc.local
+export CSS_ACCESS_KEY="<your-access-key-id>"
+export CSS_SECRET_KEY="<your-secret-key>"
+```
+
+Allow direnv to load it (one-time, per clone):
+```bash
+direnv allow
+```
+
+Credentials are then injected automatically on every `cd` into the repo.
+
 ## Prerequisites
 
 - Docker with GPU support ([install](https://docs.docker.com/engine/install/ubuntu/))
@@ -82,6 +125,17 @@ python scripts/rsl_rl/train.py --task Sharpa-V2P-v0
 ```
 
 See [robotic_grounding/README.md](robotic_grounding/README.md) for retargeting, debug environments, and task definitions.
+
+### Visualizer (retargeting gallery)
+
+Browse retargeted sequences as 3D animations in a browser:
+
+```bash
+python robotic_grounding/visualizer/sync_visualizer_data.py   # download datasets
+python robotic_grounding/visualizer/serve.py                   # http://<server-ip>:8080
+```
+
+See [robotic_grounding/visualizer/README.md](robotic_grounding/visualizer/README.md) for setup, data layout, and how to generate `.viser` files from processed Parquets.
 
 ## Design Philosophy
 

--- a/robotic_grounding/.gitignore
+++ b/robotic_grounding/.gitignore
@@ -264,3 +264,6 @@ exps/
 
 # Temporary generated YAML files (e.g. OSMO workflow submissions)
 tmp_*.yaml
+
+# Visualizer datasets (large binary recordings, downloaded via sync_visualizer_data.py)
+visualizer/datasets/

--- a/robotic_grounding/README.md
+++ b/robotic_grounding/README.md
@@ -16,6 +16,49 @@
 
 - NVIDIA Driver Version 580.126.09, CUDA Version: 13.0 Recommended. In case of visualization errors, check NVIDIA driver version.
 
+## Environment & Credentials
+
+Retrieve your CSS/PDX keys from `~/.config/osmo/config.yaml` under `swift://pdx.s8k.io/AUTH_team-isaac`.
+
+**Option A — Edit the credentials file directly (simple)**
+
+Fill in your keys in `scripts/setup_css_env.sh`:
+
+```bash
+export CSS_ACCESS_KEY="<your-access-key-id>"
+export CSS_SECRET_KEY="<your-secret-key>"
+```
+
+Then source it manually when needed:
+```bash
+source scripts/setup_css_env.sh
+```
+
+**Option B — direnv (automatic, recommended)**
+
+[direnv](https://direnv.net/) auto-loads credentials whenever you `cd` into the repo.
+
+Install:
+```bash
+sudo apt-get install direnv        # Ubuntu/Debian
+# then add to ~/.bashrc:
+eval "$(direnv hook bash)"
+```
+
+Create a **gitignored** `.envrc.local` in the **repo root** (`video_to_data/.envrc.local`):
+```bash
+# .envrc.local
+export CSS_ACCESS_KEY="<your-access-key-id>"
+export CSS_SECRET_KEY="<your-secret-key>"
+```
+
+Allow direnv to load it (one-time, per clone):
+```bash
+direnv allow
+```
+
+Credentials are then injected automatically on every `cd` into the repo.
+
 ## Docker Usage
 
 Development should be **inside** the Container, and Git operations should be done **outside** the Container on the host machine.
@@ -123,3 +166,22 @@ python scripts/rsl_rl/play.py         # Play environment without a checkpoint (s
 ## RL Tasks
 - `Sharpa-V2P-v0-Play`
 - `Sharpa-V2P-v0`
+
+## Visualizer
+
+Browse retargeted sequences as 3D animations at **http://10.111.83.14:8080/**
+
+To run the server yourself or generate new recordings:
+
+```bash
+# Download datasets from OSMO
+python visualizer/sync_visualizer_data.py
+
+# Start the gallery server
+python visualizer/serve.py          # → http://0.0.0.0:8080
+
+# Serve vis_retargeted.py output directly (no copy needed)
+python visualizer/serve.py --html-dir /path/to/v2d_arctic_retarget_exp_200
+```
+
+See [visualizer/README.md](visualizer/README.md) for the full reference: parallel downloads, generating `.viser` files inside Docker, and running as a systemd service.

--- a/robotic_grounding/scripts/setup_css_env.sh
+++ b/robotic_grounding/scripts/setup_css_env.sh
@@ -21,8 +21,8 @@
 #   source scripts/setup_css_env.sh
 
 export CSS_ENDPOINT_URL="https://pdx.s8k.io"
-export CSS_ACCESS_KEY="REPLACE_ME"
-export CSS_SECRET_KEY="REPLACE_ME"
+export CSS_ACCESS_KEY="${CSS_ACCESS_KEY:-REPLACE_ME}"
+export CSS_SECRET_KEY="${CSS_SECRET_KEY:-REPLACE_ME}"
 export CSS_REGION="us-east-1"
 
 if [ "${CSS_ACCESS_KEY}" = "REPLACE_ME" ] || [ "${CSS_SECRET_KEY}" = "REPLACE_ME" ]; then

--- a/robotic_grounding/visualizer/README.md
+++ b/robotic_grounding/visualizer/README.md
@@ -1,0 +1,181 @@
+# Robotics Visualizer
+
+A lightweight gallery server for browsing motion-capture retargeting datasets.
+Each sequence shows a split-screen view: **viser 3D playback** (top) and
+**MP4 camera feed** (bottom).
+
+No external Python dependencies — stdlib only.
+
+---
+
+## Downloading Dataset Recordings
+
+Recordings are stored in OSMO (`isaac/v2d_{name}_retarget_exp_200`). The sync
+script wraps `osmo dataset download` for all six datasets.
+
+```bash
+# All datasets → robotic_grounding/visualizer/datasets/
+python robotic_grounding/visualizer/sync_visualizer_data.py
+
+# Specific datasets
+python robotic_grounding/visualizer/sync_visualizer_data.py --dataset arctic h2o
+
+# Narrow to sequences matching a pattern (regex applied within {name}_html/)
+python robotic_grounding/visualizer/sync_visualizer_data.py --dataset arctic --pattern arctic_s01
+
+# Download all datasets in parallel (3 concurrent osmo processes)
+python robotic_grounding/visualizer/sync_visualizer_data.py --jobs 3
+
+# Dry run — prints the osmo command without executing
+python robotic_grounding/visualizer/sync_visualizer_data.py --dry-run
+```
+
+Requires the `osmo` CLI to be on PATH and authenticated:
+```bash
+osmo login https://us-west-2-aws.osmo.nvidia.com/
+```
+---
+
+## Quick Start
+
+```bash
+# Point at a directory containing v2d_* dataset folders
+python robotic_grounding/visualizer/serve.py
+# → http://<server-ip>:8080  (serves from visualizer/datasets/ by default)
+```
+
+Options:
+```bash
+python serve.py --port 9000
+python serve.py --host 127.0.0.1
+python serve.py --data-dir /path/to/external/data   # override data directory
+python serve.py --html-dir /path/to/v2d_arctic_retarget_exp_200   # serve a single html output dir directly
+```
+
+`--html-dir` accepts a directory that has `recordings/` and `viser-client/` **directly inside** (i.e. the output of `vis_retargeted.py`). It can be repeated to mount multiple directories alongside the standard datasets. Each mount appears as an additional dataset in the sidebar.
+
+---
+
+## Data Directory Layout
+
+The server auto-discovers any directory matching `v2d_{name}_retarget*/`:
+
+```
+<data-dir>/
+  v2d_arctic_retarget_exp_200/
+    arctic_html/
+      recordings/
+        *.viser          ← 3D playback file (required)
+        *.mp4            ← camera feed video (optional)
+      viser-client/      ← static viser SPA (copy from any existing dataset)
+  v2d_taco_retarget_exp_200/
+    ...
+```
+
+Restart the server to pick up new datasets — no code changes needed.
+
+---
+
+## Generating `.viser` Files from Retargeted Parquets
+
+`.viser` files are recorded viser sessions — 3D animations of the robot hand
+and object playing back a retargeted sequence.
+
+Run `scripts/retarget/vis_retargeted.py` **inside the Docker container**:
+
+```bash
+# Start and enter the container (from repo root)
+./workflow/run.sh start
+
+# Inside the container —————————————————————————————————————
+
+# 1. Retarget if not already done (writes Parquet to arctic_processed/)
+python scripts/retarget/run_retarget.py --dataset arctic --save
+
+# 2. Record .viser (and optionally .mp4) for every sequence in the dataset
+python scripts/retarget/vis_retargeted.py \
+    --dataset arctic \
+    --save_html \
+    --save_mp4 \
+    --html_dir /workspace/video_to_data/robotic_grounding/visualizer/datasets/v2d_arctic_retarget_exp_200/arctic_html
+
+# Or a single sequence:
+python scripts/retarget/vis_retargeted.py \
+    --dataset arctic \
+    --sequence_id arctic_s01_scissors_use_01 \
+    --save_html \
+    --save_mp4 \
+    --html_dir /workspace/video_to_data/robotic_grounding/visualizer/datasets/v2d_arctic_retarget_exp_200/arctic_html
+```
+
+`--save_html` records the animation to a `.viser` file and copies the viser JS
+client. `--save_mp4` also renders an offline MP4 via pyrender (no display needed).
+
+The output lands in a flat layout inside `--html_dir`:
+
+```
+<html_dir>/
+  recordings/
+    arctic_s01_scissors_use_01.viser
+    arctic_s01_scissors_use_01.mp4
+    ...
+  viser-client/
+```
+
+**Serving from a custom path (outside the standard datasets layout)**
+
+If you write to a path that is not under `visualizer/datasets/`, point the server
+at it directly with `--html-dir` **on the host**:
+
+```bash
+python robotic_grounding/visualizer/serve.py \
+    --html-dir /path/to/arctic_html
+# → the dataset appears in the sidebar alongside any downloaded datasets
+```
+
+---
+
+## Adding a New Dataset
+
+1. Create the directory structure under your `--data-dir`:
+   ```
+   v2d_{name}_retarget/
+     {name}_html/
+       recordings/       ← put .viser and .mp4 files here
+       viser-client/     ← copy from any existing dataset directory
+   ```
+
+2. Copy the `viser-client/` folder from an existing dataset (they all share the
+   same build — the server deduplicates the JS bundle automatically).
+
+3. Restart the server — the new dataset appears in the sidebar immediately.
+
+---
+
+## Current Datasets
+
+| Dataset | Sequences | Avg .viser size |
+|---------|-----------|----------------|
+| arctic  | 200       | 8.5 MB         |
+| dexycb  | 200       | 7.1 MB         |
+| grab    | 200       | 14.0 MB        |
+| h2o     | 110       | 9.2 MB         |
+| hot3d   | 200       | 73.3 MB        |
+| taco    | 200       | 10.6 MB        |
+
+> hot3d sequences are 8–10× larger due to data generation differences.
+> Each sequence is cached in the browser for 7 days so the slow first load
+> only happens once per week.
+
+---
+
+## Technical Notes
+
+- **Loop mechanism:** viser has hardcoded internal looping. The server covers
+  the ~30 ms blank flash at each loop boundary with a CSS overlay — no iframe
+  reload, so camera position is always preserved.
+- **Shared viser-client:** All datasets with the same viser build share one
+  canonical URL, so the browser downloads the 2.7 MB JS bundle once regardless
+  of how many datasets are loaded.
+- **HTTP 206 range requests:** Supported for MP4 video seeking.
+- **Cache:** Recordings cached 7 days; hashed JS/CSS/WASM bundles cached 1 year.

--- a/robotic_grounding/visualizer/serve.py
+++ b/robotic_grounding/visualizer/serve.py
@@ -1,0 +1,716 @@
+#!/usr/bin/env python3
+"""
+Robotics Visualizer Gallery Server
+
+Serves all datasets under a data directory. Datasets are discovered automatically
+by scanning for the pattern: v2d_{name}_retarget*/*/recordings/*.viser
+
+Usage:
+  python serve.py                                  # http://0.0.0.0:8080, data in ./
+  python serve.py --data-dir ~/ROBOTICS_VISUALIZER
+  python serve.py --data-dir /data/vis --port 9000
+  python serve.py --host 127.0.0.1 --port 8080
+"""
+
+import argparse
+import json
+import re
+import mimetypes
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+from socketserver import ThreadingMixIn
+from urllib.parse import urlparse, unquote
+
+CHUNK = 1024 * 1024  # 1 MB read chunks
+
+ROOT = Path(__file__).parent
+DATASETS_DIR = ROOT / "datasets"
+
+# Set by main() from --data-dir; defaults to DATASETS_DIR
+DATA_DIR: Path = DATASETS_DIR
+
+# Extra html dirs added via --html-dir; mounted at _live/<dirname>/ in URLs.
+# Maps virtual URL prefix → real filesystem path.
+_LIVE_MOUNTS: dict[str, Path] = {}
+
+
+# ── Dataset discovery ─────────────────────────────────────────────────────────
+
+def _vc_bundle_key(vc_dir: Path):
+    """(filename, size) of the main JS bundle — identifies identical viser-client builds."""
+    bundles = sorted(vc_dir.glob("assets/index-*.js"))
+    if not bundles:
+        return None
+    b = bundles[0]
+    return (b.name, b.stat().st_size)
+
+
+def discover_datasets():
+    """Scan for datasets under DATA_DIR and any --html-dir mounts."""
+    datasets = []
+    # bundle_key -> canonical vc path; identical builds share one browser-cache entry
+    canonical_vc: dict = {}
+
+    # ── standard layout: DATA_DIR/v2d_*/*/recordings ──────────────────────────
+    for recordings_dir in sorted(DATA_DIR.glob("v2d_*/*/recordings")):
+        top = recordings_dir.parts[-3]          # e.g. v2d_h2o_retarget_exp_200
+        m = re.match(r"v2d_(.+?)_retarget", top)
+        if not m:
+            continue
+        name = m.group(1)
+
+        viser_files = sorted(recordings_dir.glob("*.viser"))
+        if not viser_files:
+            continue
+
+        viser_client_dir = recordings_dir.parent / "viser-client"
+        rec_rel = recordings_dir.relative_to(DATA_DIR).as_posix()
+
+        vc_rel = None
+        if viser_client_dir.exists():
+            key = _vc_bundle_key(viser_client_dir)
+            if key and key in canonical_vc:
+                vc_rel = canonical_vc[key]
+            else:
+                vc_rel = viser_client_dir.relative_to(DATA_DIR).as_posix()
+                if key:
+                    canonical_vc[key] = vc_rel
+
+        recordings = []
+        for f in viser_files:
+            stem = f.stem
+            mp4 = recordings_dir / f"{stem}.mp4"
+            recordings.append({
+                "stem": stem,
+                "viser": f"{rec_rel}/{f.name}",
+                "mp4": f"{rec_rel}/{stem}.mp4" if mp4.exists() else None,
+            })
+
+        datasets.append({
+            "name": name,
+            "viser_client": vc_rel,
+            "count": len(viser_files),
+            "recordings": recordings,
+        })
+
+    # ── --html-dir mounts: each dir has recordings/ directly inside ───────────
+    for prefix, html_dir in sorted(_LIVE_MOUNTS.items()):
+        recordings_dir = html_dir / "recordings"
+        if not recordings_dir.exists():
+            continue
+        viser_files = sorted(recordings_dir.glob("*.viser"))
+        if not viser_files:
+            continue
+
+        m = re.match(r"v2d_(.+?)_retarget", html_dir.name)
+        name = m.group(1) if m else html_dir.name
+
+        rec_rel = f"{prefix}/recordings"
+        viser_client_dir = html_dir / "viser-client"
+        vc_rel = None
+        if viser_client_dir.exists():
+            key = _vc_bundle_key(viser_client_dir)
+            if key and key in canonical_vc:
+                vc_rel = canonical_vc[key]
+            else:
+                vc_rel = f"{prefix}/viser-client"
+                if key:
+                    canonical_vc[key] = vc_rel
+
+        recordings = []
+        for f in viser_files:
+            stem = f.stem
+            mp4 = recordings_dir / f"{stem}.mp4"
+            recordings.append({
+                "stem": stem,
+                "viser": f"{rec_rel}/{f.name}",
+                "mp4": f"{rec_rel}/{stem}.mp4" if mp4.exists() else None,
+            })
+
+        datasets.append({
+            "name": name,
+            "viser_client": vc_rel,
+            "count": len(viser_files),
+            "recordings": recordings,
+        })
+
+    return datasets
+
+
+# ── Gallery HTML ──────────────────────────────────────────────────────────────
+
+GALLERY_HTML = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Robotics Visualizer</title>
+  <style>
+    :root {
+      --bg:        #0d1117;
+      --surface:   #161b22;
+      --surface2:  #1c2128;
+      --border:    #30363d;
+      --accent:    #58a6ff;
+      --accent-bg: #1a2d45;
+      --text:      #e6edf3;
+      --muted:     #7d8590;
+      --r:         8px;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body {
+      height: 100%;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      font-size: 14px;
+      overflow: hidden;
+    }
+
+    /* ── Layout ─────────────────────────────── */
+    #app { display: flex; flex-direction: column; height: 100vh; }
+
+    #header {
+      display: flex;
+      align-items: center;
+      gap: 20px;
+      padding: 12px 20px;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    #header h1 { font-size: 16px; font-weight: 600; color: var(--accent); }
+    #stats { font-size: 13px; color: var(--muted); }
+    #stats strong { color: var(--text); }
+
+    #body { display: flex; flex: 1; overflow: hidden; }
+
+    /* ── Sidebar ─────────────────────────────── */
+    #sidebar {
+      width: 300px;
+      min-width: 260px;
+      flex-shrink: 0;
+      border-right: 1px solid var(--border);
+      overflow-y: auto;
+      padding: 10px;
+    }
+    #sidebar::-webkit-scrollbar { width: 4px; }
+    #sidebar::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+    .ds-card {
+      border: 1px solid var(--border);
+      border-radius: var(--r);
+      margin-bottom: 8px;
+      overflow: hidden;
+    }
+    .ds-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 14px;
+      background: var(--surface);
+      cursor: pointer;
+      user-select: none;
+      transition: background .12s;
+    }
+    .ds-header:hover { background: var(--surface2); }
+    .ds-name { font-weight: 600; flex: 1; font-size: 14px; }
+    .ds-badge {
+      font-size: 11px;
+      color: var(--muted);
+      background: var(--bg);
+      border: 1px solid var(--border);
+      padding: 1px 8px;
+      border-radius: 10px;
+      white-space: nowrap;
+    }
+    .chevron { color: var(--muted); flex-shrink: 0; transition: transform .2s; }
+    .ds-card.open .chevron { transform: rotate(180deg); }
+
+    .ds-body { display: none; padding: 6px; }
+    .ds-card.open .ds-body { display: block; }
+
+    .group-label {
+      font-size: 11px;
+      font-weight: 500;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: .07em;
+      padding: 8px 8px 3px;
+    }
+    .group-label:first-child { padding-top: 4px; }
+
+    .seq-btn {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      width: 100%;
+      padding: 6px 10px;
+      background: transparent;
+      border: none;
+      border-radius: 5px;
+      color: var(--text);
+      font-size: 13px;
+      text-align: left;
+      cursor: pointer;
+      transition: background .1s;
+    }
+    .seq-btn:hover { background: var(--surface2); }
+    .seq-btn.active {
+      background: var(--accent-bg);
+      color: var(--accent);
+    }
+    .seq-dot {
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      background: var(--border);
+      flex-shrink: 0;
+    }
+    .seq-btn.active .seq-dot { background: var(--accent); }
+
+    /* ── Viewer ──────────────────────────────── */
+    #viewer {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      min-width: 0;
+    }
+
+    #viewer-bar {
+      flex-shrink: 0;
+      padding: 7px 16px;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      font-size: 12px;
+      color: var(--muted);
+      display: none;
+    }
+    #viewer-bar.show { display: block; }
+    #viewer-bar strong { color: var(--text); }
+
+    #viewer-empty {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      color: var(--muted);
+    }
+    #viewer-empty svg { opacity: .3; }
+
+    #viser-wrap { flex: 1; overflow: hidden; min-height: 0; }
+    #viser-frame { width: 100%; height: 100%; border: none; display: block; }
+
+    #video-pane {
+      height: 240px;
+      flex-shrink: 0;
+      border-top: 1px solid var(--border);
+      background: #000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+    }
+    #video-pane video {
+      max-width: 100%;
+      height: 100%;
+      object-fit: contain;
+    }
+    #video-label {
+      position: absolute;
+      top: 7px; left: 12px;
+      font-size: 11px;
+      color: rgba(255,255,255,.35);
+      pointer-events: none;
+      letter-spacing: .04em;
+    }
+    .no-video { color: var(--muted); font-size: 13px; }
+  </style>
+</head>
+<body>
+<div id="app">
+  <div id="header">
+    <h1>Robotics Visualizer</h1>
+    <span id="stats">Loading&hellip;</span>
+  </div>
+  <div id="body">
+    <div id="sidebar">
+      <div id="ds-list"><span style="color:var(--muted)">Loading&hellip;</span></div>
+    </div>
+    <div id="viewer">
+      <div id="viewer-bar"></div>
+      <div id="viewer-empty">
+        <svg width="56" height="56" viewBox="0 0 24 24" fill="none"
+             stroke="currentColor" stroke-width="1">
+          <path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/>
+          <polyline points="3.27 6.96 12 12.01 20.73 6.96"/>
+          <line x1="12" y1="22.08" x2="12" y2="12"/>
+        </svg>
+        <p>Select a sequence to visualize</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+let datasets = [];
+let activeViewerSrc = null;
+let loopWatcher = null;
+let loopTimer   = null;
+let loopBlocked = false;
+let lastMax     = null;
+
+function getOverlay() {
+  const wrap = document.getElementById('viser-wrap');
+  if (!wrap) return null;
+  let ov = document.getElementById('loop-overlay');
+  if (!ov) {
+    ov = document.createElement('div');
+    ov.id = 'loop-overlay';
+    ov.style.cssText =
+      'position:absolute;inset:0;background:#0d1117;z-index:9;' +
+      'pointer-events:none;opacity:0;transition:opacity .05s';
+    wrap.style.position = 'relative';
+    wrap.appendChild(ov);
+  }
+  return ov;
+}
+
+function getBestSlider(frame) {
+  const sliders = frame.contentDocument.querySelectorAll('[role="slider"]');
+  if (!sliders.length) return null;
+  let best = null;
+  for (const s of sliders) {
+    const m = parseFloat(s.getAttribute('aria-valuemax'));
+    if (!best || m > parseFloat(best.getAttribute('aria-valuemax'))) best = s;
+  }
+  return best;
+}
+
+function triggerLoop() {
+  if (loopBlocked) return;
+  if (loopTimer) { clearTimeout(loopTimer); loopTimer = null; }
+
+  // Guard: if user seeked away, reschedule rather than fire
+  const frame = document.getElementById('viser-frame');
+  try {
+    const best = getBestSlider(frame);
+    if (best) {
+      const max = parseFloat(best.getAttribute('aria-valuemax'));
+      const cur = parseFloat(best.getAttribute('aria-valuenow'));
+      if (!isNaN(cur) && cur < max - 0.3) { lastMax = null; return; }
+    }
+  } catch(e) {}
+
+  loopBlocked = true;
+  lastMax = null;
+
+  // Viser auto-loops internally — we only need a brief overlay to hide its
+  // ~30 ms blank flash (h() sets scene objects invisible before frame 0 runs)
+  const ov = getOverlay();
+  if (ov) ov.style.opacity = '1';
+  setTimeout(() => {
+    if (ov) ov.style.opacity = '0';
+    loopBlocked = false;
+  }, 200);
+}
+
+function startLoopWatcher() {
+  if (loopWatcher) clearInterval(loopWatcher);
+  if (loopTimer)  { clearTimeout(loopTimer); loopTimer = null; }
+  loopBlocked = false;
+  lastMax = null;
+
+  loopWatcher = setInterval(() => {
+    if (loopBlocked) return;
+    const frame = document.getElementById('viser-frame');
+    if (!frame || !activeViewerSrc) return;
+    try {
+      const best = getBestSlider(frame);
+      if (!best) return;
+      const max     = parseFloat(best.getAttribute('aria-valuemax'));
+      const current = parseFloat(best.getAttribute('aria-valuenow'));
+      if (!(max > 5) || isNaN(current)) return;
+
+      // Fallback: already at end
+      if (current >= max - 0.1) { triggerLoop(); return; }
+
+      // Precise timer: fires just before viser's internal loop resets the scene
+      if (max !== lastMax) {
+        lastMax = max;
+        if (loopTimer) clearTimeout(loopTimer);
+        loopTimer = setTimeout(triggerLoop, Math.max((max - current - 0.05) * 1000, 0));
+      }
+    } catch(e) {}
+  }, 200);
+}
+
+function buildGallery() {
+  const total = datasets.reduce((s, d) => s + d.count, 0);
+  document.getElementById('stats').innerHTML =
+    `<strong>${datasets.length}</strong> dataset${datasets.length !== 1 ? 's' : ''} &nbsp;&middot;&nbsp; ` +
+    `<strong>${total}</strong> total sequences`;
+
+  const list = document.getElementById('ds-list');
+  list.innerHTML = '';
+
+  for (const ds of datasets) {
+    const card = document.createElement('div');
+    card.className = 'ds-card';
+    card.innerHTML = `
+      <div class="ds-header">
+        <span class="ds-name">${ds.name}</span>
+        <span class="ds-badge">${ds.count} sequences</span>
+        <svg class="chevron" width="14" height="14" viewBox="0 0 24 24"
+             fill="none" stroke="currentColor" stroke-width="2.5">
+          <polyline points="6 9 12 15 18 9"/>
+        </svg>
+      </div>
+      <div class="ds-body"></div>`;
+
+    card.querySelector('.ds-header').addEventListener('click', () => card.classList.toggle('open'));
+
+    const body = card.querySelector('.ds-body');
+    for (const rec of ds.recordings) {
+      const btn = document.createElement('button');
+      btn.className = 'seq-btn';
+      btn.dataset.stem = rec.stem;
+      btn.innerHTML = `<span class="seq-dot"></span>${rec.stem}`;
+      btn.addEventListener('click', () => activate(rec, ds, btn));
+      body.appendChild(btn);
+    }
+
+    list.appendChild(card);
+  }
+}
+
+function activate(rec, ds, btn) {
+  document.querySelectorAll('.seq-btn.active').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+
+  const origin = window.location.origin;
+
+  // Pre-fetch the .viser file immediately — the iframe won't request it for
+  // ~300-500ms (while its JS loads), so this gives the download a head start.
+  // The browser coalesces the iframe's later request with this in-flight fetch.
+  fetch(`${origin}/${rec.viser}`).catch(() => {});
+  const playbackUrl  = `${origin}/${rec.viser}`;
+  const viewerSrc    = `${origin}/${ds.viser_client}/?playbackPath=${encodeURIComponent(playbackUrl)}`;
+
+  // Title bar
+  const bar = document.getElementById('viewer-bar');
+  bar.className = 'show';
+  bar.innerHTML = `<strong>${ds.name}</strong> &nbsp;/&nbsp; ${rec.stem}`;
+
+  const viewer = document.getElementById('viewer');
+
+  // Remove empty state once
+  const empty = document.getElementById('viewer-empty');
+  if (empty) empty.remove();
+
+  // Viser iframe — reuse wrapper, just swap src
+  activeViewerSrc = viewerSrc;
+  let wrap = document.getElementById('viser-wrap');
+  if (!wrap) {
+    wrap = document.createElement('div');
+    wrap.id = 'viser-wrap';
+    wrap.innerHTML = `<iframe id="viser-frame" src="" allow="fullscreen"></iframe>`;
+    viewer.insertBefore(wrap, document.getElementById('video-pane'));
+  }
+  document.getElementById('viser-frame').src = viewerSrc;
+  startLoopWatcher();
+
+  // Video pane — reuse, swap src
+  let vpane = document.getElementById('video-pane');
+  if (!vpane) {
+    vpane = document.createElement('div');
+    vpane.id = 'video-pane';
+    viewer.appendChild(vpane);
+  }
+  if (rec.mp4) {
+    // Replace video element to force reload
+    vpane.innerHTML = `
+      <div id="video-label">Camera feed &mdash; ${rec.stem}</div>
+      <video src="/${rec.mp4}" autoplay loop muted playsinline controls></video>`;
+  } else {
+    vpane.innerHTML = `<span class="no-video">No video available</span>`;
+  }
+}
+
+fetch('/api/datasets')
+  .then(r => r.json())
+  .then(data => { datasets = data; buildGallery(); })
+  .catch(err => {
+    document.getElementById('ds-list').innerHTML =
+      `<span style="color:var(--muted)">Error: ${err.message}</span>`;
+  });
+</script>
+</body>
+</html>
+"""
+
+
+# ── HTTP Handler ──────────────────────────────────────────────────────────────
+
+class Handler(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        raw_path = unquote(urlparse(self.path).path).lstrip("/")
+
+        # Gallery root
+        if raw_path in ("", "index.html"):
+            self._send_text(GALLERY_HTML, "text/html; charset=utf-8")
+            return
+
+        # Dataset API
+        if raw_path == "api/datasets":
+            self._send_json(discover_datasets())
+            return
+
+        # Static files — check _live/ mounts first, then DATA_DIR
+        file_path = None
+        for prefix, html_dir in _LIVE_MOUNTS.items():
+            if raw_path == prefix or raw_path.startswith(prefix + "/"):
+                rel = raw_path[len(prefix):].lstrip("/")
+                file_path = html_dir / rel if rel else html_dir
+                break
+        if file_path is None:
+            file_path = DATA_DIR / raw_path
+        if file_path.is_dir():
+            file_path = file_path / "index.html"
+        if not file_path.is_file():
+            self.send_error(404, f"Not found: {raw_path}")
+            return
+
+        self._send_file(file_path)
+
+    # ── helpers ──
+
+    def _send_text(self, body: str, ctype: str):
+        data = body.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _send_json(self, obj):
+        data = json.dumps(obj, indent=2).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _send_file(self, file_path: Path):
+        mime = mimetypes.guess_type(str(file_path))[0] or "application/octet-stream"
+        size = file_path.stat().st_size
+
+        # Immutable assets (hash in name) get a long cache lifetime
+        name = file_path.name
+        if re.search(r"-[A-Za-z0-9]{8,}\.(js|css|wasm)$", name):
+            cache = "public, max-age=31536000, immutable"
+        elif file_path.suffix in (".viser", ".mp4", ".hdr", ".ttf"):
+            cache = "public, max-age=604800"  # recordings don't change; 7-day cache
+        else:
+            cache = "no-cache"
+
+        # Range request — required for video seeking
+        range_hdr = self.headers.get("Range")
+        if range_hdr:
+            m = re.match(r"bytes=(\d+)-(\d*)", range_hdr)
+            if m:
+                start  = int(m.group(1))
+                end    = int(m.group(2)) if m.group(2) else size - 1
+                end    = min(end, size - 1)
+                length = end - start + 1
+                self.send_response(206)
+                self.send_header("Content-Type", mime)
+                self.send_header("Content-Range", f"bytes {start}-{end}/{size}")
+                self.send_header("Content-Length", str(length))
+                self.send_header("Accept-Ranges", "bytes")
+                self.send_header("Cache-Control", cache)
+                self.end_headers()
+                self._stream(file_path, start, length)
+                return
+
+        self.send_response(200)
+        self.send_header("Content-Type", mime)
+        self.send_header("Content-Length", str(size))
+        self.send_header("Accept-Ranges", "bytes")
+        self.send_header("Cache-Control", cache)
+        self.end_headers()
+        self._stream(file_path, 0, size)
+
+    def _stream(self, file_path: Path, offset: int, length: int):
+        try:
+            with open(file_path, "rb") as f:
+                f.seek(offset)
+                remaining = length
+                while remaining > 0:
+                    chunk = f.read(min(CHUNK, remaining))
+                    if not chunk:
+                        break
+                    self.wfile.write(chunk)
+                    remaining -= len(chunk)
+        except (BrokenPipeError, ConnectionResetError):
+            pass  # client navigated away mid-transfer
+
+    def log_message(self, fmt, *args):
+        pass  # suppress per-request noise
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def main():
+    global DATA_DIR
+
+    parser = argparse.ArgumentParser(description="Robotics Visualizer Gallery Server")
+    parser.add_argument("--host", default="0.0.0.0",
+                        help="Bind address (default: 0.0.0.0 — all interfaces)")
+    parser.add_argument("--port", type=int, default=8080,
+                        help="Port (default: 8080)")
+    parser.add_argument("--data-dir", type=Path, default=DATASETS_DIR,
+                        help="Directory containing v2d_* dataset folders (default: visualizer/datasets/)")
+    parser.add_argument("--html-dir", type=Path, action="append", default=[],
+                        metavar="DIR",
+                        help="Extra html output dir (has recordings/ directly inside). "
+                             "Can be repeated. E.g. the --html_dir passed to vis_retargeted.py.")
+    args = parser.parse_args()
+
+    DATA_DIR = args.data_dir.expanduser().resolve()
+    if not DATA_DIR.is_dir():
+        raise SystemExit(f"ERROR: --data-dir does not exist: {DATA_DIR}")
+
+    for raw in args.html_dir:
+        p = raw.expanduser().resolve()
+        if not p.is_dir():
+            raise SystemExit(f"ERROR: --html-dir does not exist: {p}")
+        _LIVE_MOUNTS[f"_live/{p.name}"] = p
+
+    datasets = discover_datasets()
+    total    = sum(d["count"] for d in datasets)
+
+    print(f"\n  Robotics Visualizer  →  http://{args.host}:{args.port}")
+    print(f"  data dir: {DATA_DIR}")
+    print(f"  {len(datasets)} dataset(s)  ·  {total} sequences total")
+    for d in datasets:
+        print(f"    {d['name']:20s}  {d['count']} sequences")
+    print("\n  Press Ctrl+C to stop.\n")
+
+    class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+        daemon_threads = True
+
+    server = ThreadedHTTPServer((args.host, args.port), Handler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/robotic_grounding/visualizer/serve.py
+++ b/robotic_grounding/visualizer/serve.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-Robotics Visualizer Gallery Server
+"""Robotics Visualizer Gallery Server.
 
 Serves all datasets under a data directory. Datasets are discovered automatically
 by scanning for the pattern: v2d_{name}_retarget*/*/recordings/*.viser
@@ -14,12 +13,13 @@ Usage:
 
 import argparse
 import json
-import re
 import mimetypes
-from http.server import HTTPServer, BaseHTTPRequestHandler
+import re
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from socketserver import ThreadingMixIn
-from urllib.parse import urlparse, unquote
+from typing import Any
+from urllib.parse import unquote, urlparse
 
 CHUNK = 1024 * 1024  # 1 MB read chunks
 
@@ -36,8 +36,9 @@ _LIVE_MOUNTS: dict[str, Path] = {}
 
 # ── Dataset discovery ─────────────────────────────────────────────────────────
 
-def _vc_bundle_key(vc_dir: Path):
-    """(filename, size) of the main JS bundle — identifies identical viser-client builds."""
+
+def _vc_bundle_key(vc_dir: Path) -> tuple[str, int] | None:
+    """Return (filename, size) of the main JS bundle to identify identical viser-client builds."""
     bundles = sorted(vc_dir.glob("assets/index-*.js"))
     if not bundles:
         return None
@@ -45,7 +46,7 @@ def _vc_bundle_key(vc_dir: Path):
     return (b.name, b.stat().st_size)
 
 
-def discover_datasets():
+def discover_datasets() -> list[dict]:  # type: ignore[type-arg]
     """Scan for datasets under DATA_DIR and any --html-dir mounts."""
     datasets = []
     # bundle_key -> canonical vc path; identical builds share one browser-cache entry
@@ -53,7 +54,7 @@ def discover_datasets():
 
     # ── standard layout: DATA_DIR/v2d_*/*/recordings ──────────────────────────
     for recordings_dir in sorted(DATA_DIR.glob("v2d_*/*/recordings")):
-        top = recordings_dir.parts[-3]          # e.g. v2d_h2o_retarget_exp_200
+        top = recordings_dir.parts[-3]  # e.g. v2d_h2o_retarget_exp_200
         m = re.match(r"v2d_(.+?)_retarget", top)
         if not m:
             continue
@@ -80,18 +81,22 @@ def discover_datasets():
         for f in viser_files:
             stem = f.stem
             mp4 = recordings_dir / f"{stem}.mp4"
-            recordings.append({
-                "stem": stem,
-                "viser": f"{rec_rel}/{f.name}",
-                "mp4": f"{rec_rel}/{stem}.mp4" if mp4.exists() else None,
-            })
+            recordings.append(
+                {
+                    "stem": stem,
+                    "viser": f"{rec_rel}/{f.name}",
+                    "mp4": f"{rec_rel}/{stem}.mp4" if mp4.exists() else None,
+                }
+            )
 
-        datasets.append({
-            "name": name,
-            "viser_client": vc_rel,
-            "count": len(viser_files),
-            "recordings": recordings,
-        })
+        datasets.append(
+            {
+                "name": name,
+                "viser_client": vc_rel,
+                "count": len(viser_files),
+                "recordings": recordings,
+            }
+        )
 
     # ── --html-dir mounts: each dir has recordings/ directly inside ───────────
     for prefix, html_dir in sorted(_LIVE_MOUNTS.items()):
@@ -121,18 +126,22 @@ def discover_datasets():
         for f in viser_files:
             stem = f.stem
             mp4 = recordings_dir / f"{stem}.mp4"
-            recordings.append({
-                "stem": stem,
-                "viser": f"{rec_rel}/{f.name}",
-                "mp4": f"{rec_rel}/{stem}.mp4" if mp4.exists() else None,
-            })
+            recordings.append(
+                {
+                    "stem": stem,
+                    "viser": f"{rec_rel}/{f.name}",
+                    "mp4": f"{rec_rel}/{stem}.mp4" if mp4.exists() else None,
+                }
+            )
 
-        datasets.append({
-            "name": name,
-            "viser_client": vc_rel,
-            "count": len(viser_files),
-            "recordings": recordings,
-        })
+        datasets.append(
+            {
+                "name": name,
+                "viser_client": vc_rel,
+                "count": len(viser_files),
+                "recordings": recordings,
+            }
+        )
 
     return datasets
 
@@ -555,9 +564,12 @@ fetch('/api/datasets')
 
 # ── HTTP Handler ──────────────────────────────────────────────────────────────
 
-class Handler(BaseHTTPRequestHandler):
 
-    def do_GET(self):
+class Handler(BaseHTTPRequestHandler):
+    """HTTP request handler for the gallery server."""
+
+    def do_GET(self) -> None:
+        """Serve gallery HTML, dataset API, and static files."""
         raw_path = unquote(urlparse(self.path).path).lstrip("/")
 
         # Gallery root
@@ -574,7 +586,7 @@ class Handler(BaseHTTPRequestHandler):
         file_path = None
         for prefix, html_dir in _LIVE_MOUNTS.items():
             if raw_path == prefix or raw_path.startswith(prefix + "/"):
-                rel = raw_path[len(prefix):].lstrip("/")
+                rel = raw_path[len(prefix) :].lstrip("/")
                 file_path = html_dir / rel if rel else html_dir
                 break
         if file_path is None:
@@ -589,7 +601,7 @@ class Handler(BaseHTTPRequestHandler):
 
     # ── helpers ──
 
-    def _send_text(self, body: str, ctype: str):
+    def _send_text(self, body: str, ctype: str) -> None:
         data = body.encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", ctype)
@@ -597,7 +609,7 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(data)
 
-    def _send_json(self, obj):
+    def _send_json(self, obj: Any) -> None:
         data = json.dumps(obj, indent=2).encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
@@ -606,7 +618,7 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(data)
 
-    def _send_file(self, file_path: Path):
+    def _send_file(self, file_path: Path) -> None:
         mime = mimetypes.guess_type(str(file_path))[0] or "application/octet-stream"
         size = file_path.stat().st_size
 
@@ -624,9 +636,9 @@ class Handler(BaseHTTPRequestHandler):
         if range_hdr:
             m = re.match(r"bytes=(\d+)-(\d*)", range_hdr)
             if m:
-                start  = int(m.group(1))
-                end    = int(m.group(2)) if m.group(2) else size - 1
-                end    = min(end, size - 1)
+                start = int(m.group(1))
+                end = int(m.group(2)) if m.group(2) else size - 1
+                end = min(end, size - 1)
                 length = end - start + 1
                 self.send_response(206)
                 self.send_header("Content-Type", mime)
@@ -646,7 +658,7 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self._stream(file_path, 0, size)
 
-    def _stream(self, file_path: Path, offset: int, length: int):
+    def _stream(self, file_path: Path, offset: int, length: int) -> None:
         try:
             with open(file_path, "rb") as f:
                 f.seek(offset)
@@ -660,26 +672,39 @@ class Handler(BaseHTTPRequestHandler):
         except (BrokenPipeError, ConnectionResetError):
             pass  # client navigated away mid-transfer
 
-    def log_message(self, fmt, *args):
-        pass  # suppress per-request noise
+    def log_message(self, fmt: str, *args: object) -> None:
+        """Suppress per-request noise."""
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────
 
-def main():
-    global DATA_DIR
+
+def main() -> None:
+    """Parse CLI arguments and start the threaded HTTP server."""
+    global DATA_DIR  # noqa: PLW0603
 
     parser = argparse.ArgumentParser(description="Robotics Visualizer Gallery Server")
-    parser.add_argument("--host", default="0.0.0.0",
-                        help="Bind address (default: 0.0.0.0 — all interfaces)")
-    parser.add_argument("--port", type=int, default=8080,
-                        help="Port (default: 8080)")
-    parser.add_argument("--data-dir", type=Path, default=DATASETS_DIR,
-                        help="Directory containing v2d_* dataset folders (default: visualizer/datasets/)")
-    parser.add_argument("--html-dir", type=Path, action="append", default=[],
-                        metavar="DIR",
-                        help="Extra html output dir (has recordings/ directly inside). "
-                             "Can be repeated. E.g. the --html_dir passed to vis_retargeted.py.")
+    parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="Bind address (default: 0.0.0.0 — all interfaces)",
+    )
+    parser.add_argument("--port", type=int, default=8080, help="Port (default: 8080)")
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=DATASETS_DIR,
+        help="Directory containing v2d_* dataset folders (default: visualizer/datasets/)",
+    )
+    parser.add_argument(
+        "--html-dir",
+        type=Path,
+        action="append",
+        default=[],
+        metavar="DIR",
+        help="Extra html output dir (has recordings/ directly inside). "
+        "Can be repeated. E.g. the --html_dir passed to vis_retargeted.py.",
+    )
     args = parser.parse_args()
 
     DATA_DIR = args.data_dir.expanduser().resolve()
@@ -693,7 +718,7 @@ def main():
         _LIVE_MOUNTS[f"_live/{p.name}"] = p
 
     datasets = discover_datasets()
-    total    = sum(d["count"] for d in datasets)
+    total = sum(d["count"] for d in datasets)
 
     print(f"\n  Robotics Visualizer  →  http://{args.host}:{args.port}")
     print(f"  data dir: {DATA_DIR}")

--- a/robotic_grounding/visualizer/sync_visualizer_data.py
+++ b/robotic_grounding/visualizer/sync_visualizer_data.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Download visualizer recordings from OSMO to local datasets dir.
+
+Syncs {name}_html/ trees (*.viser, *.mp4, viser-client/) from the OSMO
+isaac bucket using `osmo dataset download`. Multiple datasets can be
+downloaded in parallel with --jobs (use MAX to download all at once).
+Ctrl+C terminates all running downloads immediately.
+
+Prerequisites:
+  - osmo CLI on PATH and authenticated
+
+Usage:
+  python robotic_grounding/visualizer/sync_visualizer_data.py
+  python robotic_grounding/visualizer/sync_visualizer_data.py --dataset arctic
+  python robotic_grounding/visualizer/sync_visualizer_data.py --dataset arctic h2o
+  python robotic_grounding/visualizer/sync_visualizer_data.py --jobs MAX
+  python robotic_grounding/visualizer/sync_visualizer_data.py --dry-run
+"""
+
+import argparse
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+from rich.progress import (
+    BarColumn,
+    Progress,
+    TaskID,
+    TextColumn,
+    TimeRemainingColumn,
+    TransferSpeedColumn,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+DATASETS = ("arctic", "h2o", "grab", "taco", "dexycb", "hot3d")
+
+LOCAL_DATASETS_DIR = Path(__file__).resolve().parent / "datasets"
+
+# Rich color per dataset (same order as DATASETS)
+_RICH_COLORS = ("cyan", "green", "yellow", "magenta", "blue", "red")
+
+# Regex to parse a tqdm progress line emitted by osmo
+# Matches: "  17%|███  | 181M/1.06G [00:05<00:22, 42.5MB/s, ...]"
+_TQDM_RE = re.compile(
+    r"^\s*(\d+)%\|"               # percentage
+    r".*?\|\s*"
+    r"([\d.]+\s*\S+)"             # bytes done
+    r"/"
+    r"([\d.]+\s*\S+)"             # bytes total
+    r"\s*\["
+    r"[^,<]+"                     # elapsed
+    r"<?[^,]*"                    # eta
+    r",?\s*([\d.]+\s*\S+/s)?"    # speed (optional)
+)
+
+# Shutdown flag + registry of active subprocesses for Ctrl+C cleanup
+_shutdown = threading.Event()
+_active_procs: list[subprocess.Popen] = []
+_procs_lock = threading.Lock()
+
+
+def _terminate_all() -> None:
+    """Kill every active osmo process group (osmo spawns ~64 child workers)."""
+    with _procs_lock:
+        for proc in _active_procs:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except OSError:
+                try:
+                    proc.kill()
+                except OSError:
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _rich_color(name: str) -> str:
+    try:
+        return _RICH_COLORS[list(DATASETS).index(name)]
+    except ValueError:
+        return "white"
+
+
+def _osmo_dataset(name: str) -> str:
+    return f"isaac/v2d_{name}_retarget_exp_200"
+
+
+def _local_dir(name: str) -> Path:
+    return LOCAL_DATASETS_DIR / f"v2d_{name}_retarget_exp_200"
+
+
+def _parse_tqdm(line: str) -> tuple[int, str, str, str] | None:
+    """Parse a tqdm progress line.
+
+    Returns (pct, done, total, speed) or None if the line isn't a tqdm bar.
+    """
+    m = _TQDM_RE.match(line)
+    if not m:
+        return None
+    pct = int(m.group(1))
+    done = m.group(2).strip()
+    total = m.group(3).strip()
+    speed = (m.group(4) or "").strip()
+    return pct, done, total, speed
+
+
+# ---------------------------------------------------------------------------
+# Streaming output → rich progress
+# ---------------------------------------------------------------------------
+def _stream(
+    proc: subprocess.Popen,
+    name: str,
+    progress: Progress,
+    task_id: TaskID,
+) -> None:
+    """Read proc stdout+stderr, update the rich task on tqdm lines,
+    and print other lines (errors, info) above the progress bars.
+    """
+    color = _rich_color(name)
+    buf = b""
+
+    while True:
+        chunk = proc.stdout.read(256)
+        if not chunk:
+            break
+        buf += chunk
+
+        while True:
+            ni = buf.find(b"\n")
+            ri = buf.find(b"\r")
+            if ni == -1 and ri == -1:
+                break
+            if ni == -1 or (ri != -1 and ri < ni):
+                raw, buf = buf[:ri], buf[ri + 1:]
+            else:
+                raw, buf = buf[:ni], buf[ni + 1:]
+
+            line = raw.decode(errors="replace").strip()
+            if not line:
+                continue
+
+            parsed = _parse_tqdm(line)
+            if parsed:
+                pct, done, total, speed = parsed
+                label = f"[{color}]{name:<7}[/{color}]"
+                info = f"[dim]{done}/{total}"
+                if speed:
+                    info += f" @ {speed}"
+                info += "[/dim]"
+                progress.update(task_id, completed=pct, description=f"{label} {info}")
+            else:
+                progress.console.print(f"[{color}]\\[{name}][/{color}] {line}")
+
+    if buf.strip():
+        line = buf.decode(errors="replace").strip()
+        progress.console.print(f"[{_rich_color(name)}]\\[{name}][/{_rich_color(name)}] {line}")
+
+
+# ---------------------------------------------------------------------------
+# Core sync
+# ---------------------------------------------------------------------------
+def sync(
+    name: str,
+    pattern: str | None,
+    dry_run: bool,
+    progress: Progress,
+) -> int:
+    """Download {name}_html/ from OSMO. Returns osmo exit code."""
+    if _shutdown.is_set():
+        progress.console.print(f"[dim]\\[{name}] skipped (interrupted)[/dim]")
+        return 1
+
+    dest = _local_dir(name)
+    regex = rf"^{name}_html/.*{pattern}" if pattern else rf"^{name}_html/"
+
+    # osmo ALWAYS creates a DATASET_NAME/ subdirectory inside whatever path it
+    # receives. So pass LOCAL_DATASETS_DIR (the parent); osmo then creates
+    # v2d_{name}_retarget_exp_200/ inside it — which is exactly dest.
+    # Delete dest first so osmo creates it fresh without nesting inside itself.
+    cmd = [
+        "osmo", "dataset", "download",
+        _osmo_dataset(name),
+        str(LOCAL_DATASETS_DIR),
+        "--regex", regex,
+    ]
+
+    color = _rich_color(name)
+    progress.console.print(
+        f"[{color}]\\[{name}][/{color}] "
+        f"{_osmo_dataset(name)} [dim]→[/dim] {dest}"
+    )
+
+    if dry_run:
+        progress.console.print(
+            f"[{color}]\\[{name}][/{color}] [dim][dry-run] {' '.join(cmd)}[/dim]"
+        )
+        return 0
+
+    LOCAL_DATASETS_DIR.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        shutil.rmtree(dest)  # remove so osmo creates dest/ fresh, not dest/dest/
+
+    task_id = progress.add_task(
+        f"[{color}]{name:<7}[/{color}] [dim]starting...[/dim]",
+        total=100,
+    )
+
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,   # own process group → killpg kills all workers
+    )
+    with _procs_lock:
+        _active_procs.append(proc)
+    try:
+        _stream(proc, name, progress, task_id)
+        rc = proc.wait()
+    finally:
+        with _procs_lock:
+            try:
+                _active_procs.remove(proc)
+            except ValueError:
+                pass
+
+    if rc == 0:
+        progress.update(task_id, completed=100,
+                        description=f"[{color}]{name:<7}[/{color}] [green]done[/green]")
+    elif not _shutdown.is_set():
+        progress.update(task_id,
+                        description=f"[{color}]{name:<7}[/{color}] [red]failed (code {rc})[/red]")
+    return rc
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download visualizer recordings from OSMO to local datasets dir.",
+    )
+    parser.add_argument(
+        "--dataset",
+        nargs="+",
+        choices=[*DATASETS, "all"],
+        default=["all"],
+        help="Dataset(s) to sync, or 'all' (default).",
+    )
+    parser.add_argument(
+        "--pattern",
+        type=str,
+        default=None,
+        help="Extra regex to narrow files within {name}_html/ (e.g. 'arctic_s01').",
+    )
+    parser.add_argument(
+        "--jobs", "-j",
+        type=str,
+        default="1",
+        metavar="N|MAX",
+        help="Parallel downloads: integer or MAX to download all datasets at once.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Print the osmo command without running it.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    datasets = list(DATASETS) if "all" in args.dataset else args.dataset
+
+    jobs_str = args.jobs.upper()
+    n_jobs = len(datasets) if jobs_str == "MAX" else int(args.jobs)
+
+    progress = Progress(
+        TextColumn("{task.description}", justify="left"),
+        BarColumn(bar_width=30),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        TimeRemainingColumn(),
+        refresh_per_second=10,
+        transient=False,
+    )
+
+    # ---- sequential path -----------------------------------------------
+    if n_jobs == 1:
+        try:
+            with progress:
+                for name in datasets:
+                    if _shutdown.is_set():
+                        break
+                    rc = sync(name, args.pattern, args.dry_run, progress)
+                    if rc != 0 and not _shutdown.is_set():
+                        sys.exit(rc)
+        except KeyboardInterrupt:
+            print("\nInterrupted — terminating download.")
+            _shutdown.set()
+            _terminate_all()
+            os._exit(130)
+        return
+
+    # ---- parallel path -------------------------------------------------
+    failed: list[str] = []
+    pool = ThreadPoolExecutor(max_workers=n_jobs)
+    futures = {
+        pool.submit(sync, name, args.pattern, args.dry_run, progress): name
+        for name in datasets
+    }
+    try:
+        with progress:
+            for fut in as_completed(futures):
+                name = futures[fut]
+                try:
+                    rc = fut.result()
+                except Exception as exc:
+                    progress.console.print(f"[red]\\[{name}] EXCEPTION: {exc}[/red]")
+                    failed.append(name)
+                else:
+                    if rc != 0:
+                        failed.append(name)
+    except KeyboardInterrupt:
+        print("\nInterrupted — terminating all downloads.")
+        _shutdown.set()
+        _terminate_all()
+        pool.shutdown(wait=False, cancel_futures=True)
+        os._exit(130)
+
+    pool.shutdown(wait=True)
+
+    if failed:
+        print(f"Failed datasets: {', '.join(failed)}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/robotic_grounding/visualizer/sync_visualizer_data.py
+++ b/robotic_grounding/visualizer/sync_visualizer_data.py
@@ -34,7 +34,6 @@ from rich.progress import (
     TaskID,
     TextColumn,
     TimeRemainingColumn,
-    TransferSpeedColumn,
 )
 
 # ---------------------------------------------------------------------------
@@ -50,15 +49,15 @@ _RICH_COLORS = ("cyan", "green", "yellow", "magenta", "blue", "red")
 # Regex to parse a tqdm progress line emitted by osmo
 # Matches: "  17%|███  | 181M/1.06G [00:05<00:22, 42.5MB/s, ...]"
 _TQDM_RE = re.compile(
-    r"^\s*(\d+)%\|"               # percentage
+    r"^\s*(\d+)%\|"  # percentage
     r".*?\|\s*"
-    r"([\d.]+\s*\S+)"             # bytes done
+    r"([\d.]+\s*\S+)"  # bytes done
     r"/"
-    r"([\d.]+\s*\S+)"             # bytes total
+    r"([\d.]+\s*\S+)"  # bytes total
     r"\s*\["
-    r"[^,<]+"                     # elapsed
-    r"<?[^,]*"                    # eta
-    r",?\s*([\d.]+\s*\S+/s)?"    # speed (optional)
+    r"[^,<]+"  # elapsed
+    r"<?[^,]*"  # eta
+    r",?\s*([\d.]+\s*\S+/s)?"  # speed (optional)
 )
 
 # Shutdown flag + registry of active subprocesses for Ctrl+C cleanup
@@ -122,12 +121,11 @@ def _stream(
     progress: Progress,
     task_id: TaskID,
 ) -> None:
-    """Read proc stdout+stderr, update the rich task on tqdm lines,
-    and print other lines (errors, info) above the progress bars.
-    """
+    """Read proc stdout+stderr; update rich progress bars and print non-tqdm lines."""
     color = _rich_color(name)
     buf = b""
 
+    assert proc.stdout is not None
     while True:
         chunk = proc.stdout.read(256)
         if not chunk:
@@ -140,9 +138,9 @@ def _stream(
             if ni == -1 and ri == -1:
                 break
             if ni == -1 or (ri != -1 and ri < ni):
-                raw, buf = buf[:ri], buf[ri + 1:]
+                raw, buf = buf[:ri], buf[ri + 1 :]
             else:
-                raw, buf = buf[:ni], buf[ni + 1:]
+                raw, buf = buf[:ni], buf[ni + 1 :]
 
             line = raw.decode(errors="replace").strip()
             if not line:
@@ -162,7 +160,9 @@ def _stream(
 
     if buf.strip():
         line = buf.decode(errors="replace").strip()
-        progress.console.print(f"[{_rich_color(name)}]\\[{name}][/{_rich_color(name)}] {line}")
+        progress.console.print(
+            f"[{_rich_color(name)}]\\[{name}][/{_rich_color(name)}] {line}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -187,16 +187,18 @@ def sync(
     # v2d_{name}_retarget_exp_200/ inside it — which is exactly dest.
     # Delete dest first so osmo creates it fresh without nesting inside itself.
     cmd = [
-        "osmo", "dataset", "download",
+        "osmo",
+        "dataset",
+        "download",
         _osmo_dataset(name),
         str(LOCAL_DATASETS_DIR),
-        "--regex", regex,
+        "--regex",
+        regex,
     ]
 
     color = _rich_color(name)
     progress.console.print(
-        f"[{color}]\\[{name}][/{color}] "
-        f"{_osmo_dataset(name)} [dim]→[/dim] {dest}"
+        f"[{color}]\\[{name}][/{color}] " f"{_osmo_dataset(name)} [dim]→[/dim] {dest}"
     )
 
     if dry_run:
@@ -218,7 +220,7 @@ def sync(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        start_new_session=True,   # own process group → killpg kills all workers
+        start_new_session=True,  # own process group → killpg kills all workers
     )
     with _procs_lock:
         _active_procs.append(proc)
@@ -233,11 +235,16 @@ def sync(
                 pass
 
     if rc == 0:
-        progress.update(task_id, completed=100,
-                        description=f"[{color}]{name:<7}[/{color}] [green]done[/green]")
+        progress.update(
+            task_id,
+            completed=100,
+            description=f"[{color}]{name:<7}[/{color}] [green]done[/green]",
+        )
     elif not _shutdown.is_set():
-        progress.update(task_id,
-                        description=f"[{color}]{name:<7}[/{color}] [red]failed (code {rc})[/red]")
+        progress.update(
+            task_id,
+            description=f"[{color}]{name:<7}[/{color}] [red]failed (code {rc})[/red]",
+        )
     return rc
 
 
@@ -262,7 +269,8 @@ def _parse_args() -> argparse.Namespace:
         help="Extra regex to narrow files within {name}_html/ (e.g. 'arctic_s01').",
     )
     parser.add_argument(
-        "--jobs", "-j",
+        "--jobs",
+        "-j",
         type=str,
         default="1",
         metavar="N|MAX",
@@ -278,6 +286,7 @@ def _parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    """Parse CLI args and run sequential or parallel dataset downloads."""
     args = _parse_args()
     datasets = list(DATASETS) if "all" in args.dataset else args.dataset
 


### PR DESCRIPTION
Adds a self-contained visualizer server for browsing motion-capture retargeting datasets — a split-screen view of viser 3D playback and MP4 camera feed per sequence, served over HTTP with no external Python dependencies.

robotic_grounding/visualizer/serve.py — server

robotic_grounding/visualizer/sync_visualizer_data.py — New OSMO download script

robotic_grounding/visualizer/README.md — New full docs

Supporting changes
- README.md (top-level): added Visualizer quickstart section
- robotic_grounding/.gitignore: exclude visualizer/datasets/ (large binary recordings)
- .envrc: source .envrc.local before setup_css_env.sh so local overrides take precedence
- setup_css_env.sh: use ${CSS_ACCESS_KEY:-REPLACE_ME} so env vars set in .envrc.local are not overwritten 