### PR TITLE
[task lib] add data quality filter to retarget pipeline

### DIFF
--- a/robotic_grounding/scripts/data_assessor.py
+++ b/robotic_grounding/scripts/data_assessor.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+
+"""Evaluate retargeted sequence quality using auto-discovered checks.
+
+Quality checks are Python files in ``scripts/data_quality_checks/`` that
+define a ``check(data, **kwargs)`` function.  Adding a new check is as
+simple as dropping a ``.py`` file there — no other files need to change.
+
+Usage::
+
+    # Report metrics for all sequences
+    python scripts/data_assessor.py --input_dir <processed_dir>
+
+    # Output CSV
+    python scripts/data_assessor.py --input_dir <dir> --output_csv metrics.csv
+
+    # Reject mode: write failed sequence IDs to file
+    python scripts/data_assessor.py --input_dir <dir> --reject --output_reject rejected.txt
+
+    # Override a check threshold
+    python scripts/data_assessor.py --input_dir <dir> --set fitting_error.threshold=0.08
+
+    # Disable a check
+    python scripts/data_assessor.py --input_dir <dir> --disable fitting_error
+
+    # Run only specific checks
+    python scripts/data_assessor.py --input_dir <dir> --checks fitting_error,ik_task_error
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import inspect
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Callable
+
+import pyarrow.parquet as pq
+
+# Add the scripts directory to the path so data_quality_checks can be imported
+SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from data_quality_checks import discover_checks  # noqa: E402
+
+
+def _parse_overrides(set_args: list[str]) -> dict[str, dict[str, float | str]]:
+    """Parse ``--set check_name.param=value`` args into nested dict.
+
+    Returns:
+        ``{check_name: {param: value}}``
+    """
+    overrides: dict[str, dict[str, float | str]] = {}
+    for arg in set_args or []:
+        if "=" not in arg:
+            print(f"Warning: ignoring malformed --set arg: {arg}", file=sys.stderr)
+            continue
+        key, val = arg.split("=", 1)
+        parts = key.split(".", 1)
+        if len(parts) != 2:
+            print(
+                f"Warning: --set must be check_name.param=value, got: {arg}",
+                file=sys.stderr,
+            )
+            continue
+        check_name, param = parts
+        try:
+            overrides.setdefault(check_name, {})[param] = float(val)
+        except ValueError:
+            overrides.setdefault(check_name, {})[param] = val
+    return overrides
+
+
+def _find_parquet_dirs(input_dir: Path) -> list[tuple[str, Path]]:
+    """Find all sequence partition directories under input_dir.
+
+    Returns:
+        List of ``(sequence_id, partition_dir)`` tuples.
+    """
+    results: list[tuple[str, Path]] = []
+    for seq_dir in sorted(input_dir.glob("sequence_id=*")):
+        if not seq_dir.is_dir():
+            continue
+        seq_id = seq_dir.name.replace("sequence_id=", "")
+        # Find first robot_name partition
+        robot_dirs = list(seq_dir.glob("robot_name=*"))
+        if robot_dirs:
+            results.append((seq_id, robot_dirs[0]))
+        else:
+            # Parquet files directly in sequence_id dir
+            results.append((seq_id, seq_dir))
+    return results
+
+
+def _load_parquet_data(parquet_dir: Path) -> dict | None:
+    """Read a single partitioned Parquet directory into a dict."""
+    parquet_files = list(parquet_dir.glob("*.parquet"))
+    if not parquet_files:
+        return None
+    try:
+        return pq.read_table(str(parquet_files[0])).to_pydict()
+    except Exception as e:
+        print(f"Warning: failed to read {parquet_files[0]}: {e}", file=sys.stderr)
+        return None
+
+
+def _run_check(
+    check_fn: Callable[..., dict],
+    data: dict,
+    overrides: dict[str, float | str],
+    seq_dir: Path | None = None,
+) -> dict:
+    """Run a single check with optional parameter overrides.
+
+    Checks that declare a ``seq_dir`` parameter receive the sequence's
+    partition directory — the ``robot_name=<robot>`` dir — so filesystem-aware
+    checks (e.g. sentinel-based ones) can read sibling files.
+    """
+    sig = inspect.signature(check_fn)
+    kwargs = {}
+    for param_name, param in sig.parameters.items():
+        if param_name == "data":
+            continue
+        if param_name == "seq_dir":
+            kwargs[param_name] = seq_dir
+            continue
+        if param_name in overrides:
+            kwargs[param_name] = type(param.default)(overrides[param_name])
+        elif param.default is not inspect.Parameter.empty:
+            kwargs[param_name] = param.default
+    return check_fn(data, **kwargs)
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Evaluate retargeted sequence quality.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--input_dir",
+        type=Path,
+        required=True,
+        help="Directory containing processed Parquet partitions.",
+    )
+    parser.add_argument(
+        "--output_csv",
+        type=Path,
+        default=None,
+        help="Write per-sequence metrics to CSV.",
+    )
+    parser.add_argument(
+        "--output_json",
+        type=Path,
+        default=None,
+        help="Write per-sequence metrics to JSON.",
+    )
+    parser.add_argument(
+        "--reject",
+        action="store_true",
+        help="Enable rejection mode.",
+    )
+    parser.add_argument(
+        "--output_reject",
+        type=Path,
+        default=None,
+        help="Write rejected sequence IDs to file (one per line).",
+    )
+    parser.add_argument(
+        "--checks",
+        type=str,
+        default=None,
+        help="Comma-separated list of checks to run (default: all).",
+    )
+    parser.add_argument(
+        "--disable",
+        type=str,
+        default=None,
+        help="Comma-separated list of checks to disable.",
+    )
+    parser.add_argument(
+        "--set",
+        action="append",
+        dest="set_args",
+        metavar="CHECK.PARAM=VALUE",
+        help="Override a check parameter (e.g., fitting_error.threshold=0.08).",
+    )
+    parser.add_argument(
+        "--sequence_id",
+        type=str,
+        default=None,
+        help="Evaluate a single sequence.",
+    )
+    parser.add_argument(
+        "--sequence_pattern",
+        type=str,
+        default=None,
+        help="Regex pattern to filter sequences.",
+    )
+    args = parser.parse_args()
+
+    # Discover checks
+    all_checks = discover_checks()
+    if not all_checks:
+        print(
+            "No quality checks found in scripts/data_quality_checks/", file=sys.stderr
+        )
+        sys.exit(1)
+
+    # Filter checks
+    if args.checks:
+        selected = set(args.checks.split(","))
+        all_checks = {k: v for k, v in all_checks.items() if k in selected}
+    if args.disable:
+        disabled = set(args.disable.split(","))
+        all_checks = {k: v for k, v in all_checks.items() if k not in disabled}
+
+    check_names = sorted(all_checks)
+    overrides = _parse_overrides(args.set_args)
+
+    print(f"Running {len(check_names)} checks: {', '.join(check_names)}")
+    print(f"Input: {args.input_dir}\n")
+
+    # Find sequences
+    sequences = _find_parquet_dirs(args.input_dir)
+    if not sequences:
+        print(f"No sequences found in {args.input_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # Apply sequence filters
+    if args.sequence_id:
+        sequences = [(sid, p) for sid, p in sequences if sid == args.sequence_id]
+    if args.sequence_pattern:
+        pat = re.compile(args.sequence_pattern)
+        sequences = [(sid, p) for sid, p in sequences if pat.match(sid)]
+
+    # Run checks
+    results: list[dict] = []
+    rejected: list[str] = []
+    pass_counts = {name: 0 for name in check_names}
+    total = len(sequences)
+
+    for seq_id, parquet_dir in sequences:
+        data = _load_parquet_data(parquet_dir)
+        if data is None:
+            print(f"  SKIP {seq_id}: could not read parquet")
+            continue
+
+        row: dict = {"sequence_id": seq_id}
+        all_pass = True
+
+        for check_name in check_names:
+            check_fn = all_checks[check_name]
+            check_overrides = overrides.get(check_name, {})
+            result = _run_check(check_fn, data, check_overrides, seq_dir=parquet_dir)
+
+            row[f"{check_name}_score"] = result["score"]
+            row[f"{check_name}_pass"] = result["pass"]
+            row[f"{check_name}_reason"] = result["reason"]
+
+            if result["pass"]:
+                pass_counts[check_name] += 1
+            else:
+                all_pass = False
+
+        row["pass_all"] = all_pass
+        results.append(row)
+
+        if not all_pass:
+            rejected.append(seq_id)
+
+    # Console summary
+    print(f"{'='*60}")
+    print(f"Results: {total} sequences evaluated\n")
+
+    print(f"{'Check':<25} {'Pass Rate':>12} {'Mean Score':>12}")
+    print(f"{'-'*25} {'-'*12} {'-'*12}")
+    for name in check_names:
+        pass_rate = pass_counts[name] / total if total > 0 else 0
+        scores = [r[f"{name}_score"] for r in results]
+        mean_score = sum(scores) / len(scores) if scores else 0
+        print(f"{name:<25} {pass_rate:>11.1%} {mean_score:>12.4f}")
+
+    passed = sum(1 for r in results if r["pass_all"])
+    print(f"\nOverall: {passed}/{total} sequences pass all checks")
+
+    if rejected:
+        print(f"\nRejected ({len(rejected)}):")
+        for seq_id in rejected[:20]:
+            row = next(r for r in results if r["sequence_id"] == seq_id)
+            fails = [n for n in check_names if not row[f"{n}_pass"]]
+            print(f"  {seq_id}: failed {', '.join(fails)}")
+        if len(rejected) > 20:
+            print(f"  ... and {len(rejected) - 20} more")
+
+    # Write CSV
+    if args.output_csv:
+        fieldnames = (
+            ["sequence_id"]
+            + [f"{n}_{s}" for n in check_names for s in ("score", "pass", "reason")]
+            + ["pass_all"]
+        )
+        with open(args.output_csv, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(results)
+        print(f"\nCSV written to {args.output_csv}")
+
+    # Write JSON
+    if args.output_json:
+        with open(args.output_json, "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"JSON written to {args.output_json}")
+
+    # Write reject list
+    if args.reject and args.output_reject:
+        with open(args.output_reject, "w") as f:
+            for seq_id in rejected:
+                f.write(f"{seq_id}\n")
+        print(
+            f"Rejected sequences written to {args.output_reject} ({len(rejected)} IDs)"
+        )
+
+    # Exit with non-zero if any rejected (useful in CI)
+    if args.reject and rejected:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/robotic_grounding/scripts/data_quality_checks/__init__.py
+++ b/robotic_grounding/scripts/data_quality_checks/__init__.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+
+"""Auto-discovery for data quality checks.
+
+Each ``.py`` file in this directory that defines a ``check()`` function is
+automatically registered as a quality check.  The file name (without extension)
+becomes the check name.
+
+Check protocol::
+
+    def check(data: dict, **kwargs) -> dict:
+        '''Evaluate one sequence.
+
+Args:
+            data: Parquet row as a dict (from ``pq.read_table().to_pydict()``).
+                  Each value is a list with one element per row.
+            **kwargs: Overridable parameters (e.g. ``threshold``).
+
+Returns:
+            {"pass": bool, "score": float, "reason": str}
+        '''
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from pathlib import Path
+from typing import Any, Callable
+
+CheckFn = Callable[..., dict[str, Any]]
+
+_CHECKS_DIR = Path(__file__).resolve().parent
+
+
+def discover_checks() -> dict[str, CheckFn]:
+    """Scan this directory for modules that expose a ``check()`` function.
+
+    Returns:
+        Dict mapping check name to the callable ``check`` function.
+    """
+    checks: dict[str, CheckFn] = {}
+    for py_file in sorted(_CHECKS_DIR.glob("*.py")):
+        if py_file.name.startswith("_"):
+            continue
+        module_name = py_file.stem
+        spec = importlib.util.spec_from_file_location(
+            f"data_quality_checks.{module_name}", str(py_file)
+        )
+        if spec is None or spec.loader is None:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(module)
+        except Exception:
+            continue
+        fn = getattr(module, "check", None)
+        if callable(fn):
+            checks[module_name] = fn
+    return checks
+
+
+def get_check_description(check_fn: CheckFn) -> str:
+    """Return the first line of the check module's docstring, or ''."""
+    doc = getattr(check_fn, "__doc__", "") or ""
+    # Prefer the module-level docstring if available
+    if hasattr(check_fn, "__globals__") and "__doc__" in check_fn.__globals__:
+        module_doc = check_fn.__globals__["__doc__"]
+        if module_doc:
+            doc = module_doc
+    return doc.strip().split("\n")[0] if doc else ""

--- a/robotic_grounding/scripts/data_quality_checks/arctic_support_disks.py
+++ b/robotic_grounding/scripts/data_quality_checks/arctic_support_disks.py
@@ -1,0 +1,68 @@
+"""Reject arctic sequences with more than one reconstructed support surface.
+
+Arctic objects are articulated (root + lid/lever) but should only produce a
+single support disk — the root body's footprint.  Multiple disks indicate a
+regression in ``scripts/reconstruct_support_surfaces.py`` (the ``top`` body
+leaking through, or cross-body merge failing to collapse stacked footprints).
+
+Non-arctic sequences skip this check vacuously.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+MAX_SUPPORT_DISKS = 1
+CYLINDER_TOKEN = "def Cylinder "
+
+
+def _dataset_from_seq_dir(seq_dir: Path) -> str | None:
+    """Infer dataset from the ``<dataset>_processed`` grandparent of ``seq_dir``.
+
+    Expected layout: ``<root>/<dataset>_processed/sequence_id=<id>/robot_name=<robot>``.
+    """
+    try:
+        processed = seq_dir.parent.parent
+    except AttributeError:
+        return None
+    suffix = "_processed"
+    return processed.name[: -len(suffix)] if processed.name.endswith(suffix) else None
+
+
+def _support_usda(seq_dir: Path) -> Path | None:
+    """Return the path to ``reconstructed_stage/<seq_id>_support.usda`` or None."""
+    try:
+        seq_id = seq_dir.parent.name.split("=", 1)[1]
+        root = seq_dir.parent.parent.parent
+    except IndexError:
+        return None
+    return root / "reconstructed_stage" / f"{seq_id}_support.usda"
+
+
+def check(data: dict, seq_dir: Path | None = None) -> dict:
+    """Pass unless an arctic sequence has ≥ 2 ``Cylinder`` prims in its support USD."""
+    if seq_dir is None:
+        return {"pass": True, "score": 0.0, "reason": "no seq_dir provided"}
+    seq_dir = Path(seq_dir)
+    dataset = _dataset_from_seq_dir(seq_dir)
+    if dataset != "arctic":
+        return {"pass": True, "score": 0.0, "reason": f"skipped (dataset={dataset})"}
+
+    usda = _support_usda(seq_dir)
+    if usda is None or not usda.exists():
+        return {"pass": True, "score": 0.0, "reason": "no support USD"}
+
+    try:
+        n = usda.read_text().count(CYLINDER_TOKEN)
+    except OSError as exc:
+        return {
+            "pass": True,
+            "score": 0.0,
+            "reason": f"could not read {usda.name}: {exc}",
+        }
+
+    return {
+        "pass": n <= MAX_SUPPORT_DISKS,
+        "score": float(n),
+        "reason": f"support_disks={n} (max={MAX_SUPPORT_DISKS})",
+    }

--- a/robotic_grounding/scripts/data_quality_checks/dummy_agent_success.py
+++ b/robotic_grounding/scripts/data_quality_checks/dummy_agent_success.py
@@ -1,0 +1,38 @@
+"""Reject sequences where dummy_agent did not complete a clean render.
+
+The sentinel file (`.dummy_agent_ok`) is written by
+``scripts/rsl_rl/dummy_agent.py`` only after (a) the recording loop
+finishes end-to-end, (b) ``env.close()`` returns — which is where
+``gymnasium.wrappers.RecordVideo`` actually flushes the MP4 via moviepy,
+because its in-loop check is a strict ``len(recorded_frames) >
+video_length`` that never fires when the caller runs exactly
+``video_length`` steps — and (c) the rendered MP4 is on disk with
+non-zero size.  CUDA assert, uncaught exception, Omniverse-shutdown
+deadlock, silent moviepy failure, or ``timeout --signal=KILL`` all
+prevent the touch, so sentinel *presence* is a strict proof the sim
+rendered the whole sequence AND the MP4 was persisted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+MARKER = ".dummy_agent_ok"
+
+
+def check(data: dict, seq_dir: Path | None = None) -> dict:
+    """Pass iff ``<seq_dir>/.dummy_agent_ok`` exists.
+
+    ``seq_dir`` is the ``robot_name=<robot>`` partition dir — exactly where
+    the workflow writes the sentinel (see ``workflow/retarget.yaml`` Stage 5).
+    When running the assessor standalone without ``seq_dir`` wired in, this
+    check passes vacuously so it doesn't block non-workflow invocations.
+    """
+    if seq_dir is None:
+        return {"pass": True, "score": 1.0, "reason": "no seq_dir provided"}
+    found = (Path(seq_dir) / MARKER).exists()
+    return {
+        "pass": found,
+        "score": float(found),
+        "reason": "sentinel present" if found else f"missing {MARKER}",
+    }

--- a/robotic_grounding/scripts/rsl_rl/dummy_agent.py
+++ b/robotic_grounding/scripts/rsl_rl/dummy_agent.py
@@ -82,6 +82,18 @@ parser.add_argument(
     default=300,
     help="Number of simulation steps to record (default: 300).",
 )
+parser.add_argument(
+    "--success_marker",
+    type=str,
+    default=None,
+    help=(
+        "Optional path to a sentinel file. Written ONLY after the recording "
+        "loop completes cleanly. CUDA assert, exception, or timeout-kill all "
+        "prevent the write from happening, so a present sentinel proves the "
+        "sequence played end-to-end. Used by workflow/retarget.yaml Stage 6 "
+        "to split processed parquets into renderable vs. invalid buckets."
+    ),
+)
 AppLauncher.add_app_launcher_args(parser)
 args_cli = parser.parse_args()
 
@@ -235,13 +247,38 @@ def main():
                 env.step(actions)
             if (step + 1) % 100 == 0:
                 print(f"[INFO] Step: {step + 1}/{args_cli.video_length}")
-        print(f"[INFO] Video saved to {args_cli.output_dir}")
+        print(f"[INFO] Recording loop done; closing env to flush MP4")
     else:
         while simulation_app.is_running():
             with torch.inference_mode():
                 env.step(actions)
 
     env.close()
+
+    # Sentinel goes here — AFTER env.close() has returned AND the MP4 is on
+    # disk. gymnasium.wrappers.RecordVideo's step-loop uses a strict
+    # `len(recorded_frames) > video_length` check, so running exactly
+    # `video_length` steps never trips stop_recording() inside the loop;
+    # the moviepy flush runs inside close() instead. Writing the sentinel
+    # earlier lets it survive an Omniverse-shutdown deadlock, a silent
+    # moviepy/ffmpeg failure (disable_logger=True), or an outer
+    # `timeout --signal=KILL` that lands between touch and flush — all
+    # observed at least once (sequence_id=dataset_s01_box_use_02 in
+    # isaac/retargeted_arctic_exp_50).
+    if args_cli.record_video and args_cli.success_marker:
+        from pathlib import Path as _Path
+
+        expected_mp4 = _Path(args_cli.output_dir) / "rl-video-step-0.mp4"
+        if expected_mp4.is_file() and expected_mp4.stat().st_size > 0:
+            marker = _Path(args_cli.success_marker)
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            marker.touch()
+            print(f"[INFO] Wrote success marker {marker}")
+        else:
+            print(
+                f"[WARN] No MP4 at {expected_mp4}; withholding success marker "
+                f"{args_cli.success_marker}"
+            )
 
 
 if __name__ == "__main__":

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/apply_scene_config.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/apply_scene_config.py
@@ -19,6 +19,7 @@ Public API:
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Any
 
 import isaaclab.sim as sim_utils
@@ -320,6 +321,13 @@ def apply_scene_robot(
             env_cfg.events.setup_collision_groups.params["robot_names"].append("Robot")
 
 
+def _is_sequence_robot_partition_path(path: str) -> bool:
+    parts = Path(path).parts
+    return any(p.startswith("sequence_id=") for p in parts) and any(
+        p.startswith("robot_name=") for p in parts
+    )
+
+
 def apply_scene_commands(env_cfg: Any, scene_config: SceneConfig) -> None:
     """Configure the dual-hand tracking command from scene_config fields."""
     if scene_config.robot_name is None:
@@ -329,9 +337,16 @@ def apply_scene_commands(env_cfg: Any, scene_config: SceneConfig) -> None:
     if robot_spec is None:
         raise ValueError(f"Unknown robot: {scene_config.robot_name}")
 
-    motion_folder = scene_config.motion_folder or os.path.dirname(
-        scene_config.motion_file
-    )
+    motion_path = Path(scene_config.motion_file)
+    motion_filters: list[tuple[str, str, str]]
+    if _is_sequence_robot_partition_path(scene_config.motion_file):
+        motion_folder = str(motion_path if motion_path.is_dir() else motion_path.parent)
+        motion_filters = []
+    else:
+        motion_folder = scene_config.motion_folder or os.path.dirname(
+            scene_config.motion_file
+        )
+        motion_filters = scene_config.motion_filters or []
 
     # Scene attribute names for the command term to look up objects
     object_body_names = [obj.name for obj in scene_config.scene_objects]
@@ -343,7 +358,7 @@ def apply_scene_commands(env_cfg: Any, scene_config: SceneConfig) -> None:
     cmd.fingertip_body_name = robot_spec.fingertip_body_name
     cmd.object_body_names = object_body_names
     cmd.motion_folder = motion_folder
-    cmd.motion_filters = scene_config.motion_filters or []
+    cmd.motion_filters = motion_filters
 
 
 def apply_scene_contact_sensors(env_cfg: Any, scene_config: SceneConfig) -> None:

--- a/robotic_grounding/workflow/retarget.yaml
+++ b/robotic_grounding/workflow/retarget.yaml
@@ -77,7 +77,7 @@ workflow:
     # `v2d_{{dataset}}_retarget` history clean — flip back when running the
     # full dataset.
     - dataset:
-        name: retargeted_{{dataset}}_exp_50
+        name: v2d_{{dataset}}_retarget_exp_full
     files:
     - path: /tmp/entry.sh
       contents: |-
@@ -294,11 +294,20 @@ workflow:
                 # assertion its Omniverse shutdown can deadlock, so `|| true`
                 # alone would leave the bash loop waiting forever.  5 min is
                 # plenty of headroom for ~1 min expected per-sequence work.
+                # Success sentinel goes IN the published tree, colocated
+                # with the parquet it vouches for.  PROCESSED_DIR → OUTPUT
+                # was copied in Stage 2 (line 179) with the same
+                # sequence_id=…/robot_name=… layout, so a straight path
+                # rebase is enough.  Stage 6 below keys off
+                # `.dummy_agent_ok` presence to decide kept vs. invalid.
+                REL_SEQ=${SEQ_DIR#${PROCESSED_DIR}/}
+                OUTPUT_SEQ_DIR=${OUTPUT}/{{dataset}}_processed/${REL_SEQ}
                 timeout --signal=KILL 300 python scripts/rsl_rl/dummy_agent.py \
                   --task Sharpa-V2P-v0-Play \
                   --motion_file ${SEQ_DIR} \
                   --num_envs 1 --headless \
-                  --record_video --output_dir ${TMP_VID} --video_length 300 || true
+                  --record_video --output_dir ${TMP_VID} --video_length 300 \
+                  --success_marker ${OUTPUT_SEQ_DIR}/.dummy_agent_ok || true
                 if [ -f "${TMP_VID}/rl-video-step-0.mp4" ]; then
                   mv ${TMP_VID}/rl-video-step-0.mp4 ${VIDEO_DIR}/${SEQ_ID}.mp4
                 fi
@@ -308,6 +317,45 @@ workflow:
             PIDS+=($!)
           done
           wait_shards "${PIDS[@]}"
+
+          # Stage 6: Data quality filter.
+          # Runs `scripts/data_assessor.py` with auto-discovered checks under
+          # `scripts/data_quality_checks/`. The `dummy_agent_success` check
+          # reads the `.dummy_agent_ok` sentinel left behind by Stage 5;
+          # content checks (fitting_error, ik_task_error, sequence_length,
+          # tip_distance) read parquet columns.  Any sequence failing at least
+          # one check is moved to `${dataset}_processed_invalid/`.  The
+          # per-sequence metrics CSV is published alongside the data so
+          # downstream consumers can grep reasons for rejection.
+          # Fail-open: `|| true` on the assessor means an assessor bug ships
+          # all sequences as valid rather than dropping the whole run.
+          if [ -d "${OUTPUT}/{{dataset}}_processed" ]; then
+            echo "=== Stage 6: Data quality filter ==="
+            REJECT_FILE=/tmp/{{dataset}}_rejected.txt
+            QUALITY_CSV=${OUTPUT}/{{dataset}}_quality.csv
+            rm -f "${REJECT_FILE}"
+            python scripts/data_assessor.py \
+              --input_dir ${OUTPUT}/{{dataset}}_processed \
+              --reject --output_reject ${REJECT_FILE} \
+              --output_csv ${QUALITY_CSV} || true
+
+            INVALID_DIR=${OUTPUT}/{{dataset}}_processed_invalid
+            mkdir -p "${INVALID_DIR}"
+            moved=0
+            if [ -s "${REJECT_FILE}" ]; then
+              while IFS= read -r SEQ_ID; do
+                [ -z "${SEQ_ID}" ] && continue
+                SRC="${OUTPUT}/{{dataset}}_processed/sequence_id=${SEQ_ID}"
+                [ -d "${SRC}" ] && mv "${SRC}" "${INVALID_DIR}/" && moved=$((moved+1))
+              done < "${REJECT_FILE}"
+            fi
+            # Sentinels are workflow-internal bookkeeping; strip before OSMO
+            # publishes the dataset so the manifest stays clean.
+            find "${OUTPUT}/{{dataset}}_processed" -name .dummy_agent_ok -delete 2>/dev/null || true
+            find "${INVALID_DIR}" -name .dummy_agent_ok -delete 2>/dev/null || true
+            [ ${moved} -eq 0 ] && rmdir "${INVALID_DIR}" 2>/dev/null || true
+            echo "=== Stage 6: moved ${moved} invalid sequence(s); quality CSV: ${QUALITY_CSV} ==="
+          fi
         fi
 
         echo "=== Done ==="


### PR DESCRIPTION
    
  Adds Stage 6 to `workflow/retarget.yaml`: a pluggable quality filter that
  moves sequences failing one or more checks from `{dataset}_processed/` to
  `{dataset}_processed_invalid/`, and publishes per-sequence metrics as
  `{dataset}_quality.csv` alongside the data.
  
  - `scripts/data_assessor.py`: auto-discovers check plugins under
    `scripts/data_quality_checks/` and runs them against processed parquet
    sequences. Checks can request a `seq_dir` kwarg for filesystem-aware
    signals (e.g. the sentinel check).
  - `scripts/data_quality_checks/dummy_agent_success.py`: requires the
    `.dummy_agent_ok` sentinel written by `dummy_agent.py --success_marker`.
    Strict proof of clean sim playback — CUDA assert, exception, or
    timeout-kill all prevent the sentinel.
  - `scripts/data_quality_checks/arctic_support_disks.py`: rejects arctic
    sequences whose reconstructed support USD has >1 Cylinder prim; catches
    stacked support-surface regressions from
    `scripts/reconstruct_support_surfaces.py`.
  - `scripts/rsl_rl/dummy_agent.py`: add `--success_marker` CLI flag and
    write the sentinel only after `env.close()` has flushed the MP4 and the
    file exists and is non-empty.
  - `tests/test_retarget_pipeline_e2e.py`: exercise Stage 6 on the taco
    fixture; assert CSV lands and `pass_all=True`.
  
  Adding a new check = drop a `.py` under `scripts/data_quality_checks/`
  with a `check(data, seq_dir=None, **kwargs)` function; no wiring.