### PR TITLE
adaptive curriculum + eval pipeline improvements

### DIFF
--- a/robotic_grounding/experiments/run_experiment.py
+++ b/robotic_grounding/experiments/run_experiment.py
@@ -229,6 +229,7 @@ def generate_single_task_workflow(
     # Derive motion_file from OSMO dataset path when motion_data_url is set, matching
     # the behaviour of generate_multi_sequence_workflow so single-sequence relaunch
     # batches use the same path format as the original multi-sequence workflow.
+    urdfs_src_path = None
     if (
         motion_file is None
         and motion_data_url
@@ -237,8 +238,15 @@ def generate_single_task_workflow(
     ):
         seq_id = config["sequences"][0]
         dataset_name = motion_data_url.rstrip("/").split("/")[-1]
-        dataset_seq_id = seq_id.replace("arctic_", "dataset_", 1)
-        motion_file = f"{{{{input:0}}}}/{dataset_name}/arctic_processed/sequence_id={dataset_seq_id}/robot_name=sharpa_wave"
+        sequences_subfolder = osmo_cfg.get("sequences_subfolder", "arctic_processed")
+        if sequences_subfolder == "arctic_processed":
+            dataset_seq_id = seq_id.replace("arctic_", "dataset_", 1)
+        else:
+            dataset_seq_id = seq_id
+        motion_file = f"{{{{input:0}}}}/{dataset_name}/{sequences_subfolder}/sequence_id={dataset_seq_id}/robot_name=sharpa_wave"
+        urdfs_subfolder = osmo_cfg.get("urdfs_subfolder")
+        if urdfs_subfolder:
+            urdfs_src_path = f"{{{{input:0}}}}/{dataset_name}/{urdfs_subfolder}"
 
     entry = make_entry_script(
         run_name,
@@ -255,6 +263,7 @@ def generate_single_task_workflow(
         zero_actor=zero_actor,
         use_primitive_urdfs=use_primitive_urdfs,
         use_timestamp=True,
+        urdfs_src_path=urdfs_src_path,
     )
     # Escape for YAML literal block
     entry_indent = "\n".join("        " + line for line in entry.split("\n"))
@@ -357,14 +366,27 @@ def generate_multi_sequence_workflow(
 
         if motion_data_url:
             dataset_name = motion_data_url.rstrip("/").split("/")[-1]
-            dataset_seq_id = seq_id.replace("arctic_", "dataset_", 1)
-            motion_file = f"{{{{input:0}}}}/{dataset_name}/arctic_processed/sequence_id={dataset_seq_id}/robot_name=sharpa_wave"
+            sequences_subfolder = osmo_cfg.get(
+                "sequences_subfolder", "arctic_processed"
+            )
+            if sequences_subfolder == "arctic_processed":
+                dataset_seq_id = seq_id.replace("arctic_", "dataset_", 1)
+            else:
+                dataset_seq_id = seq_id
+            motion_file = f"{{{{input:0}}}}/{dataset_name}/{sequences_subfolder}/sequence_id={dataset_seq_id}/robot_name=sharpa_wave"
             inputs_block = (
                 "\n    inputs:\n" "    - dataset:\n" f"        name: {dataset_name}\n"
+            )
+            urdfs_subfolder = osmo_cfg.get("urdfs_subfolder")
+            urdfs_src_path = (
+                f"{{{{input:0}}}}/{dataset_name}/{urdfs_subfolder}"
+                if urdfs_subfolder
+                else None
             )
         else:
             motion_file = f"arctic/arctic_processed/{seq_id}/sharpa_wave"
             inputs_block = ""
+            urdfs_src_path = None
 
         entry = make_entry_script(
             run_name,
@@ -382,6 +404,7 @@ def generate_multi_sequence_workflow(
             log_project_name=project,
             use_primitive_urdfs=use_primitive_urdfs,
             use_timestamp=True,
+            urdfs_src_path=urdfs_src_path,
         )
         entry_indent = "\n".join("        " + line for line in entry.split("\n"))
         task_name = f"train-{seq_key.replace('_', '-')}"

--- a/robotic_grounding/experiments/run_experiment.py
+++ b/robotic_grounding/experiments/run_experiment.py
@@ -217,6 +217,10 @@ def generate_single_task_workflow(
         overrides = {**overrides, **osmo_cfg["run_name_overrides"]}
     seed = config.get("seed")
     video = config.get("video", True)
+    eval_video_only = config.get("eval_video_only", False)
+    video_length = config.get("video_length")
+    video_interval = config.get("video_interval")
+    eval_episodes_per_save = config.get("eval_episodes_per_save", 0)
     motion_file = config.get("motion_file")
     num_envs = config.get("num_envs")
     max_iterations = config.get("max_iterations")
@@ -258,6 +262,10 @@ def generate_single_task_workflow(
         num_envs=num_envs,
         max_iterations=max_iterations,
         video=video,
+        eval_video_only=eval_video_only,
+        video_length=video_length,
+        video_interval=video_interval,
+        eval_episodes_per_save=eval_episodes_per_save,
         task=task,
         logger=logger,
         log_project_name=log_project_name,
@@ -478,6 +486,10 @@ def _print_workflow(exp_id: str, config: dict) -> None:
         resume_from = None
     seed = config.get("seed")
     video = config.get("video", True)
+    eval_video_only = config.get("eval_video_only", False)
+    video_length = config.get("video_length")
+    video_interval = config.get("video_interval")
+    eval_episodes_per_save = config.get("eval_episodes_per_save", 0)
     motion_file = config.get("motion_file")
     num_envs = config.get("num_envs")
     max_iterations = config.get("max_iterations")
@@ -497,6 +509,10 @@ def _print_workflow(exp_id: str, config: dict) -> None:
         num_envs=num_envs,
         max_iterations=max_iterations,
         video=video,
+        eval_video_only=eval_video_only,
+        video_length=video_length,
+        video_interval=video_interval,
+        eval_episodes_per_save=eval_episodes_per_save,
         task=task,
         logger=logger,
         log_project_name=log_project_name,

--- a/robotic_grounding/experiments/run_experiment.py
+++ b/robotic_grounding/experiments/run_experiment.py
@@ -223,7 +223,22 @@ def generate_single_task_workflow(
     zero_actor = config.get("zero_actor", False)
     use_primitive_urdfs = config.get("use_primitive_urdfs", False)
     logger = config.get("logger", "wandb")
-    log_project_name = config.get("log_project_name", "v2p_hands")
+    log_project_name = config.get("wandb_project") or config.get(
+        "log_project_name", "v2p_hands"
+    )
+    # Derive motion_file from OSMO dataset path when motion_data_url is set, matching
+    # the behaviour of generate_multi_sequence_workflow so single-sequence relaunch
+    # batches use the same path format as the original multi-sequence workflow.
+    if (
+        motion_file is None
+        and motion_data_url
+        and "sequences" in config
+        and config["sequences"]
+    ):
+        seq_id = config["sequences"][0]
+        dataset_name = motion_data_url.rstrip("/").split("/")[-1]
+        dataset_seq_id = seq_id.replace("arctic_", "dataset_", 1)
+        motion_file = f"{{{{input:0}}}}/{dataset_name}/arctic_processed/sequence_id={dataset_seq_id}/robot_name=sharpa_wave"
 
     entry = make_entry_script(
         run_name,
@@ -309,7 +324,7 @@ def _seq_to_key(seq_id: str) -> str:
 
 
 def generate_multi_sequence_workflow(
-    exp_id: str, config: dict, overrides: dict[str, str]
+    exp_id: str, config: dict, overrides: dict[str, str], workflow_label: str = ""
 ) -> str:
     """Generate a multi-task OSMO workflow for single-stage configs with multiple sequences.
 
@@ -327,6 +342,7 @@ def generate_multi_sequence_workflow(
     eval_episodes_per_save = config.get("eval_episodes_per_save", 0)
     seed = config.get("seed")
     num_envs = config.get("num_envs")
+    task = config.get("task", "Sharpa-V2P-v0")
     use_primitive_urdfs = config.get("use_primitive_urdfs", False)
     wandb_api_key = os.environ.get("WANDB_API_KEY", "")
     if not wandb_api_key:
@@ -361,6 +377,7 @@ def generate_multi_sequence_workflow(
             video_length=video_length,
             video_interval=video_interval,
             eval_episodes_per_save=eval_episodes_per_save,
+            task=task,
             logger="wandb",
             log_project_name=project,
             use_primitive_urdfs=use_primitive_urdfs,
@@ -403,7 +420,7 @@ def generate_multi_sequence_workflow(
         f"{tasks_str}\n"
         f"\n"
         f"default-values:\n"
-        f"  workflow_name: robotic_grounding_{exp_id}\n"
+        f"  workflow_name: robotic_grounding_{exp_id}{'_' + workflow_label if workflow_label else ''}\n"
         f"  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:latest\n"
     )
 
@@ -490,6 +507,7 @@ def run_osmo(
     image: str | None = None,
     priority: str = "NORMAL",
     dry_run: bool = False,
+    workflow_label: str = "",
 ) -> None:
     """Generate workflow YAML and submit to OSMO via run_osmo.py."""
     if not dry_run:
@@ -514,7 +532,9 @@ def run_osmo(
         workflow_content = generator(exp_id, config)
     elif "sequences" in config and len(config["sequences"]) > 1:
         _, overrides = get_effective_overrides(config, osmo=True)
-        workflow_content = generate_multi_sequence_workflow(exp_id, config, overrides)
+        workflow_content = generate_multi_sequence_workflow(
+            exp_id, config, overrides, workflow_label
+        )
     else:
         run_name, overrides = get_effective_overrides(config, osmo=True)
         if "osmo" in config and "run_name_suffix" in config["osmo"]:
@@ -545,6 +565,8 @@ def run_osmo(
             exp_name = "exp10_sequence_parallel"
         elif exp_id == "exp11":
             exp_name = "exp11_zeroinit"
+        if workflow_label:
+            exp_name = f"{exp_name}_{workflow_label}"
         cmd = [
             sys.executable,
             str(run_osmo_py),
@@ -910,8 +932,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--pool",
-        default="isaac-dev-l40s-04",
-        help="OSMO pool (default: isaac-dev-l40s-04)",
+        default=None,
+        help="OSMO pool (default: from config osmo.pool, or isaac-dev-l40s-04)",
     )
     parser.add_argument(
         "--build-image", action="store_true", help="Build and push image before OSMO"
@@ -944,6 +966,11 @@ def main() -> None:
         "--run-name-prefix",
         default=None,
         help="Prefix to prepend to W&B run names (e.g. 'exp48_')",
+    )
+    parser.add_argument(
+        "--workflow-label",
+        default="",
+        help="Label appended to the OSMO workflow name for descriptive identification (e.g. 'init', 'rerun_2')",
     )
     args = parser.parse_args()
 
@@ -993,14 +1020,17 @@ def main() -> None:
         # Image precedence: CLI --image > config osmo.image > (auto-derived from exp_id
         # when --build-image and nothing else is set, see run_osmo) > workflow YAML default.
         image = args.image or osmo_cfg.get("image")
+        pool = args.pool or osmo_cfg.get("pool", "isaac-dev-l40s-04")
+        priority = args.priority or osmo_cfg.get("priority", "NORMAL")
         run_osmo(
             args.exp_id,
             config,
-            pool=args.pool,
+            pool=pool,
             build_image=build_image,
             image=image,
-            priority=args.priority,
+            priority=priority,
             dry_run=args.dry_run,
+            workflow_label=args.workflow_label,
         )
     elif args.wandb_sweep_create:
         create_wandb_sweep(args.exp_id, config)

--- a/robotic_grounding/experiments/run_experiment.py
+++ b/robotic_grounding/experiments/run_experiment.py
@@ -322,6 +322,9 @@ def generate_multi_sequence_workflow(
     project = config.get("wandb_project", "v2p_hands")
     eval_video_only = config.get("eval_video_only", False)
     video = config.get("video", True)
+    video_length = config.get("video_length")
+    video_interval = config.get("video_interval")
+    eval_episodes_per_save = config.get("eval_episodes_per_save", 0)
     seed = config.get("seed")
     num_envs = config.get("num_envs")
     use_primitive_urdfs = config.get("use_primitive_urdfs", False)
@@ -355,6 +358,9 @@ def generate_multi_sequence_workflow(
             num_envs=num_envs,
             video=video,
             eval_video_only=eval_video_only,
+            video_length=video_length,
+            video_interval=video_interval,
+            eval_episodes_per_save=eval_episodes_per_save,
             logger="wandb",
             log_project_name=project,
             use_primitive_urdfs=use_primitive_urdfs,

--- a/robotic_grounding/experiments/run_experiment.py
+++ b/robotic_grounding/experiments/run_experiment.py
@@ -191,6 +191,7 @@ def generate_single_task_workflow(
 ) -> str:
     """Generate OSMO workflow YAML for a single training task."""
     osmo_cfg = config.get("osmo", {})
+    storage_gi = osmo_cfg.get("storage_gi", 200)
     # OSMO runs in a fresh container; local checkpoint paths don't exist.
     # - osmo.resume_from: false -> train from scratch
     # - osmo.resume_from: "<local path>" -> upload via dataset input (localpath) at submit time
@@ -298,7 +299,7 @@ workflow:
       cpu: 6
       gpu: 1
       memory: 120Gi
-      storage: 200Gi
+      storage: {storage_gi}Gi
 
   tasks:
   - name: train
@@ -341,6 +342,7 @@ def generate_multi_sequence_workflow(
     """
     sequences = config.get("sequences", [])
     osmo_cfg = config.get("osmo", {})
+    storage_gi = osmo_cfg.get("storage_gi", 200)
     motion_data_url = osmo_cfg.get("motion_data_url")
     run_name_suffix = config.get("run_name_suffix", exp_id)
     project = config.get("wandb_project", "v2p_hands")
@@ -437,7 +439,7 @@ def generate_multi_sequence_workflow(
         f"      cpu: 6\n"
         f"      gpu: 1\n"
         f"      memory: 120Gi\n"
-        f"      storage: 200Gi\n"
+        f"      storage: {storage_gi}Gi\n"
         f"\n"
         f"  tasks:\n"
         f"{tasks_str}\n"

--- a/robotic_grounding/experiments/utils.py
+++ b/robotic_grounding/experiments/utils.py
@@ -139,6 +139,7 @@ def make_entry_script(
     log_project_name: str = "v2p_hands",
     zero_actor: bool = False,
     use_primitive_urdfs: bool = False,
+    urdfs_src_path: str | None = None,
 ) -> str:
     """Generate /tmp/entry.sh content for OSMO."""
     # Pass run_name (suffix only) to train; train.py adds its own timestamp to avoid duplication.
@@ -146,6 +147,14 @@ def make_entry_script(
         "set -ex",
         "",
     ]
+    if urdfs_src_path:
+        lines += [
+            # Generate all TACO rigid URDFs + visual STL meshes from *_cm.obj files in
+            # the image. Produces workspace assets/urdfs/taco/ + assets/meshes/taco/ with
+            # correct relative mesh paths — no OSMO cp needed.
+            "python scripts/generate_rigid_urdfs.py --dataset taco",
+            "",
+        ]
     cmd = build_train_command(
         run_name,
         overrides,

--- a/robotic_grounding/experiments/utils.py
+++ b/robotic_grounding/experiments/utils.py
@@ -70,6 +70,9 @@ def build_train_command(
     headless: bool = True,
     video: bool = True,
     eval_video_only: bool = False,
+    video_length: int | None = None,
+    video_interval: int | None = None,
+    eval_episodes_per_save: int = 0,
     task: str = "Sharpa-V2P-v0",
     logger: str | None = None,
     log_project_name: str | None = None,
@@ -92,6 +95,12 @@ def build_train_command(
     cmd = [c for c in cmd if c]  # drop empty
     if eval_video_only:
         cmd.append("--eval_video_only")
+    if video_length is not None:
+        cmd.extend(["--video_length", str(video_length)])
+    if video_interval is not None:
+        cmd.extend(["--video_interval", str(video_interval)])
+    if eval_episodes_per_save > 0:
+        cmd.extend(["--eval_episodes_per_save", str(eval_episodes_per_save)])
     if resume_from:
         cmd.extend(["--resume", "--checkpoint", resume_from])
     if seed is not None:
@@ -122,6 +131,9 @@ def make_entry_script(
     use_timestamp: bool = True,
     video: bool = True,
     eval_video_only: bool = False,
+    video_length: int | None = None,
+    video_interval: int | None = None,
+    eval_episodes_per_save: int = 0,
     task: str = "Sharpa-V2P-v0",
     logger: str = "wandb",
     log_project_name: str = "v2p_hands",
@@ -144,6 +156,9 @@ def make_entry_script(
         max_iterations=max_iterations,
         video=video,
         eval_video_only=eval_video_only,
+        video_length=video_length,
+        video_interval=video_interval,
+        eval_episodes_per_save=eval_episodes_per_save,
         task=task,
         logger=logger,
         log_project_name=log_project_name,

--- a/robotic_grounding/scripts/rsl_rl/eval.py
+++ b/robotic_grounding/scripts/rsl_rl/eval.py
@@ -364,10 +364,10 @@ def main(
         data = completed[:eval_episodes]
         lens = [e[0] for e in data]
         traj_len = _cmd.retargeted_horizon
-        # Subtract warm-start steps from ep_len; cap at traj_len to keep ratio in [0, 1]
-        ratios = [
-            min(max(e[0] - _warmup, 0), traj_len) / max(traj_len, 1) for e in data
-        ]
+        # Ratio = post-warmup steps / post-warmup trajectory length so a perfectly
+        # completing episode always gives ratio = 1.0.
+        _usable = max(traj_len - _warmup, 1)
+        ratios = [min(max(e[0] - _warmup, 0), _usable) / _usable for e in data]
         full = sum(1 for r in ratios if r >= 0.99)
         mean_len = sum(lens) / len(lens)
         std_len = (

--- a/robotic_grounding/scripts/rsl_rl/eval.py
+++ b/robotic_grounding/scripts/rsl_rl/eval.py
@@ -141,6 +141,7 @@ except ImportError:
 import isaaclab_tasks  # noqa: F401
 import robotic_grounding.tasks  # noqa: F401
 from robotic_grounding.tasks.scene_utils import SceneConfig, apply_scene_config
+from viewer_utils import autoframe_viewer
 
 from isaaclab_tasks.utils import get_checkpoint_path
 from isaaclab_tasks.utils.hydra import hydra_task_config
@@ -172,12 +173,14 @@ def main(
         apply_scene_config(
             env_cfg, scene_config, use_primitive_urdfs=args_cli.use_primitive_urdfs
         )
+        autoframe_viewer(env_cfg, scene_config.motion_file)
     elif args_cli.scene_config is not None:
         env_cfg.scene_config_path = args_cli.scene_config
         scene_config = SceneConfig.from_yaml(args_cli.scene_config)
         apply_scene_config(
             env_cfg, scene_config, use_primitive_urdfs=args_cli.use_primitive_urdfs
         )
+        autoframe_viewer(env_cfg, scene_config.motion_file)
 
     # set the environment seed
     # note: certain randomizations occur in the environment initialization so we set the seed here

--- a/robotic_grounding/scripts/rsl_rl/eval_batch.py
+++ b/robotic_grounding/scripts/rsl_rl/eval_batch.py
@@ -148,9 +148,8 @@ def main(env_cfg: ManagerBasedRLEnvCfg, agent_cfg):
                     my_ep_tracking_len[i] = _cmd.tracking_lengths[i].float()
 
         data = completed[: args_cli.eval_episodes]
-        ratios = [
-            min(max(e[0] - _warmup, 0), traj_len) / max(traj_len, 1) for e in data
-        ]
+        _usable = max(traj_len - _warmup, 1)
+        ratios = [min(max(e[0] - _warmup, 0), _usable) / _usable for e in data]
         n_full = sum(1 for r in ratios if r >= 0.99)
         mean_r = sum(ratios) / len(ratios)
         std_r = (

--- a/robotic_grounding/scripts/rsl_rl/eval_batch.py
+++ b/robotic_grounding/scripts/rsl_rl/eval_batch.py
@@ -57,6 +57,7 @@ from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper
 import isaaclab_tasks  # noqa: F401
 import robotic_grounding.tasks  # noqa: F401
 from robotic_grounding.tasks.scene_utils import SceneConfig, apply_scene_config
+from viewer_utils import autoframe_viewer
 
 from isaaclab_tasks.utils.hydra import hydra_task_config
 
@@ -88,6 +89,7 @@ def main(env_cfg: ManagerBasedRLEnvCfg, agent_cfg):
     if env_cfg.motion_file is not None:
         scene_cfg = SceneConfig.from_motion_file(env_cfg.motion_file)
         apply_scene_config(env_cfg, scene_cfg)
+        autoframe_viewer(env_cfg, scene_cfg.motion_file)
     env_cfg.seed = agent_cfg.seed
     env_cfg.sim.device = args_cli.device if args_cli.device else env_cfg.sim.device
 

--- a/robotic_grounding/scripts/rsl_rl/eval_callback.py
+++ b/robotic_grounding/scripts/rsl_rl/eval_callback.py
@@ -80,21 +80,26 @@ class EvalCallback:
 
         obs = self.env.get_observations()
 
+        # ── Save training state that eval steps would contaminate ──────────── #
+        # All three are restored unconditionally in the finally block so that
+        # training resumes with exactly the state it had before the checkpoint.
+        import copy as _copy
+
+        _saved_episode_sums = {
+            k: v.clone()
+            for k, v in self._isaac_env.reward_manager._episode_sums.items()
+        }
+        _saved_metrics = {k: v.clone() for k, v in self._cmd.metrics.items()}
+        _saved_cws_buf = (
+            _copy.copy(self._cmd._cws_reward_step_buf)
+            if hasattr(self._cmd, "_cws_reward_step_buf")
+            else None
+        )
+
         # Force all resets to start from the first trajectory frame for the
         # duration of eval; restored unconditionally in the finally block below.
         _orig_reset_to_first = self._cmd.cfg.always_reset_to_first_frame
         self._cmd.cfg.always_reset_to_first_frame = True
-
-        # --- Warm-up: step until every env has completed at least one episode ---
-        # This ensures the episodes we collect started from a genuine reset, not
-        # mid-episode when the callback fired.
-        env_reset_once = torch.zeros(num_envs, dtype=torch.bool, device=device)
-        while not env_reset_once.all():
-            with torch.inference_mode():
-                actions = policy(obs)
-                obs, _, dones, _ = self.env.step(actions)
-                policy_nn.reset(dones)
-            env_reset_once |= dones.bool()
 
         # --- Collect eval_episodes clean episodes + drain recording ---
         # Allocate state tensors before the try so they're accessible after the
@@ -107,21 +112,34 @@ class EvalCallback:
         completed: list[tuple[float, float]] = []
 
         try:
+            # --- Warm-up: step until every env has completed at least one episode ---
+            # This ensures the episodes we collect started from a genuine reset, not
+            # mid-episode when the callback fired.
+            env_reset_once = torch.zeros(num_envs, dtype=torch.bool, device=device)
+            while not env_reset_once.all():
+                with torch.inference_mode():
+                    actions = policy(obs)
+                    obs, _, dones, _ = self.env.step(actions)
+                    policy_nn.reset(dones)
+                env_reset_once |= dones.bool()
             # --- Trigger video recording for the upcoming eval rollout ---
             # Redirect RecordVideo to videos/eval so the clip is logged separately
             # from training videos (uploaded as eval/video rather than train/video).
             # Done inside try so the finally always restores video_folder, even if
             # the eval loop or drain throws (e.g. CUDA OOM, moviepy write error).
-            if self.log_video:
-                if self._record_video_env is not None:
-                    self._record_video_env.video_folder = self._eval_video_folder
-                self._isaac_env.eval_video_trigger_pending = True
+            if self.log_video and self._record_video_env is not None:
+                self._record_video_env.video_folder = self._eval_video_folder
 
             # After warmup each env's episode is at some arbitrary midpoint.  We
             # discard each env's first post-warmup episode (the "tail"), then count
             # only full episodes that started fresh.  tracking_length is captured at
             # the START of each fresh episode so the per-episode denominator is
             # correct regardless of random start offsets.
+            #
+            # Video recording is triggered when the first tail ends — at that moment
+            # the env resets to tc=0 (always_reset_to_first_frame=True), so the
+            # recording captures a genuine from-frame-0 fresh episode.
+            _video_triggered = False
             while len(completed) < self.eval_episodes:
                 with torch.inference_mode():
                     actions = policy(obs)
@@ -142,6 +160,11 @@ class EvalCallback:
                             # Tail of a mid-episode that pre-dated the warmup end;
                             # mark done so the NEXT episode is recorded.
                             env_first_done[i] = True
+                            # The env just reset to tc=0; trigger recording now so
+                            # the video captures a fresh from-frame-0 episode.
+                            if self.log_video and not _video_triggered:
+                                self._isaac_env.eval_video_trigger_pending = True
+                                _video_triggered = True
                         my_ep_len[i] = 0.0
                         # Capture tracking_length for the new episode that just started.
                         my_ep_max_len[i] = self._cmd.tracking_lengths[i].float()
@@ -171,10 +194,46 @@ class EvalCallback:
 
         finally:
             self._cmd.cfg.always_reset_to_first_frame = _orig_reset_to_first
-            # Flush and zero all episode reward sums so that inference-mode steps
-            # accumulated during eval don't bleed into the first training batch's
-            # episode-reward logs (which would cause a spurious peak every save_interval).
-            self._isaac_env.reward_manager.log(env_ids=slice(None))
+
+            # ── Restore training state saved before eval ───────────────────── #
+            # Restoring (not flushing) avoids both spikes AND dips:
+            # • _episode_sums: eval steps accumulated inference-mode rewards;
+            #   restore pre-eval sums so the next training episode completion logs
+            #   the correct partial-episode reward, not zero or eval-quality values.
+            #   (The previous fix called reward_manager.log() which does not exist —
+            #   AttributeError silently aborted the entire finally block every time.)
+            for k, v in _saved_episode_sums.items():
+                if k in self._isaac_env.reward_manager._episode_sums:
+                    self._isaac_env.reward_manager._episode_sums[k].copy_(v)
+            # • self._cmd.metrics: _update_metrics() runs inside command_manager.compute()
+            #   which is called AFTER _reset_idx in each env.step(). The first training
+            #   episode reset therefore logs metrics from the *last eval step* (inference-
+            #   mode, better performance) → spike in every Metrics/* key.
+            for k, v in _saved_metrics.items():
+                if k in self._cmd.metrics:
+                    self._cmd.metrics[k].copy_(v)
+            # • _cws_reward_step_buf: deque(maxlen=200) filled entirely with eval values
+            #   → contact_wrench_support_reward_cv wrong for 200 training steps.
+            if _saved_cws_buf is not None and hasattr(
+                self._cmd, "_cws_reward_step_buf"
+            ):
+                self._cmd._cws_reward_step_buf.clear()
+                self._cmd._cws_reward_step_buf.extend(_saved_cws_buf)
+
+            # Restore policy to train mode.  get_inference_policy() calls
+            # alg.eval_mode(); RSL-RL only calls train_mode() once at the start of
+            # learn(), so without this the network stays in eval mode for all
+            # subsequent training iterations after the first checkpoint.
+            try:
+                self.runner.alg.train_mode()
+            except AttributeError:
+                pass
+
+            # Clear stale extras["log"]: the last eval-step reset left episode
+            # metrics from inference mode in this dict; it persists until the next
+            # training reset overwrites it, so the RSL-RL logger would process it.
+            self._isaac_env.extras["log"] = dict()
+
             # Always restore the train video folder and clear any unconsumed pending
             # trigger, regardless of whether an exception occurred above.
             if self.log_video:

--- a/robotic_grounding/scripts/rsl_rl/eval_callback.py
+++ b/robotic_grounding/scripts/rsl_rl/eval_callback.py
@@ -171,6 +171,10 @@ class EvalCallback:
 
         finally:
             self._cmd.cfg.always_reset_to_first_frame = _orig_reset_to_first
+            # Flush and zero all episode reward sums so that inference-mode steps
+            # accumulated during eval don't bleed into the first training batch's
+            # episode-reward logs (which would cause a spurious peak every save_interval).
+            self._isaac_env.reward_manager.log(env_ids=slice(None))
             # Always restore the train video folder and clear any unconsumed pending
             # trigger, regardless of whether an exception occurred above.
             if self.log_video:

--- a/robotic_grounding/scripts/rsl_rl/eval_callback.py
+++ b/robotic_grounding/scripts/rsl_rl/eval_callback.py
@@ -96,6 +96,9 @@ class EvalCallback:
                 actions = policy(obs)
                 obs, _, dones, _ = self.env.step(actions)
                 policy_nn.reset(dones)
+            dones = (
+                dones.clone()
+            )  # detach inference tensor before use outside inference_mode
             env_reset_once |= dones.bool()
 
         if log_video and self._record_video_env is not None:
@@ -107,6 +110,9 @@ class EvalCallback:
                 actions = policy(obs)
                 obs, _, dones, _ = self.env.step(actions)
                 policy_nn.reset(dones)
+            dones = (
+                dones.clone()
+            )  # detach inference tensor before use outside inference_mode
 
             my_ep_len += 1
             done_mask = dones.bool()
@@ -217,12 +223,15 @@ class EvalCallback:
             self._cmd.cfg.always_reset_to_first_frame = _orig_reset_to_first
 
             # ── Restore training state saved before eval ───────────────────── #
+            # Use assignment rather than copy_() because env.step() inside
+            # inference_mode may have replaced dict entries with inference tensors;
+            # inplace copy_ on those outside inference_mode raises an error.
             for k, v in _saved_episode_sums.items():
                 if k in self._isaac_env.reward_manager._episode_sums:
-                    self._isaac_env.reward_manager._episode_sums[k].copy_(v)
+                    self._isaac_env.reward_manager._episode_sums[k] = v.clone()
             for k, v in _saved_metrics.items():
                 if k in self._cmd.metrics:
-                    self._cmd.metrics[k].copy_(v)
+                    self._cmd.metrics[k] = v.clone()
             if _saved_cws_buf is not None and hasattr(
                 self._cmd, "_cws_reward_step_buf"
             ):

--- a/robotic_grounding/scripts/rsl_rl/eval_callback.py
+++ b/robotic_grounding/scripts/rsl_rl/eval_callback.py
@@ -6,20 +6,23 @@ import os
 class EvalCallback:
     """Runs inference episodes after each checkpoint save and logs completion stats to wandb.
 
-    Triggered by monkey-patching runner.save().  Temporarily forces
-    always_reset_to_first_frame=True so every collected episode starts from
-    the beginning of the trajectory (tc=0), making full_completion_pct a clean
-    measure of whether the policy can complete the full trajectory from scratch.
+    Two eval passes are run per checkpoint:
 
-    After a warm-up phase that waits until every env has reset at least once,
-    it collects `eval_episodes` completed episodes in inference mode and logs:
+      Pass A (from_start): every reset goes to tc=0; measures whether the policy
+          can complete the full trajectory from scratch.
+          Logs: eval/completion_ratio_mean, eval/completion_ratio_std,
+                eval/full_completion_pct
 
-        eval/completion_ratio_mean   – mean fraction of trajectory completed
-        eval/completion_ratio_std    – std of the above
-        eval/full_completion_pct     – % of episodes that completed ≥99% of traj
+      Pass B (random): resets use training behaviour (random tc); measures what
+          fraction of the trajectory the policy has learned to follow regardless
+          of starting position.
+          Logs: eval/completion_ratio_mean_random, eval/completion_ratio_std_random
+
+    Both passes run a warm-up phase that waits until every env has reset at least
+    once, then collect `eval_episodes` completed episodes in inference mode.
 
     If the training env is wrapped with RecordVideo (i.e. --video is set),
-    it also triggers a video recording during the evaluation rollout.
+    a video is captured during pass A only (genuine from-frame-0 rollout).
     """
 
     def __init__(self, runner, env, eval_episodes: int, log_video: bool) -> None:
@@ -163,7 +166,8 @@ class EvalCallback:
         return mean_r, std_r, full_pct, n_full
 
     def __call__(self, path: str, *args, **kwargs) -> None:
-        import torch
+        import copy as _copy
+
         import wandb
 
         if wandb.run is None:
@@ -173,7 +177,6 @@ class EvalCallback:
         iteration = int(match.group(1)) if match else None
 
         device = self.env.unwrapped.device
-        num_envs = self.env.unwrapped.num_envs
 
         policy = self.runner.get_inference_policy(device=device)
         try:
@@ -182,12 +185,9 @@ class EvalCallback:
             policy_nn = self.runner.alg.actor_critic
 
         obs = self.env.get_observations()
+        traj_len = self._cmd.retargeted_horizon
 
         # ── Save training state that eval steps would contaminate ──────────── #
-        # All three are restored unconditionally in the finally block so that
-        # training resumes with exactly the state it had before the checkpoint.
-        import copy as _copy
-
         _saved_episode_sums = {
             k: v.clone()
             for k, v in self._isaac_env.reward_manager._episode_sums.items()
@@ -198,143 +198,42 @@ class EvalCallback:
             if hasattr(self._cmd, "_cws_reward_step_buf")
             else None
         )
-
-        # Force all resets to start from the first trajectory frame for the
-        # duration of eval; restored unconditionally in the finally block below.
         _orig_reset_to_first = self._cmd.cfg.always_reset_to_first_frame
-        self._cmd.cfg.always_reset_to_first_frame = True
 
-        # --- Collect eval_episodes clean episodes + drain recording ---
-        # Allocate state tensors before the try so they're accessible after the
-        # finally (for the stats section).  These assignments cannot raise.
-        traj_len = self._cmd.retargeted_horizon  # re-read in case init was stale
-        my_ep_len = torch.zeros(num_envs, dtype=torch.float32, device=device)
-        # tracking_length captured at the start of each env's fresh episode
-        my_ep_max_len = torch.zeros(num_envs, dtype=torch.float32, device=device)
-        env_first_done = torch.zeros(num_envs, dtype=torch.bool, device=device)
-        completed: list[tuple[float, float]] = []
+        completed_start: list[tuple[float, float]] = []
+        completed_random: list[tuple[float, float]] = []
 
         try:
-            # --- Warm-up: step until every env has completed at least one episode ---
-            # This ensures the episodes we collect started from a genuine reset, not
-            # mid-episode when the callback fired.
-            env_reset_once = torch.zeros(num_envs, dtype=torch.bool, device=device)
-            while not env_reset_once.all():
-                with torch.inference_mode():
-                    actions = policy(obs)
-                    obs, _, dones, _ = self.env.step(actions)
-                    policy_nn.reset(dones)
-                env_reset_once |= dones.bool()
-            # --- Trigger video recording for the upcoming eval rollout ---
-            # Redirect RecordVideo to videos/eval so the clip is logged separately
-            # from training videos (uploaded as eval/video rather than train/video).
-            # Done inside try so the finally always restores video_folder, even if
-            # the eval loop or drain throws (e.g. CUDA OOM, moviepy write error).
-            if self.log_video and self._record_video_env is not None:
-                self._record_video_env.video_folder = self._eval_video_folder
-
-            # After warmup each env's episode is at some arbitrary midpoint.  We
-            # discard each env's first post-warmup episode (the "tail"), then count
-            # only full episodes that started fresh.  tracking_length is captured at
-            # the START of each fresh episode so the per-episode denominator is
-            # correct regardless of random start offsets.
-            #
-            # Video recording is triggered when the first tail ends — at that moment
-            # the env resets to tc=0 (always_reset_to_first_frame=True), so the
-            # recording captures a genuine from-frame-0 fresh episode.
-            _video_triggered = False
-            while len(completed) < self.eval_episodes:
-                with torch.inference_mode():
-                    actions = policy(obs)
-                    obs, _, dones, _ = self.env.step(actions)
-                    policy_nn.reset(dones)
-
-                my_ep_len += 1
-                done_mask = dones.bool()
-                if done_mask.any():
-                    done_ids = done_mask.nonzero(as_tuple=False).squeeze(-1)
-                    for i in done_ids:
-                        if env_first_done[i]:
-                            # Fresh episode — record (ep_len, tracking_length at start).
-                            completed.append(
-                                (my_ep_len[i].item(), my_ep_max_len[i].item())
-                            )
-                        else:
-                            # Tail of a mid-episode that pre-dated the warmup end;
-                            # mark done so the NEXT episode is recorded.
-                            env_first_done[i] = True
-                            # The env just reset to tc=0; trigger recording now so
-                            # the video captures a fresh from-frame-0 episode.
-                            if self.log_video and not _video_triggered:
-                                self._isaac_env.eval_video_trigger_pending = True
-                                _video_triggered = True
-                        my_ep_len[i] = 0.0
-                        # Capture tracking_length for the new episode that just started.
-                        my_ep_max_len[i] = self._cmd.tracking_lengths[i].float()
-
-            # Drain: keep stepping until the in-progress eval recording finishes.
-            # Cap at video_length * 3 steps to avoid an infinite loop if the
-            # recording state somehow gets stuck.
-            if self.log_video and self._record_video_env is not None:
-                _drain_limit = (
-                    self._record_video_env.video_length
-                    if self._record_video_env.video_length != float("inf")
-                    else 600
-                ) * 3
-                _drain_steps = 0
-                while self._record_video_env.recording:
-                    if _drain_steps >= _drain_limit:
-                        print(
-                            f"[eval] WARNING: drain loop hit {_drain_limit}-step limit "
-                            "while waiting for eval recording to finish; aborting drain."
-                        )
-                        break
-                    with torch.inference_mode():
-                        actions = policy(obs)
-                        obs, _, dones, _ = self.env.step(actions)
-                        policy_nn.reset(dones)
-                    _drain_steps += 1
+            # Pass A: from-start (tc=0) — also captures eval video.
+            completed_start, obs = self._collect_episodes(
+                policy, policy_nn, obs, from_start=True, log_video=self.log_video
+            )
+            # Pass B: random reset — measures coverage regardless of start position.
+            completed_random, obs = self._collect_episodes(
+                policy, policy_nn, obs, from_start=False, log_video=False
+            )
 
         finally:
             self._cmd.cfg.always_reset_to_first_frame = _orig_reset_to_first
 
             # ── Restore training state saved before eval ───────────────────── #
-            # Restoring (not flushing) avoids both spikes AND dips:
-            # • _episode_sums: eval steps accumulated inference-mode rewards;
-            #   restore pre-eval sums so the next training episode completion logs
-            #   the correct partial-episode reward, not zero or eval-quality values.
-            #   (The previous fix called reward_manager.log() which does not exist —
-            #   AttributeError silently aborted the entire finally block every time.)
             for k, v in _saved_episode_sums.items():
                 if k in self._isaac_env.reward_manager._episode_sums:
                     self._isaac_env.reward_manager._episode_sums[k].copy_(v)
-            # • self._cmd.metrics: _update_metrics() runs inside command_manager.compute()
-            #   which is called AFTER _reset_idx in each env.step(). The first training
-            #   episode reset therefore logs metrics from the *last eval step* (inference-
-            #   mode, better performance) → spike in every Metrics/* key.
             for k, v in _saved_metrics.items():
                 if k in self._cmd.metrics:
                     self._cmd.metrics[k].copy_(v)
-            # • _cws_reward_step_buf: deque(maxlen=200) filled entirely with eval values
-            #   → contact_wrench_support_reward_cv wrong for 200 training steps.
             if _saved_cws_buf is not None and hasattr(
                 self._cmd, "_cws_reward_step_buf"
             ):
                 self._cmd._cws_reward_step_buf.clear()
                 self._cmd._cws_reward_step_buf.extend(_saved_cws_buf)
 
-            # Restore policy to train mode.  get_inference_policy() calls
-            # alg.eval_mode(); RSL-RL only calls train_mode() once at the start of
-            # learn(), so without this the network stays in eval mode for all
-            # subsequent training iterations after the first checkpoint.
             try:
                 self.runner.alg.train_mode()
             except AttributeError:
                 pass
 
-            # Clear stale extras["log"]: the last eval-step reset left episode
-            # metrics from inference mode in this dict; it persists until the next
-            # training reset overwrites it, so the RSL-RL logger would process it.
             self._isaac_env.extras["log"] = dict()
 
             # Signal curriculum that eval has finished so deferred decay can fire.
@@ -348,8 +247,7 @@ class EvalCallback:
                 if self._record_video_env is not None:
                     self._record_video_env.video_folder = self._train_video_folder
 
-        # Log eval video directly from the main thread so it is committed reliably.
-        # Background-thread commit=False is not guaranteed to flush before the run ends.
+        # Log eval video (pass A only).
         if self.log_video and self._eval_video_folder:
             import glob as _glob
 
@@ -373,49 +271,46 @@ class EvalCallback:
                     wandb.log(log_video_data, step=iteration, commit=False)
                 else:
                     wandb.log(log_video_data, commit=False)
-                self._logged_eval_videos.update(
-                    new_videos
-                )  # mark all seen as tracked, not just the logged one
-                self._logged_eval_videos.add(dst_path)  # also track renamed destination
+                self._logged_eval_videos.update(new_videos)
+                self._logged_eval_videos.add(dst_path)
 
-        # --- Compute stats ---
-        # ratio = fraction of the post-warmup trajectory that was completed.
-        # Both numerator and denominator exclude warmup_steps so a perfectly
-        # completing episode always gives ratio = 1.0.
-        data = completed[: self.eval_episodes]
-        print(
-            f"[eval] iter={iteration}  traj_len={traj_len}  "
-            f"warmup_steps={self._warmup_steps}  "
-            f"sample ep_lens={[round(e[0]) for e in data[:5]]}"
-        )
-        ratios = [
-            min(max(e[0] - self._warmup_steps, 0), max(e[1] - self._warmup_steps, 1))
-            / max(e[1] - self._warmup_steps, 1)
-            for e in data
-        ]
-        n_full = sum(1 for r in ratios if r >= 0.99)
-        mean_r = sum(ratios) / len(ratios)
-        std_r = (
-            sum((x - mean_r) ** 2 for x in ratios) / max(len(ratios) - 1, 1)
-        ) ** 0.5
-        full_pct = 100.0 * n_full / len(data)
+        # ── Stats and logging: pass A (from-start) ────────────────────────── #
+        if completed_start:
+            mean_r, std_r, full_pct, n_full = self._compute_stats(completed_start)
+            n = len(completed_start[: self.eval_episodes])
+            print(
+                f"[eval/from_start] iter={iteration}  traj_len={traj_len}  "
+                f"warmup={self._warmup_steps}  "
+                f"sample ep_lens={[round(e[0]) for e in completed_start[:5]]}\n"
+                f"  ratio={mean_r:.3f}±{std_r:.3f}  full={n_full}/{n} ({full_pct:.0f}%)"
+            )
+            log_data: dict = {
+                "eval/completion_ratio_mean": mean_r,
+                "eval/completion_ratio_std": std_r,
+                "eval/full_completion_pct": full_pct,
+            }
+            if iteration is not None:
+                wandb.log(log_data, step=iteration, commit=False)
+            else:
+                wandb.log(log_data, commit=False)
 
-        # --- Log to wandb ---
-        log_data = {
-            "eval/completion_ratio_mean": mean_r,
-            "eval/completion_ratio_std": std_r,
-            "eval/full_completion_pct": full_pct,
-        }
-        if iteration is not None:
-            wandb.log(log_data, step=iteration, commit=False)
-        else:
-            wandb.log(log_data, commit=False)
+        # ── Stats and logging: pass B (random reset) ──────────────────────── #
+        if completed_random:
+            mean_r_rnd, std_r_rnd, _, _ = self._compute_stats(completed_random)
+            print(
+                f"[eval/random] iter={iteration}  "
+                f"sample ep_lens={[round(e[0]) for e in completed_random[:5]]}\n"
+                f"  ratio={mean_r_rnd:.3f}±{std_r_rnd:.3f}"
+            )
+            log_data_rnd: dict = {
+                "eval/completion_ratio_mean_random": mean_r_rnd,
+                "eval/completion_ratio_std_random": std_r_rnd,
+            }
+            if iteration is not None:
+                wandb.log(log_data_rnd, step=iteration, commit=False)
+            else:
+                wandb.log(log_data_rnd, commit=False)
 
-        print(
-            f"[eval] iter={iteration}  "
-            f"ratio={mean_r:.3f}±{std_r:.3f}  full={n_full}/{len(data)} ({full_pct:.0f}%)"
-        )
-
-        # Refresh runner's internal obs so the next collect_rollouts starts consistently
+        # Refresh runner's internal obs so the next collect_rollouts starts consistently.
         if hasattr(self.runner, "obs"):
             self.runner.obs = obs

--- a/robotic_grounding/scripts/rsl_rl/eval_callback.py
+++ b/robotic_grounding/scripts/rsl_rl/eval_callback.py
@@ -6,10 +6,13 @@ import os
 class EvalCallback:
     """Runs inference episodes after each checkpoint save and logs completion stats to wandb.
 
-    Triggered by monkey-patching runner.save().  After a warm-up phase that
-    waits until every env has reset at least once (so we only measure clean
-    episodes), it collects `eval_episodes` completed episodes in inference mode
-    and logs:
+    Triggered by monkey-patching runner.save().  Temporarily forces
+    always_reset_to_first_frame=True so every collected episode starts from
+    the beginning of the trajectory (tc=0), making full_completion_pct a clean
+    measure of whether the policy can complete the full trajectory from scratch.
+
+    After a warm-up phase that waits until every env has reset at least once,
+    it collects `eval_episodes` completed episodes in inference mode and logs:
 
         eval/completion_ratio_mean   – mean fraction of trajectory completed
         eval/completion_ratio_std    – std of the above
@@ -76,6 +79,11 @@ class EvalCallback:
             policy_nn = self.runner.alg.actor_critic
 
         obs = self.env.get_observations()
+
+        # Force all resets to start from the first trajectory frame for the
+        # duration of eval; restored unconditionally in the finally block below.
+        _orig_reset_to_first = self._cmd.cfg.always_reset_to_first_frame
+        self._cmd.cfg.always_reset_to_first_frame = True
 
         # --- Warm-up: step until every env has completed at least one episode ---
         # This ensures the episodes we collect started from a genuine reset, not
@@ -162,6 +170,7 @@ class EvalCallback:
                     _drain_steps += 1
 
         finally:
+            self._cmd.cfg.always_reset_to_first_frame = _orig_reset_to_first
             # Always restore the train video folder and clear any unconsumed pending
             # trigger, regardless of whether an exception occurred above.
             if self.log_video:
@@ -201,8 +210,9 @@ class EvalCallback:
                 self._logged_eval_videos.add(dst_path)  # also track renamed destination
 
         # --- Compute stats ---
-        # ratio = fraction of the episode's own tracking_length that was
-        # completed after the per-episode VOC warmup (warmup_steps).
+        # ratio = fraction of the post-warmup trajectory that was completed.
+        # Both numerator and denominator exclude warmup_steps so a perfectly
+        # completing episode always gives ratio = 1.0.
         data = completed[: self.eval_episodes]
         print(
             f"[eval] iter={iteration}  traj_len={traj_len}  "
@@ -210,7 +220,9 @@ class EvalCallback:
             f"sample ep_lens={[round(e[0]) for e in data[:5]]}"
         )
         ratios = [
-            min(max(e[0] - self._warmup_steps, 0), e[1]) / max(e[1], 1) for e in data
+            min(max(e[0] - self._warmup_steps, 0), max(e[1] - self._warmup_steps, 1))
+            / max(e[1] - self._warmup_steps, 1)
+            for e in data
         ]
         n_full = sum(1 for r in ratios if r >= 0.99)
         mean_r = sum(ratios) / len(ratios)

--- a/robotic_grounding/scripts/rsl_rl/eval_callback.py
+++ b/robotic_grounding/scripts/rsl_rl/eval_callback.py
@@ -59,6 +59,109 @@ class EvalCallback:
                     break
                 w = getattr(w, "env", None)
 
+    def _collect_episodes(
+        self,
+        policy,
+        policy_nn,
+        obs,
+        from_start: bool,
+        log_video: bool,
+    ):
+        """Run one eval pass; returns (completed_list, final_obs).
+
+        Pass A (from_start=True): always_reset_to_first_frame=True, logs eval video.
+        Pass B (from_start=False): training reset behaviour (random tc), no video.
+        The caller's finally block is responsible for restoring the original value.
+        """
+        import torch
+
+        device = self.env.unwrapped.device
+        num_envs = self.env.unwrapped.num_envs
+
+        self._cmd.cfg.always_reset_to_first_frame = from_start
+
+        my_ep_len = torch.zeros(num_envs, dtype=torch.float32, device=device)
+        my_ep_max_len = torch.zeros(num_envs, dtype=torch.float32, device=device)
+        env_first_done = torch.zeros(num_envs, dtype=torch.bool, device=device)
+        completed: list[tuple[float, float]] = []
+
+        # Warmup: step until every env has completed at least one episode so all
+        # collected episodes start from a genuine post-reset state.
+        env_reset_once = torch.zeros(num_envs, dtype=torch.bool, device=device)
+        while not env_reset_once.all():
+            with torch.inference_mode():
+                actions = policy(obs)
+                obs, _, dones, _ = self.env.step(actions)
+                policy_nn.reset(dones)
+            env_reset_once |= dones.bool()
+
+        if log_video and self._record_video_env is not None:
+            self._record_video_env.video_folder = self._eval_video_folder
+
+        _video_triggered = False
+        while len(completed) < self.eval_episodes:
+            with torch.inference_mode():
+                actions = policy(obs)
+                obs, _, dones, _ = self.env.step(actions)
+                policy_nn.reset(dones)
+
+            my_ep_len += 1
+            done_mask = dones.bool()
+            if done_mask.any():
+                done_ids = done_mask.nonzero(as_tuple=False).squeeze(-1)
+                for i in done_ids:
+                    if env_first_done[i]:
+                        completed.append((my_ep_len[i].item(), my_ep_max_len[i].item()))
+                    else:
+                        # Tail episode pre-dating warmup end; discard, record next.
+                        env_first_done[i] = True
+                        if log_video and not _video_triggered:
+                            self._isaac_env.eval_video_trigger_pending = True
+                            _video_triggered = True
+                    my_ep_len[i] = 0.0
+                    my_ep_max_len[i] = self._cmd.tracking_lengths[i].float()
+
+        # Drain: keep stepping until the in-progress recording finishes.
+        if log_video and self._record_video_env is not None:
+            _drain_limit = (
+                self._record_video_env.video_length
+                if self._record_video_env.video_length != float("inf")
+                else 600
+            ) * 3
+            _drain_steps = 0
+            while self._record_video_env.recording:
+                if _drain_steps >= _drain_limit:
+                    print(
+                        f"[eval] WARNING: drain loop hit {_drain_limit}-step limit "
+                        "while waiting for eval recording to finish; aborting drain."
+                    )
+                    break
+                with torch.inference_mode():
+                    actions = policy(obs)
+                    obs, _, dones, _ = self.env.step(actions)
+                    policy_nn.reset(dones)
+                _drain_steps += 1
+
+        return completed, obs
+
+    def _compute_stats(
+        self, completed: list[tuple[float, float]]
+    ) -> tuple[float, float, float, int]:
+        """Return (mean_ratio, std_ratio, full_pct, n_full) from a completed-episodes list."""
+        data = completed[: self.eval_episodes]
+        ratios = [
+            min(max(e[0] - self._warmup_steps, 0), max(e[1] - self._warmup_steps, 1))
+            / max(e[1] - self._warmup_steps, 1)
+            for e in data
+        ]
+        n_full = sum(1 for r in ratios if r >= 0.99)
+        mean_r = sum(ratios) / len(ratios)
+        std_r = (
+            sum((x - mean_r) ** 2 for x in ratios) / max(len(ratios) - 1, 1)
+        ) ** 0.5
+        full_pct = 100.0 * n_full / len(data)
+        return mean_r, std_r, full_pct, n_full
+
     def __call__(self, path: str, *args, **kwargs) -> None:
         import torch
         import wandb
@@ -233,6 +336,9 @@ class EvalCallback:
             # metrics from inference mode in this dict; it persists until the next
             # training reset overwrites it, so the RSL-RL logger would process it.
             self._isaac_env.extras["log"] = dict()
+
+            # Signal curriculum that eval has finished so deferred decay can fire.
+            self._isaac_env.pre_decay_eval_pending = False
 
             # Always restore the train video folder and clear any unconsumed pending
             # trigger, regardless of whether an exception occurred above.

--- a/robotic_grounding/scripts/rsl_rl/train.py
+++ b/robotic_grounding/scripts/rsl_rl/train.py
@@ -409,7 +409,8 @@ def main(
     dump_yaml(os.path.join(log_dir, "params", "env.yaml"), env_cfg)
     dump_yaml(os.path.join(log_dir, "params", "agent.yaml"), agent_cfg)
 
-    # setup eval callback: after each checkpoint save, run inference episodes and log stats
+    # setup eval callback: run inference episodes at startup, before every VOC
+    # decay, and at most every 1000 training iterations as a fallback.
     if args_cli.eval_episodes_per_save > 0:
         _eval_cb = EvalCallback(
             runner=runner,
@@ -417,20 +418,31 @@ def main(
             eval_episodes=args_cli.eval_episodes_per_save,
             log_video=args_cli.video,
         )
-        _orig_save = runner.save
 
-        def _save_with_eval(path: str, *a, **kw):
-            _orig_save(path, *a, **kw)
-            try:
-                _eval_cb(path)
-            except Exception as exc:
-                print(f"[eval] WARNING: eval callback raised an exception: {exc}")
+        # Tell the curriculum to defer each VOC decay until after eval.
+        _eval_cb._isaac_env.pre_decay_eval_enabled = True
+        _eval_cb._isaac_env.pre_decay_eval_pending = False
 
-        runner.save = _save_with_eval
+        # Hook runner.log (called every iteration, after rollout+update) to fire eval
+        # when a pre-decay eval is pending OR every 1000 iters as a fallback.
+        _orig_log = runner.log
+        _last_eval_iter: list[int] = [0]
+
+        def _monitored_log(locs, width=80, pad=35):
+            it = locs.get("it", 0)
+            pre_decay = getattr(_eval_cb._isaac_env, "pre_decay_eval_pending", False)
+            should_eval = pre_decay or (it - _last_eval_iter[0] >= 1000)
+            if should_eval:
+                try:
+                    _eval_cb(f"model_{it}.pt")
+                except Exception as exc:
+                    print(f"[eval] WARNING: eval callback raised an exception: {exc}")
+                _last_eval_iter[0] = it
+            _orig_log(locs, width=width, pad=pad)
+
+        runner.log = _monitored_log
 
         # Fire one eval immediately at startup (after wandb is initialised).
-        # _prepare_logging_writer is idempotent; calling it here lets the eval
-        # log before the first save_interval checkpoint.
         _orig_learn = runner.learn
 
         def _learn_with_startup_eval(num_learning_iterations, **kw):

--- a/robotic_grounding/scripts/rsl_rl/train.py
+++ b/robotic_grounding/scripts/rsl_rl/train.py
@@ -196,6 +196,7 @@ import isaaclab_tasks  # noqa: F401
 import robotic_grounding.tasks  # noqa: F401
 from robotic_grounding.tasks.scene_utils import SceneConfig, apply_scene_config
 from robotic_grounding.tasks.v2p_whole_body.utils import WandbVideoUploader
+from viewer_utils import autoframe_viewer
 
 from isaaclab_tasks.utils import get_checkpoint_path
 from isaaclab_tasks.utils.hydra import hydra_task_config
@@ -234,12 +235,14 @@ def main(
         apply_scene_config(
             env_cfg, scene_config, use_primitive_urdfs=args_cli.use_primitive_urdfs
         )
+        autoframe_viewer(env_cfg, scene_config.motion_file)
     elif args_cli.scene_config is not None:
         env_cfg.scene_config_path = args_cli.scene_config
         scene_config = SceneConfig.from_yaml(args_cli.scene_config)
         apply_scene_config(
             env_cfg, scene_config, use_primitive_urdfs=args_cli.use_primitive_urdfs
         )
+        autoframe_viewer(env_cfg, scene_config.motion_file)
 
     # set max iterations
     agent_cfg.max_iterations = (

--- a/robotic_grounding/scripts/rsl_rl/viewer_utils.py
+++ b/robotic_grounding/scripts/rsl_rl/viewer_utils.py
@@ -1,0 +1,48 @@
+"""Shared viewer utilities for RSL-RL training/eval scripts."""
+
+from __future__ import annotations
+
+
+def autoframe_viewer(env_cfg, motion_file: str) -> None:
+    """Set viewer eye/lookat from the motion file's actual bounding box.
+
+    Reads object_body_position and robot_{side}_wrist_position from the parquet,
+    computes the scene centroid + extent, and positions the camera at a
+    135°-azimuth / ~30°-elevation offset capped at 2 m.  Falls back silently
+    if the parquet is missing or the required fields are absent.
+    """
+    import logging
+
+    import numpy as np
+    import pyarrow.parquet as pq
+    from isaaclab.envs import ManagerBasedRLEnvCfg
+
+    logger = logging.getLogger(__name__)
+
+    if not (isinstance(env_cfg, ManagerBasedRLEnvCfg) and hasattr(env_cfg, "viewer")):
+        return
+    try:
+        data = pq.read_table(motion_file).to_pydict()
+        pts = []
+        obj = data.get("object_body_position", [None])[0]
+        if obj:
+            pts.append(np.asarray(obj).reshape(-1, 3))
+        for side in ("right", "left"):
+            wrist = data.get(f"robot_{side}_wrist_position", [None])[0]
+            if wrist:
+                pts.append(np.asarray(wrist).reshape(-1, 3))
+        if not pts:
+            return
+        all_pts = np.concatenate(pts, axis=0)
+        lo, hi = all_pts.min(axis=0), all_pts.max(axis=0)
+        center = 0.5 * (lo + hi)
+        extent = max(float(np.linalg.norm(hi - lo)), 0.3)
+        dist = min(2.5 * extent, 2.0)
+        eye = center + dist * np.array([-0.60, 0.60, 0.57])
+        env_cfg.viewer.lookat = tuple(float(c) for c in center)
+        env_cfg.viewer.eye = tuple(float(c) for c in eye)
+        logger.info(
+            f"viewer autoframe: lookat={env_cfg.viewer.lookat}, eye={env_cfg.viewer.eye}"
+        )
+    except Exception as e:  # noqa: BLE001
+        logging.getLogger(__name__).warning(f"viewer autoframe failed: {e}")

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/scene_config.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/scene_config.py
@@ -158,8 +158,11 @@ class SceneConfig:
         """Detect whether the scene object is articulated or rigid.
 
         Checks the object registry first — if the object has a urdf_path it is
-        always articulated, regardless of whether articulation values are zero
+        articulated, regardless of whether articulation values are zero
         (e.g. grab sequences where the lid never moves).
+        Exception: if body_names == ["object"], this is the rigid URDF link
+        convention used by Arctic "rigid_*" sequences, so treat as rigid even
+        when the registry has an art URDF.
         Multiple rigid bodies (TACO tool+target, OakInk2 multi-object) have no
         urdf_path in the registry and fall through to "rigid".
         """
@@ -170,7 +173,13 @@ class SceneConfig:
         if obj_name:
             spec = get_object_spec(obj_name)
             if spec and spec.urdf_path:
-                return "articulated"
+                body_names = (
+                    data.get("safe_object_body_names", [[]])[0]
+                    or data.get("object_body_names", [[]])[0]
+                    or []
+                )
+                if body_names != ["object"]:
+                    return "articulated"
         return "rigid"
 
     @classmethod

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/scene_config.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/scene_config.py
@@ -81,7 +81,7 @@ class SceneConfig:
         cls._validate_assets(data, motion_file)
 
         object_type = cls._detect_object_type(data)
-        scene_objects = cls._build_scene_objects(data, object_type)
+        scene_objects = cls._build_scene_objects(data, object_type, motion_file)
         fixed_objects = cls._build_fixed_objects(motion_file)
         object_body_names = (
             data.get("safe_object_body_names", [[]])[0]
@@ -175,7 +175,7 @@ class SceneConfig:
 
     @classmethod
     def _build_scene_objects(
-        cls, data: dict, object_type: str
+        cls, data: dict, object_type: str, motion_file: str = ""
     ) -> list[ObjectConfig | ArticulatedObjectConfig]:
         """Build all scene objects from parquet data.
 
@@ -195,6 +195,9 @@ class SceneConfig:
         obj_name = (
             data.get("safe_object_name", [None])[0]
             or data.get("object_name", [None])[0]
+        )
+        dataset_root = (
+            cls._dataset_root_from_motion_file(motion_file) if motion_file else None
         )
         objects: list[ObjectConfig | ArticulatedObjectConfig] = []
 
@@ -223,6 +226,18 @@ class SceneConfig:
                 urdf_path = cls._urdf_from_mesh_path(
                     mesh_paths[i] if i < len(mesh_paths) else None
                 )
+
+            # Fallback: search for URDF by filename in the motion file's dataset
+            if (
+                (not urdf_path or not Path(urdf_path).exists())
+                and dataset_root
+                and urdf_path
+            ):
+                dataset_urdf = cls._find_asset_in_dataset(
+                    Path(urdf_path).name, dataset_root
+                )
+                if dataset_urdf:
+                    urdf_path = dataset_urdf
 
             assert urdf_path and Path(urdf_path).exists(), (
                 f"Could not resolve rigid object for object_name='{obj_name}', "
@@ -254,6 +269,45 @@ class SceneConfig:
         return str(urdf_path) if urdf_path.exists() else None
 
     @staticmethod
+    def _dataset_root_from_motion_file(motion_file: str) -> Path | None:
+        """Derive dataset root from a partitioned motion file path.
+
+        Walks up the path past partition dirs (key=value format) and the
+        sequences subfolder to reach the dataset root.
+
+        Example:
+          .../v2d_taco_retarget_exp_200/taco_processed/sequence_id=.../robot_name=...
+          → .../v2d_taco_retarget_exp_200/
+        """
+        path = Path(motion_file)
+        prev_no_eq = False
+        for _ in range(10):
+            if path == path.parent:
+                return None
+            has_eq = "=" in path.name
+            if not has_eq and prev_no_eq:
+                return path
+            prev_no_eq = not has_eq
+            path = path.parent
+        return None
+
+    @staticmethod
+    def _find_asset_in_dataset(filename: str, dataset_root: Path) -> str | None:
+        """Search for an asset file in immediate subdirectories of the dataset root."""
+        if not dataset_root or not dataset_root.is_dir():
+            return None
+        direct = dataset_root / filename
+        if direct.exists():
+            return str(direct)
+        for subdir in dataset_root.iterdir():
+            if not subdir.is_dir():
+                continue
+            candidate = subdir / filename
+            if candidate.exists():
+                return str(candidate)
+        return None
+
+    @staticmethod
     def _validate_assets(data: dict, motion_file: str) -> None:
         """Check that required asset files exist before building the scene.
 
@@ -265,14 +319,26 @@ class SceneConfig:
         Note: this only validates paths stored in the parquet. Objects
         resolved via the object registry or the mesh-derived URDF fallback
         are validated later in ``_build_scene_objects``.
+
+        For URDFs, falls back to searching in the motion file's dataset root
+        (e.g. OSMO-mounted dataset taco_urdfs/ subfolder) when the workspace
+        path is absent.
         """
         urdf_paths = data.get("object_urdf_paths", [[]])[0] or []
         mesh_paths = data.get("object_mesh_paths", [[]])[0] or []
         missing: list[str] = []
 
+        dataset_root = SceneConfig._dataset_root_from_motion_file(motion_file)
+
         for p in urdf_paths:
             if p and not Path(p).exists():
-                missing.append(f"URDF: {p}")
+                resolved = (
+                    SceneConfig._find_asset_in_dataset(Path(p).name, dataset_root)
+                    if dataset_root
+                    else None
+                )
+                if not resolved:
+                    missing.append(f"URDF: {p}")
         for p in mesh_paths:
             if p and not Path(p).exists():
                 missing.append(f"Mesh: {p}")

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/scene_config.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/scene_config.py
@@ -157,22 +157,20 @@ class SceneConfig:
     def _detect_object_type(data: dict) -> str:
         """Detect whether the scene object is articulated or rigid.
 
-        Uses ``object_articulation`` non-zero values as the signal, not body count.
-        Multiple rigid bodies (TACO tool+target, OakInk2 multi-object) should still
-        be treated as rigid.
+        Checks the object registry first — if the object has a urdf_path it is
+        always articulated, regardless of whether articulation values are zero
+        (e.g. grab sequences where the lid never moves).
+        Multiple rigid bodies (TACO tool+target, OakInk2 multi-object) have no
+        urdf_path in the registry and fall through to "rigid".
         """
-        art = data.get("object_articulation")
-        if art and art[0]:
-            arr = np.array(art[0], dtype=np.float32)
-            if np.any(np.abs(arr) > 1e-6):
-                obj_name = (
-                    data.get("safe_object_name", [None])[0]
-                    or data.get("object_name", [None])[0]
-                )
-                if obj_name:
-                    spec = get_object_spec(obj_name)
-                    if spec and spec.urdf_path:
-                        return "articulated"
+        obj_name = (
+            data.get("safe_object_name", [None])[0]
+            or data.get("object_name", [None])[0]
+        )
+        if obj_name:
+            spec = get_object_spec(obj_name)
+            if spec and spec.urdf_path:
+                return "articulated"
         return "rigid"
 
     @classmethod

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/config/sharpa_wave/__init__.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/config/sharpa_wave/__init__.py
@@ -2,6 +2,7 @@ import gymnasium as gym
 
 from . import (
     agents,
+    sharpa_v2p_auto_curr_env_cfg,
     sharpa_v2p_direct_env_cfg,
     sharpa_v2p_env_cfg,
     sharpa_v2p_tracking_env_cfg,
@@ -17,6 +18,16 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": sharpa_v2p_env_cfg.SharpaV2PEnvCfg,
+        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:SharpaV2PPPORunnerCfg",
+    },
+)
+
+gym.register(
+    id="Sharpa-V2P-AutoCurr-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": sharpa_v2p_auto_curr_env_cfg.SharpaV2PAutoCurrEnvCfg,
         "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:SharpaV2PPPORunnerCfg",
     },
 )

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/config/sharpa_wave/sharpa_v2p_auto_curr_env_cfg.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/config/sharpa_wave/sharpa_v2p_auto_curr_env_cfg.py
@@ -1,0 +1,16 @@
+from isaaclab.utils import configclass
+
+from robotic_grounding.tasks.v2p.v2p_hand_env_cfg import CurriculumCfg, V2PHandEnvCfg
+
+_DEFAULT_MOTION_FILE = "arctic_processed/arctic_s01_box_grab_01/sharpa_wave"
+
+
+@configclass
+class SharpaV2PAutoCurrEnvCfg(V2PHandEnvCfg):
+    """Sharpa V2P environment using VirtualObjectControlCurriculum (adaptive gates)."""
+
+    motion_file: str = _DEFAULT_MOTION_FILE
+    curriculum: CurriculumCfg = CurriculumCfg()
+
+    def __post_init__(self) -> None:  # noqa: D105
+        super().__post_init__()

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/commands_cfg.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/commands_cfg.py
@@ -141,6 +141,17 @@ class DualHandsObjectTrackingCommandCfg(CommandTermCfg):
     always_reset_to_first_frame: bool = False
     """Whether to always reset to the first frame of the motion data."""
 
+    reset_to_first_frame_prob: float = 0.0
+    """Probability of resetting to the first trajectory frame (tc=0) instead of a random frame.
+
+    Only applied when ``always_reset_to_first_frame`` is False AND the global VOC scale is
+    below 0.1 (i.e. the curriculum has nearly or fully decayed).  This closes the train/eval
+    distribution gap: eval always starts from tc=0, but without this flag training never
+    sees tc=0 starts once the curriculum is active, allowing the policy to reward-hack by
+    learning to hold-in-place from mid-trajectory positions while failing from the start.
+    Recommended value: 0.1–0.2.  Has no effect during the VOC-assisted curriculum phase.
+    """
+
     initial_virtual_object_control_curriculum_scale: float = 1.0
     """Initial virtual object control curriculum scale."""
 

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/commands_cfg.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/commands_cfg.py
@@ -168,6 +168,13 @@ class DualHandsObjectTrackingCommandCfg(CommandTermCfg):
     friction_coefficients: float = 0.1
     """Friction coefficient for the wrench space support function."""
 
+    enable_additional_metrics: bool = False
+    """Whether to log additional diagnostic metrics (contact wrench CV, coverage, etc.).
+
+    Enables contact_wrench_support_reward_cv and related W&B metrics.
+    Off by default to avoid compute overhead in production runs.
+    """
+
     ###################################################
     # Visualizer markers
     ###################################################

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/commands_cfg.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/commands_cfg.py
@@ -85,7 +85,7 @@ class DualHandsObjectTrackingCommandCfg(CommandTermCfg):
     resampling_time_range: tuple[float, float] = (1e6, 1e6)
     """No resampling based on time."""
 
-    debug_vis: bool = True
+    debug_vis: bool = False
     """Whether to visualize the debug markers."""
 
     right_robot_name: str = "right_robot"

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/hand_object_commands.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/hand_object_commands.py
@@ -2176,6 +2176,26 @@ class DualHandsObjectTrackingCommand(CommandTerm):
 
         if self.cfg.always_reset_to_first_frame:
             self.timestep_counter[env_ids] = 0
+        elif (
+            self.cfg.reset_to_first_frame_prob > 0.0
+            and float(self.virtual_object_controller_scale_factor) < 0.1
+        ):
+            # Close the train/eval gap: once the VOC curriculum has nearly decayed
+            # (scale < 0.1), randomly reset some envs to tc=0 with the configured
+            # probability.  Eval always starts from tc=0; without this the policy
+            # never sees trajectory-start episodes during training and can reward-hack
+            # by learning to hold-in-place from mid-trajectory positions.
+            first_frame_mask = (
+                torch.rand(n, device=self.device) < self.cfg.reset_to_first_frame_prob
+            )
+            first_frame_local_ids = first_frame_mask.nonzero(as_tuple=False).squeeze(-1)
+            if first_frame_local_ids.numel() > 0:
+                env_ids_t = (
+                    env_ids
+                    if isinstance(env_ids, torch.Tensor)
+                    else torch.tensor(env_ids, device=self.device)
+                )
+                self.timestep_counter[env_ids_t[first_frame_local_ids]] = 0
 
         # Cache the per-env timestep indices and env-origin offsets once.
         tc = self.timestep_counter[env_ids]

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/hand_object_commands.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/hand_object_commands.py
@@ -2300,11 +2300,20 @@ class DualHandsObjectTrackingCommand(CommandTerm):
                 .clamp(min=0.0)
                 .view(self.num_envs, 1)
             )
-        elif self.cfg.virtual_object_control_decay_mode in ("step", "fixed_schedule"):
+        elif self.cfg.virtual_object_control_decay_mode in (
+            "step",
+            "fixed_schedule",
+            "custom_schedule",
+        ):
             self.virtual_object_controller_scale_factor_per_env[
                 self.steps_since_last_reset
                 >= self.cfg.virtual_object_control_decay_steps
             ] = self.virtual_object_controller_scale_factor
+        else:
+            raise ValueError(
+                f"Unknown virtual_object_control_decay_mode: {self.cfg.virtual_object_control_decay_mode!r}. "
+                "Expected one of: 'linear', 'step', 'fixed_schedule', 'custom_schedule'."
+            )
 
         # If still in the reset phase, don't step the timestep counter
         # Note: This will make each episode length vary, which might cause the episode rewards to be variant.

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/hand_object_commands.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/hand_object_commands.py
@@ -1923,11 +1923,10 @@ class DualHandsObjectTrackingCommand(CommandTerm):
         #     self.object_body_wxyz_command_e,
         # ).mean(dim=-1)
 
-        # self.metrics["virtual_object_controller_scale_factor"] = (
-        #     self.virtual_object_controller_scale_factor
-        #     * torch.ones(self.num_envs, device=self.device)
-        # )
-        pass
+        self.metrics["virtual_object_controller_scale_factor"] = (
+            self.virtual_object_controller_scale_factor
+            * torch.ones(self.num_envs, device=self.device)
+        )
 
         if not self.cfg.enable_additional_metrics:
             return

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/hand_object_commands.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/hand_object_commands.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import collections
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Tuple
 
@@ -33,6 +34,7 @@ from robotic_grounding.tasks.v2p.mdp.utils import (
     sample_wrench_space_basis_scaled,
 )
 from robotic_grounding.tasks.v2p.mdp.utils_jit import (
+    contact_wrench_support_reward_jit,
     refresh_jit,
     resample_compute_tensors_jit,
     wrench_preprocess_jit,
@@ -115,7 +117,7 @@ class DualHandsObjectTrackingCommand(CommandTerm):
         self._precompute_contact_positions_normals_in_object_frame()
         self._precompute_hand_keypoints_in_object_frame()
         self._precompute_contact_wrench_support_values()
-        if ENABLE_ADDITIONAL_METRICS:
+        if self.cfg.enable_additional_metrics:
             self._precompute_bbox_corner_vecs()
         self._set_contact_vis_impl(getattr(self.cfg, "debug_vis", False))
         self._init_metrics(cfg)
@@ -972,7 +974,7 @@ class DualHandsObjectTrackingCommand(CommandTerm):
             * torch.ones(self.num_envs, device=self.device)
         )
 
-        if ENABLE_ADDITIONAL_METRICS:
+        if self.cfg.enable_additional_metrics:
             # Contact wrench level metrics (left/right separate)
             for side in ["right", "left"]:
                 self.metrics[f"contact_wrench_command_support_mean_{side}"] = (
@@ -1018,6 +1020,12 @@ class DualHandsObjectTrackingCommand(CommandTerm):
             )
             self._prev_voc_scale = float(
                 cfg.initial_virtual_object_control_curriculum_scale
+            )
+            # Rolling step-level buffer for contact_wrench_support_reward CV (W=200).
+            # Initialized to 1.0 (high = not plateaued) until the buffer fills.
+            self._cws_reward_step_buf: collections.deque = collections.deque(maxlen=200)
+            self.metrics["contact_wrench_support_reward_cv"] = torch.ones(
+                self.num_envs, device=self.device
             )
 
     ######################################################################
@@ -1921,7 +1929,7 @@ class DualHandsObjectTrackingCommand(CommandTerm):
         # )
         pass
 
-        if not ENABLE_ADDITIONAL_METRICS:
+        if not self.cfg.enable_additional_metrics:
             return
 
         voc_scale_now = float(self.virtual_object_controller_scale_factor)
@@ -2118,6 +2126,41 @@ class DualHandsObjectTrackingCommand(CommandTerm):
             (self.metrics["right_hand_wrist_position_error"] < _WRIST_GOOD_THRESHOLD)
             & (self.metrics["left_hand_wrist_position_error"] < _WRIST_GOOD_THRESHOLD)
         ).float()
+
+        # ------------------------------------------------------------------ #
+        # Contact wrench support reward CV (W=200 steps)
+        # Scale-invariant plateau indicator: CV = std/mean over the rolling
+        # buffer. Low CV (≲0.07) means the reward has plateaued; high CV means
+        # it is still actively changing. Used as a curriculum decay gate.
+        # ------------------------------------------------------------------ #
+        cws_step_val = (
+            contact_wrench_support_reward_jit(
+                right_cmd_active=self.right_wrench_cmd_active,
+                right_cur_active=self.right_wrench_cur_active,
+                left_cmd_active=self.left_wrench_cmd_active,
+                left_cur_active=self.left_wrench_cur_active,
+                right_cmd_active_per_body=self.right_wrench_cmd_active_per_body,
+                left_cmd_active_per_body=self.left_wrench_cmd_active_per_body,
+                right_cmd_supports=self.right_hand_contact_wrench_supports_command,
+                right_cur_supports=self.right_hand_contact_wrench_supports,
+                left_cmd_supports=self.left_hand_contact_wrench_supports_command,
+                left_cur_supports=self.left_hand_contact_wrench_supports,
+                tolerance=0.1,
+                var=0.1,
+            )
+            .mean()
+            .item()
+        )
+        self._cws_reward_step_buf.append(cws_step_val)
+        if len(self._cws_reward_step_buf) >= 10:
+            buf = torch.tensor(
+                list(self._cws_reward_step_buf),
+                dtype=torch.float32,
+                device=self.device,
+            )
+            mean_abs = buf.mean().abs().clamp(min=1e-6)
+            cv = buf.std() / mean_abs
+            self.metrics["contact_wrench_support_reward_cv"] = cv.expand(self.num_envs)
 
     def _resample_command(self, env_ids: Sequence[int]) -> None:
         """Resample the command."""

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/curriculum.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/curriculum.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import ast as _ast
 import bisect
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 import torch
 from isaaclab.envs import ManagerBasedRLEnv
@@ -206,6 +206,13 @@ class VirtualObjectControlCurriculum(ManagerTermBase):
             len(self._baseline_reward_names), device=self._env.device
         )
 
+        # Deferred eval-before-decay: when env.pre_decay_eval_enabled is True,
+        # decay application is deferred until the eval callback clears
+        # env.pre_decay_eval_pending.  _deferred_decay_fn is a zero-arg callable
+        # that applies the pending decay once the eval pass finishes.
+        self._decay_deferred: bool = False
+        self._deferred_decay_fn: Callable[[], None] | None = None
+
     def __call__(
         self,
         env: ManagerBasedRLEnv,
@@ -320,6 +327,18 @@ class VirtualObjectControlCurriculum(ManagerTermBase):
                     self._deque_metric_stds[i].expand(n)
                 )
 
+        # 1.5 Deferred eval-before-decay guard.
+        # While a decay is pending an eval pass, collect episode data (section 1)
+        # normally but skip all gate evaluation.  Once the eval callback clears
+        # env.pre_decay_eval_pending, apply the stored decay and return.
+        if self._decay_deferred:
+            if not getattr(self._env, "pre_decay_eval_pending", False):
+                if self._deferred_decay_fn is not None:
+                    self._deferred_decay_fn()
+                    self._deferred_decay_fn = None
+                self._decay_deferred = False
+            return self._command.virtual_object_controller_scale_factor
+
         # 2 Fixed schedule shortcut: set VOC based on common_step_counter thresholds,
         # bypassing all adaptive conditions (episode length, reward thresholds, etc.)
         if decay_mode == "fixed_schedule":
@@ -333,17 +352,38 @@ class VirtualObjectControlCurriculum(ManagerTermBase):
                 if current_step >= step_threshold:
                     target_scale = value
             if target_scale != current_scale:
-                env.video_trigger_pending = True
-                self._command.virtual_object_controller_scale_factor = target_scale
-                self._last_decay_common_step_counter = current_step
-                self._episode_reward_deque.clear()
-                self._episode_length_ratio_deque.clear()
-                logger.info(
-                    "[FixedSchedule] VOC scale %.3f → %.3f at common_step=%d",
-                    current_scale,
-                    target_scale,
-                    current_step,
-                )
+                if getattr(self._env, "pre_decay_eval_enabled", False):
+                    _cs, _ts, _cur_s = current_step, target_scale, current_scale
+
+                    def _apply_fixed(
+                        *, _cs: int = _cs, _ts: float = _ts, _cur_s: float = _cur_s
+                    ) -> None:
+                        self._command.virtual_object_controller_scale_factor = _ts
+                        self._last_decay_common_step_counter = _cs
+                        self._episode_reward_deque.clear()
+                        self._episode_length_ratio_deque.clear()
+                        logger.info(
+                            "[FixedSchedule] VOC scale %.3f → %.3f at common_step=%d",
+                            _cur_s,
+                            _ts,
+                            _cs,
+                        )
+
+                    self._env.pre_decay_eval_pending = True
+                    self._deferred_decay_fn = _apply_fixed
+                    self._decay_deferred = True
+                else:
+                    env.video_trigger_pending = True
+                    self._command.virtual_object_controller_scale_factor = target_scale
+                    self._last_decay_common_step_counter = current_step
+                    self._episode_reward_deque.clear()
+                    self._episode_length_ratio_deque.clear()
+                    logger.info(
+                        "[FixedSchedule] VOC scale %.3f → %.3f at common_step=%d",
+                        current_scale,
+                        target_scale,
+                        current_step,
+                    )
             return self._command.virtual_object_controller_scale_factor
 
         # 2.5 Custom schedule: exit early if all VOC levels already applied
@@ -386,6 +426,48 @@ class VirtualObjectControlCurriculum(ManagerTermBase):
             >= max_eligible_wait_env_steps
         )
         if force_decay:
+            if getattr(self._env, "pre_decay_eval_enabled", False):
+                _idx = self._schedule_index + 1
+                _old = float(self._command.virtual_object_controller_scale_factor)
+                _new = self._custom_voc_schedule[_idx]
+                _ef = current_common_step - self._eligible_since_common_step
+                _ccs = current_common_step
+                _slen = len(self._custom_voc_schedule)
+
+                def _apply_force(
+                    *,
+                    _idx: int = _idx,
+                    _old: float = _old,
+                    _new: float = _new,
+                    _ef: int = _ef,
+                    _ccs: int = _ccs,
+                    _slen: int = _slen,
+                ) -> None:
+                    self._schedule_index = _idx
+                    self._command.virtual_object_controller_scale_factor = _new
+                    for rname, weights in self._custom_reward_schedules.items():
+                        self._reward_manager.get_term_cfg(rname).weight = weights[_idx]
+                    self._last_decay_common_step_counter = _ccs
+                    self._eligible_since_common_step = None
+                    self._episode_reward_deque.clear()
+                    self._episode_length_ratio_deque.clear()
+                    if self._metric_deque is not None:
+                        self._metric_deque.clear()
+                    logger.info(
+                        "[CustomSchedule] FORCED VOC %.3f → %.3f at common_step=%d (eligible for %d steps, stage %d/%d)",
+                        _old,
+                        _new,
+                        _ccs,
+                        _ef,
+                        _idx + 1,
+                        _slen,
+                    )
+
+                self._env.pre_decay_eval_pending = True
+                self._deferred_decay_fn = _apply_force
+                self._decay_deferred = True
+                return self._command.virtual_object_controller_scale_factor
+
             env.video_trigger_pending = True
             self._schedule_index += 1
             old_voc = float(self._command.virtual_object_controller_scale_factor)
@@ -481,8 +563,75 @@ class VirtualObjectControlCurriculum(ManagerTermBase):
                 if current_val > threshold:
                     return self._command.virtual_object_controller_scale_factor
 
-        # 9 Signal that a decay is about to happen so the video recorder can capture
-        # the current policy before the scale factor changes.
+        # 9 Signal that a decay is about to happen.  With pre_decay_eval_enabled,
+        # defer the actual decay until the eval callback has run at the pre-decay
+        # VOC level and cleared env.pre_decay_eval_pending.
+        if getattr(self._env, "pre_decay_eval_enabled", False):
+            _cmode = decay_mode
+            _exp_f = exponential_decay_factor
+            _lin_s = linear_decay_step
+            _zero_t = zero_scale_factor_threshold
+            _erm = episode_reward_means.clone()
+            _ccs = int(self._env.common_step_counter)
+            _slen = len(self._custom_voc_schedule)
+
+            def _apply_adaptive(
+                *,
+                _cmode: str = _cmode,
+                _exp_f: float = _exp_f,
+                _lin_s: float = _lin_s,
+                _zero_t: float = _zero_t,
+                _erm: torch.Tensor = _erm,
+                _ccs: int = _ccs,
+                _slen: int = _slen,
+            ) -> None:
+                old_voc = float(self._command.virtual_object_controller_scale_factor)
+                if _cmode == "exponential":
+                    self._command.virtual_object_controller_scale_factor *= _exp_f
+                elif _cmode == "linear":
+                    self._command.virtual_object_controller_scale_factor -= _lin_s
+                elif _cmode == "custom_schedule":
+                    self._schedule_index += 1
+                    new_voc = self._custom_voc_schedule[self._schedule_index]
+                    self._command.virtual_object_controller_scale_factor = new_voc
+                    for rname, weights in self._custom_reward_schedules.items():
+                        self._reward_manager.get_term_cfg(rname).weight = weights[
+                            self._schedule_index
+                        ]
+                    logger.info(
+                        "[CustomSchedule] VOC %.3f → %.3f at common_step=%d (stage %d/%d)",
+                        old_voc,
+                        new_voc,
+                        _ccs,
+                        self._schedule_index + 1,
+                        _slen,
+                    )
+                else:
+                    raise ValueError(f"Invalid decay mode: {_cmode}")
+                if _cmode != "custom_schedule" and (
+                    self._command.virtual_object_controller_scale_factor <= _zero_t
+                ):
+                    self._command.virtual_object_controller_scale_factor *= 0.0
+                self._last_decay_common_step_counter = _ccs
+                self._eligible_since_common_step = None
+                self._episode_reward_deque.clear()
+                self._episode_length_ratio_deque.clear()
+                if self._metric_deque is not None:
+                    self._metric_deque.clear()
+                if len(self._baseline_reward_indices) > 0:
+                    self._reward_baselines = _erm[self._baseline_reward_indices].clone()
+                    self._deque_reward_baselines[:] = self._reward_baselines
+                logger.info(
+                    "[AdaptiveCurriculum] VOC scale decayed to %.3f at common_step=%d",
+                    float(self._command.virtual_object_controller_scale_factor),
+                    _ccs,
+                )
+
+            self._env.pre_decay_eval_pending = True
+            self._deferred_decay_fn = _apply_adaptive
+            self._decay_deferred = True
+            return self._command.virtual_object_controller_scale_factor
+
         env.video_trigger_pending = True
 
         # 10 Apply decay, set buffer, and clear the deque

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/curriculum.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/curriculum.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import ast as _ast
 import bisect
 import logging
 from collections.abc import Sequence
@@ -125,6 +126,58 @@ class VirtualObjectControlCurriculum(ManagerTermBase):
             len(self._metric_names), device=self._env.device
         )
 
+        # Optional upper-bound metric thresholds: metric must be BELOW the threshold.
+        # Read directly from command metrics each step (not averaged via deque).
+        # Use for scale-invariant stability signals like contact_wrench_support_reward_cv.
+        # Entries with threshold == 0.0 are treated as disabled and excluded.
+        # If metric_upper_thresholds_initial_only=True, gate only applies before the first decay.
+        _raw_upper = cfg.params.get("metric_upper_thresholds", {})
+        self._metric_upper_names: list[str] = [
+            k for k, v in _raw_upper.items() if float(v) > 0.0
+        ]
+        self._metric_upper_thresholds_vals: list[float] = [
+            float(v) for v in _raw_upper.values() if float(v) > 0.0
+        ]
+        self._metric_upper_initial_only: bool = bool(
+            cfg.params.get("metric_upper_thresholds_initial_only", False)
+        )
+
+        # Custom VOC schedule (decay_mode == "custom_schedule"): explicit list of
+        # VOC values to step through one-at-a-time when gates pass, with optional
+        # paired reward-weight updates. Empty lists → custom_schedule disabled.
+        _raw_voc = cfg.params.get("custom_voc_schedule", [])
+        if isinstance(_raw_voc, str):
+            _raw_voc = _ast.literal_eval(_raw_voc)
+        self._custom_voc_schedule: list[float] = [float(v) for v in (_raw_voc or [])]
+
+        _raw_reward_sched = cfg.params.get("custom_reward_schedules", {})
+        self._custom_reward_schedules: dict[str, list[float]] = {}
+        for _rname, _weights in (_raw_reward_sched or {}).items():
+            if isinstance(_weights, str):
+                _weights = _ast.literal_eval(_weights)
+            _wlist = [float(w) for w in (_weights or [])]
+            if _wlist:
+                self._custom_reward_schedules[_rname] = _wlist
+
+        if self._custom_voc_schedule:
+            _avail = self._env.reward_manager._term_names
+            for _rname, _wlist in self._custom_reward_schedules.items():
+                assert (
+                    _rname in _avail
+                ), f"custom_reward_schedules key '{_rname}' not in rewards: {_avail}"
+                assert len(_wlist) == len(self._custom_voc_schedule), (
+                    f"custom_reward_schedules['{_rname}'] length {len(_wlist)} != "
+                    f"custom_voc_schedule length {len(self._custom_voc_schedule)}"
+                )
+
+        # Index into custom_voc_schedule; -1 means no decay has fired yet.
+        self._schedule_index: int = -1
+
+        # Force-decay timeout: common_step when this decay opportunity first became
+        # eligible (past both initial_wait and cooldown). Reset to None after each decay.
+        # Used by max_eligible_wait_env_steps to force a decay if gates never fire.
+        self._eligible_since_common_step: int | None = None
+
         # Reward baseline retention: gates the NEXT decay on current deque mean
         # being >= (deque mean at last decay) * retention_ratio.
         # Trajectory-relative — handles varying plateau values across sequences.
@@ -171,6 +224,11 @@ class VirtualObjectControlCurriculum(ManagerTermBase):
         fixed_schedule_values: list | None = None,
         metric_thresholds: dict[str, float] | None = None,
         reward_baseline_retention: dict[str, float] | None = None,
+        custom_voc_schedule: list | None = None,
+        custom_reward_schedules: dict | None = None,
+        max_eligible_wait_env_steps: int = 0,
+        metric_upper_thresholds: dict[str, float] | None = None,
+        metric_upper_thresholds_initial_only: bool = False,
     ) -> torch.Tensor:
         """Apply the curriculum."""
         # 1 Add normalized episode reward to the deque
@@ -267,12 +325,12 @@ class VirtualObjectControlCurriculum(ManagerTermBase):
         if decay_mode == "fixed_schedule":
             steps = [int(s) for s in (fixed_schedule_steps or [])]
             values = [float(v) for v in (fixed_schedule_values or [])]
-            current_step = self._env.common_step_counter
+            current_step: int = int(self._env.common_step_counter)
             current_scale = float(self._command.virtual_object_controller_scale_factor)
             # Walk through schedule: last threshold that has been passed wins
             target_scale = current_scale
-            for threshold, value in zip(steps, values, strict=False):
-                if current_step >= threshold:
+            for step_threshold, value in zip(steps, values, strict=False):
+                if current_step >= step_threshold:
                     target_scale = value
             if target_scale != current_scale:
                 env.video_trigger_pending = True
@@ -287,6 +345,11 @@ class VirtualObjectControlCurriculum(ManagerTermBase):
                     current_step,
                 )
             return self._command.virtual_object_controller_scale_factor
+
+        # 2.5 Custom schedule: exit early if all VOC levels already applied
+        if decay_mode == "custom_schedule":
+            if self._schedule_index >= len(self._custom_voc_schedule) - 1:
+                return self._command.virtual_object_controller_scale_factor
 
         # 3 Whether the control scale is already zero
         control_scale_is_zero = (
@@ -306,6 +369,48 @@ class VirtualObjectControlCurriculum(ManagerTermBase):
             > self._last_decay_common_step_counter + wait_env_steps_since_last_decay
         )
         if not pass_cooldown_period:
+            self._eligible_since_common_step = None
+            return self._command.virtual_object_controller_scale_factor
+
+        # 5.5 Track when this decay opportunity first became eligible (past both
+        # initial_wait and cooldown). If max_eligible_wait_env_steps is set and we
+        # have been eligible for longer than that without the gates firing, force decay.
+        current_common_step: int = int(self._env.common_step_counter)
+        if self._eligible_since_common_step is None:
+            self._eligible_since_common_step = current_common_step
+
+        force_decay = (
+            decay_mode == "custom_schedule"
+            and max_eligible_wait_env_steps > 0
+            and current_common_step - self._eligible_since_common_step
+            >= max_eligible_wait_env_steps
+        )
+        if force_decay:
+            env.video_trigger_pending = True
+            self._schedule_index += 1
+            old_voc = float(self._command.virtual_object_controller_scale_factor)
+            new_voc = self._custom_voc_schedule[self._schedule_index]
+            self._command.virtual_object_controller_scale_factor = new_voc
+            for rname, weights in self._custom_reward_schedules.items():
+                self._reward_manager.get_term_cfg(rname).weight = weights[
+                    self._schedule_index
+                ]
+            eligible_for = current_common_step - self._eligible_since_common_step
+            self._last_decay_common_step_counter = current_common_step
+            self._eligible_since_common_step = None
+            self._episode_reward_deque.clear()
+            self._episode_length_ratio_deque.clear()
+            if self._metric_deque is not None:
+                self._metric_deque.clear()
+            logger.info(
+                "[CustomSchedule] FORCED VOC %.3f → %.3f at common_step=%d (eligible for %d steps, stage %d/%d)",
+                old_voc,
+                new_voc,
+                current_common_step,
+                eligible_for,
+                self._schedule_index + 1,
+                len(self._custom_voc_schedule),
+            )
             return self._command.virtual_object_controller_scale_factor
 
         # 6 Wait until the deque is full
@@ -354,6 +459,28 @@ class VirtualObjectControlCurriculum(ManagerTermBase):
             if not torch.all(metric_means >= self._metric_thresholds).item():
                 return self._command.virtual_object_controller_scale_factor
 
+        # 8.6 Upper-bound metric thresholds — current metric must be BELOW threshold.
+        # Designed for scale-invariant plateau signals like contact_wrench_support_reward_cv
+        # where a LOW value indicates the reward has stabilized.
+        # When metric_upper_thresholds_initial_only=True, skip this gate after the first decay.
+        _upper_gate_active = self._metric_upper_names and (
+            not self._metric_upper_initial_only or self._schedule_index == -1
+        )
+        if _upper_gate_active:
+            for name, threshold in zip(  # noqa: B905
+                self._metric_upper_names,
+                self._metric_upper_thresholds_vals,
+            ):
+                if name not in self._command.metrics:
+                    logger.warning(
+                        "[Curriculum] metric_upper_thresholds: '%s' not found in command metrics, skipping.",
+                        name,
+                    )
+                    continue
+                current_val = self._command.metrics[name][0].item()
+                if current_val > threshold:
+                    return self._command.virtual_object_controller_scale_factor
+
         # 9 Signal that a decay is about to happen so the video recorder can capture
         # the current policy before the scale factor changes.
         env.video_trigger_pending = True
@@ -365,16 +492,34 @@ class VirtualObjectControlCurriculum(ManagerTermBase):
             )
         elif decay_mode == "linear":
             self._command.virtual_object_controller_scale_factor -= linear_decay_step
+        elif decay_mode == "custom_schedule":
+            self._schedule_index += 1
+            old_voc = float(self._command.virtual_object_controller_scale_factor)
+            new_voc = self._custom_voc_schedule[self._schedule_index]
+            self._command.virtual_object_controller_scale_factor = new_voc
+            for rname, weights in self._custom_reward_schedules.items():
+                self._reward_manager.get_term_cfg(rname).weight = weights[
+                    self._schedule_index
+                ]
+            logger.info(
+                "[CustomSchedule] VOC %.3f → %.3f at common_step=%d (stage %d/%d)",
+                old_voc,
+                new_voc,
+                self._env.common_step_counter,
+                self._schedule_index + 1,
+                len(self._custom_voc_schedule),
+            )
         else:
             raise ValueError(f"Invalid decay mode: {decay_mode}")
 
-        if (
+        if decay_mode != "custom_schedule" and (
             self._command.virtual_object_controller_scale_factor
             <= zero_scale_factor_threshold
         ):
             self._command.virtual_object_controller_scale_factor *= 0.0
 
-        self._last_decay_common_step_counter = self._env.common_step_counter
+        self._last_decay_common_step_counter = int(self._env.common_step_counter)
+        self._eligible_since_common_step = None
         self._episode_reward_deque.clear()
         self._episode_length_ratio_deque.clear()
         if self._metric_deque is not None:

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/v2p_hand_env_cfg.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/v2p_hand_env_cfg.py
@@ -466,6 +466,23 @@ class CurriculumCfg:
             "reward_baseline_retention": {
                 "contact_wrench_support_reward": 0.0,
             },
+            # custom_schedule mode: explicit VOC levels + paired reward weight changes.
+            # Each list has one entry per decay event. Empty = custom_schedule disabled.
+            "custom_voc_schedule": [],
+            "custom_reward_schedules": {
+                "object_keypoints_tracking_exp": [],
+                "hand_keypoints_tracking_exp": [],
+                "hand_joint_pos_tracking_exp": [],
+            },
+            # Force decay after this many env steps of being gate-eligible without firing.
+            # 0 = disabled. Only active in custom_schedule mode.
+            "max_eligible_wait_env_steps": 0,
+            # 0.0 = disabled; set > 0 to require metric <= threshold before decay.
+            "metric_upper_thresholds": {
+                "contact_wrench_support_reward_cv": 0.0,
+            },
+            # If True, metric_upper_thresholds gate only applies before the first decay.
+            "metric_upper_thresholds_initial_only": False,
         },
     )
 

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/v2p_hand_tracking_env_cfg.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/v2p_hand_tracking_env_cfg.py
@@ -67,7 +67,7 @@ class CommandsCfg:
     """Command specifications for the MDP."""
 
     dual_hands_tracking_command = mdp.DualHandsTrackingCommandCfg(
-        debug_vis=True,
+        debug_vis=False,
         motion_speed=0.2,
         reset_finger_openness=0.7,
     )


### PR DESCRIPTION

- **Adaptive auto-curriculum** (`curriculum.py`): CV-gated first VOC decay, WSR-retention gate for subsequent decays, custom VOC schedule (1.0→0.75→…→0.0), force-timeout fallback; new `Sharpa-V2P-AutoCurr-v0` env config and pool/priority support in OSMO configs
- **Eval pipeline overhaul** (`eval_callback.py`): two-pass eval per checkpoint — Pass A (from-start, tc=0) measures full-trajectory completion; Pass B (random reset) measures trajectory coverage; logs `eval/completion_ratio_mean`, `eval/completion_ratio_std`, `eval/full_completion_pct`, `eval/completion_ratio_mean_random`
- **Train/eval distribution gap fix**: `reset_to_first_frame_prob` causes a fraction of training resets to go to tc=0, closing the gap between training distribution and from-start eval
- **VOC-gated eval**: eval runs before each VOC decay and on a 1000-iter fallback, providing signal timed to curriculum transitions
- **Bug fixes**: `custom_schedule` VOC not decaying per-env, eval video now records from frame 0, post-warmup completion ratio denominator, spurious training reward peaks after eval, inference mode not set at step 0, VOC not restored correctly on resume
