### PR TITLE
Add v2d_anycalib for distortion calibration of wild videos, and fixes to hand alignment

### DIFF
--- a/reconstruction/CLAUDE.md
+++ b/reconstruction/CLAUDE.md
@@ -196,6 +196,7 @@ from v2d.mv.calibration.docker.run_calibrate_extrinsics import run_calibrate_ext
 | `v2d_detectron2` | Person detection + IoU tracking from images/video (Detectron2 ViTDet). MV: `run_mv_track_bboxes` |
 | `v2d_moge` | Monocular depth + camera intrinsics from video (MoGe model) |
 | `v2d_unidepth` | Monocular depth estimation (UniDepth model) |
+| `v2d_anycalib` | Single-view camera calibration (intrinsics + distortion) and undistortion for image / video / image folder (AnyCalib model) |
 | `v2d_sam2` | Video segmentation with interactive annotation UI. MV: `run_mv_videos_to_masks` (bbox track `.pt` or grounding dino `.json`) |
 | `v2d_sam3d` | 3D mesh reconstruction from image + mask |
 | `v2d_sam3d_body` | Human body pose and shape estimation (SAM3D-Body MHR). MV: `run_mv_optimize_mhr_params` |

--- a/reconstruction/modules/v2d_anycalib/.dockerignore
+++ b/reconstruction/modules/v2d_anycalib/.dockerignore
@@ -1,0 +1,8 @@
+data/
+checkpoints/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.git/
+.ipynb_checkpoints/

--- a/reconstruction/modules/v2d_anycalib/.gitignore
+++ b/reconstruction/modules/v2d_anycalib/.gitignore
@@ -1,0 +1,6 @@
+data/
+checkpoints/
+*.pt
+*.pth
+*.zip
+__pycache__/

--- a/reconstruction/modules/v2d_anycalib/docker/Dockerfile
+++ b/reconstruction/modules/v2d_anycalib/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    libgl1 \
+    libglib2.0-0 \
+    git \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /workspace
+
+RUN pip install -e /workspace/v2d_common -e /workspace/v2d_anycalib/lib

--- a/reconstruction/modules/v2d_anycalib/docker/_config.py
+++ b/reconstruction/modules/v2d_anycalib/docker/_config.py
@@ -1,0 +1,4 @@
+import os
+
+IMAGE_NAME = "v2d_anycalib"
+MODULES_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."))

--- a/reconstruction/modules/v2d_anycalib/docker/build.py
+++ b/reconstruction/modules/v2d_anycalib/docker/build.py
@@ -1,0 +1,17 @@
+import os
+import subprocess
+
+IMAGE_NAME = "v2d_anycalib"
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+module_dir = os.path.join(current_dir, "..")
+root_dir = os.path.join(module_dir, "..")
+dockerfile_path = os.path.join(current_dir, "Dockerfile")
+
+
+def build_docker_image() -> None:
+    subprocess.run(["docker", "build", "-t", IMAGE_NAME, "-f", dockerfile_path, root_dir], check=True)
+
+
+if __name__ == "__main__":
+    build_docker_image()

--- a/reconstruction/modules/v2d_anycalib/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_anycalib/docker/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "v2d-anycalib-docker"
+version = "0.1.0"
+description = "Docker orchestration scripts for AnyCalib"
+requires-python = ">=3.10"
+dependencies = ["v2d-docker"]
+
+[tool.setuptools]
+packages = ["v2d.anycalib.docker"]
+
+[tool.setuptools.package-dir]
+"v2d.anycalib.docker" = "."

--- a/reconstruction/modules/v2d_anycalib/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_anycalib/docker/run_download_weights.py
@@ -4,7 +4,7 @@ import subprocess
 
 from v2d.anycalib.docker._config import IMAGE_NAME, MODULES_DIR
 
-DEFAULT_MODEL_ID = "javrtg/anycalib_gen"
+DEFAULT_MODEL_ID = "anycalib_gen"
 
 
 def run_download(output_dir: str, model_id: str = DEFAULT_MODEL_ID, dev: bool = False) -> None:
@@ -16,7 +16,7 @@ def run_download(output_dir: str, model_id: str = DEFAULT_MODEL_ID, dev: bool = 
         "docker", "run", "--rm",
         "--gpus", "all",
         "--user", f"{os.getuid()}:{os.getgid()}",
-        "-e", "HF_HOME=/tmp/hf_cache",
+        "-e", "TORCH_HOME=/data/weights",
         "-v", f"{output_dir}:/data/weights",
     ]
     if dev:
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Download AnyCalib checkpoint")
     parser.add_argument("--output_dir", required=True, help="Output directory for checkpoint")
     parser.add_argument("--model_id", type=str, default=DEFAULT_MODEL_ID,
-                        help="HF repo id (default: javrtg/anycalib_gen)")
+                        help="AnyCalib variant: anycalib_pinhole|gen|dist|edit")
     parser.add_argument("--dev", action="store_true", help="Mount local modules for development")
     args = parser.parse_args()
     run_download(output_dir=args.output_dir, model_id=args.model_id, dev=args.dev)

--- a/reconstruction/modules/v2d_anycalib/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_anycalib/docker/run_download_weights.py
@@ -1,0 +1,40 @@
+import argparse
+import os
+import subprocess
+
+from v2d.anycalib.docker._config import IMAGE_NAME, MODULES_DIR
+
+DEFAULT_MODEL_ID = "javrtg/anycalib_gen"
+
+
+def run_download(output_dir: str, model_id: str = DEFAULT_MODEL_ID, dev: bool = False) -> None:
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    output_dir = os.path.abspath(output_dir)
+
+    cmd = [
+        "docker", "run", "--rm",
+        "--gpus", "all",
+        "--user", f"{os.getuid()}:{os.getgid()}",
+        "-e", "HF_HOME=/tmp/hf_cache",
+        "-v", f"{output_dir}:/data/weights",
+    ]
+    if dev:
+        cmd += ["-v", f"{MODULES_DIR}:/workspace"]
+    cmd += [
+        IMAGE_NAME,
+        "python", "-m", "v2d.anycalib.lib.download_weights",
+        "--output_dir", "/data/weights",
+        "--model_id", model_id,
+    ]
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Download AnyCalib checkpoint")
+    parser.add_argument("--output_dir", required=True, help="Output directory for checkpoint")
+    parser.add_argument("--model_id", type=str, default=DEFAULT_MODEL_ID,
+                        help="HF repo id (default: javrtg/anycalib_gen)")
+    parser.add_argument("--dev", action="store_true", help="Mount local modules for development")
+    args = parser.parse_args()
+    run_download(output_dir=args.output_dir, model_id=args.model_id, dev=args.dev)

--- a/reconstruction/modules/v2d_anycalib/docker/run_image_folder_to_calibration.py
+++ b/reconstruction/modules/v2d_anycalib/docker/run_image_folder_to_calibration.py
@@ -1,0 +1,68 @@
+from v2d.docker.container import run_in_container
+from v2d.anycalib.docker._config import IMAGE_NAME, MODULES_DIR
+
+
+def run_image_folder_to_calibration(
+    image_folder: str,
+    intrinsics_path: str,
+    distortion_path: str,
+    weights_path: str,
+    cam_id: str = "kb:4",
+    model_id: str = "anycalib_gen",
+    num_samples: int = 16,
+    undistorted_folder: str | None = None,
+    undistorted_intrinsics_path: str | None = None,
+    balance: float = 0.0,
+    dev: bool = False,
+) -> None:
+    outputs = {"intrinsics_path": intrinsics_path, "distortion_path": distortion_path}
+    if undistorted_folder is not None:
+        outputs["undistorted_folder"] = undistorted_folder
+    if undistorted_intrinsics_path is not None:
+        outputs["undistorted_intrinsics_path"] = undistorted_intrinsics_path
+    run_in_container(
+        image=IMAGE_NAME,
+        module="v2d.anycalib.lib.image_folder_to_calibration",
+        inputs={"image_folder": image_folder, "weights_path": weights_path},
+        outputs=outputs,
+        extra_args={
+            "cam_id": cam_id,
+            "model_id": model_id,
+            "num_samples": num_samples,
+            "balance": balance,
+        },
+        dev=dev,
+        modules_dir=MODULES_DIR,
+        gpus=True,
+    )
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Estimate camera calibration from a folder of images")
+    parser.add_argument("--image_folder", required=True)
+    parser.add_argument("--intrinsics_path", required=True)
+    parser.add_argument("--distortion_path", required=True)
+    parser.add_argument("--weights_path", required=True)
+    parser.add_argument("--cam_id", type=str, default="kb:4")
+    parser.add_argument("--model_id", type=str, default="anycalib_gen")
+    parser.add_argument("--num_samples", type=int, default=16)
+    parser.add_argument("--undistorted_folder", type=str, default=None)
+    parser.add_argument("--undistorted_intrinsics_path", type=str, default=None)
+    parser.add_argument("--balance", type=float, default=0.0)
+    parser.add_argument("--dev", action="store_true")
+    args = parser.parse_args()
+    run_image_folder_to_calibration(
+        image_folder=args.image_folder,
+        intrinsics_path=args.intrinsics_path,
+        distortion_path=args.distortion_path,
+        weights_path=args.weights_path,
+        cam_id=args.cam_id,
+        model_id=args.model_id,
+        num_samples=args.num_samples,
+        undistorted_folder=args.undistorted_folder,
+        undistorted_intrinsics_path=args.undistorted_intrinsics_path,
+        balance=args.balance,
+        dev=args.dev,
+    )

--- a/reconstruction/modules/v2d_anycalib/docker/run_image_to_calibration.py
+++ b/reconstruction/modules/v2d_anycalib/docker/run_image_to_calibration.py
@@ -1,0 +1,60 @@
+from v2d.docker.container import run_in_container
+from v2d.anycalib.docker._config import IMAGE_NAME, MODULES_DIR
+
+
+def run_image_to_calibration(
+    image_path: str,
+    intrinsics_path: str,
+    distortion_path: str,
+    weights_path: str,
+    cam_id: str = "kb:4",
+    model_id: str = "anycalib_gen",
+    undistorted_image_path: str | None = None,
+    undistorted_intrinsics_path: str | None = None,
+    balance: float = 0.0,
+    dev: bool = False,
+) -> None:
+    outputs = {"intrinsics_path": intrinsics_path, "distortion_path": distortion_path}
+    if undistorted_image_path is not None:
+        outputs["undistorted_image_path"] = undistorted_image_path
+    if undistorted_intrinsics_path is not None:
+        outputs["undistorted_intrinsics_path"] = undistorted_intrinsics_path
+    run_in_container(
+        image=IMAGE_NAME,
+        module="v2d.anycalib.lib.image_to_calibration",
+        inputs={"image_path": image_path, "weights_path": weights_path},
+        outputs=outputs,
+        extra_args={"cam_id": cam_id, "model_id": model_id, "balance": balance},
+        dev=dev,
+        modules_dir=MODULES_DIR,
+        gpus=True,
+    )
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Estimate camera calibration from a single image")
+    parser.add_argument("--image_path", required=True)
+    parser.add_argument("--intrinsics_path", required=True)
+    parser.add_argument("--distortion_path", required=True)
+    parser.add_argument("--weights_path", required=True)
+    parser.add_argument("--cam_id", type=str, default="kb:4")
+    parser.add_argument("--model_id", type=str, default="anycalib_gen")
+    parser.add_argument("--undistorted_image_path", type=str, default=None)
+    parser.add_argument("--undistorted_intrinsics_path", type=str, default=None)
+    parser.add_argument("--balance", type=float, default=0.0)
+    parser.add_argument("--dev", action="store_true")
+    args = parser.parse_args()
+    run_image_to_calibration(
+        image_path=args.image_path,
+        intrinsics_path=args.intrinsics_path,
+        distortion_path=args.distortion_path,
+        weights_path=args.weights_path,
+        cam_id=args.cam_id,
+        model_id=args.model_id,
+        undistorted_image_path=args.undistorted_image_path,
+        undistorted_intrinsics_path=args.undistorted_intrinsics_path,
+        balance=args.balance,
+        dev=args.dev,
+    )

--- a/reconstruction/modules/v2d_anycalib/docker/run_shell.py
+++ b/reconstruction/modules/v2d_anycalib/docker/run_shell.py
@@ -1,0 +1,25 @@
+import os
+import subprocess
+
+from v2d.anycalib.docker._config import IMAGE_NAME, MODULES_DIR
+
+
+def run_shell(dev: bool = False) -> None:
+    cmd = [
+        "docker", "run", "-it", "--rm",
+        "--gpus", "all",
+        "--user", f"{os.getuid()}:{os.getgid()}",
+    ]
+    if dev:
+        cmd += ["-v", f"{MODULES_DIR}:/workspace"]
+    cmd += [IMAGE_NAME, "bash"]
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run shell in v2d_anycalib container")
+    parser.add_argument("--dev", action="store_true", help="Mount local modules for development")
+    args = parser.parse_args()
+    run_shell(dev=args.dev)

--- a/reconstruction/modules/v2d_anycalib/docker/run_video_to_calibration.py
+++ b/reconstruction/modules/v2d_anycalib/docker/run_video_to_calibration.py
@@ -1,0 +1,72 @@
+from v2d.docker.container import run_in_container
+from v2d.anycalib.docker._config import IMAGE_NAME, MODULES_DIR
+
+
+def run_video_to_calibration(
+    video_path: str,
+    intrinsics_path: str,
+    distortion_path: str,
+    weights_path: str,
+    cam_id: str = "kb:4",
+    model_id: str = "anycalib_gen",
+    num_samples: int = 16,
+    undistorted_video_path: str | None = None,
+    undistorted_intrinsics_path: str | None = None,
+    balance: float = 0.0,
+    crf: int = 17,
+    dev: bool = False,
+) -> None:
+    outputs = {"intrinsics_path": intrinsics_path, "distortion_path": distortion_path}
+    if undistorted_video_path is not None:
+        outputs["undistorted_video_path"] = undistorted_video_path
+    if undistorted_intrinsics_path is not None:
+        outputs["undistorted_intrinsics_path"] = undistorted_intrinsics_path
+    run_in_container(
+        image=IMAGE_NAME,
+        module="v2d.anycalib.lib.video_to_calibration",
+        inputs={"video_path": video_path, "weights_path": weights_path},
+        outputs=outputs,
+        extra_args={
+            "cam_id": cam_id,
+            "model_id": model_id,
+            "num_samples": num_samples,
+            "balance": balance,
+            "crf": crf,
+        },
+        dev=dev,
+        modules_dir=MODULES_DIR,
+        gpus=True,
+    )
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Estimate camera calibration from a video")
+    parser.add_argument("--video_path", required=True)
+    parser.add_argument("--intrinsics_path", required=True)
+    parser.add_argument("--distortion_path", required=True)
+    parser.add_argument("--weights_path", required=True)
+    parser.add_argument("--cam_id", type=str, default="kb:4")
+    parser.add_argument("--model_id", type=str, default="anycalib_gen")
+    parser.add_argument("--num_samples", type=int, default=16)
+    parser.add_argument("--undistorted_video_path", type=str, default=None)
+    parser.add_argument("--undistorted_intrinsics_path", type=str, default=None)
+    parser.add_argument("--balance", type=float, default=0.0)
+    parser.add_argument("--crf", type=int, default=17)
+    parser.add_argument("--dev", action="store_true")
+    args = parser.parse_args()
+    run_video_to_calibration(
+        video_path=args.video_path,
+        intrinsics_path=args.intrinsics_path,
+        distortion_path=args.distortion_path,
+        weights_path=args.weights_path,
+        cam_id=args.cam_id,
+        model_id=args.model_id,
+        num_samples=args.num_samples,
+        undistorted_video_path=args.undistorted_video_path,
+        undistorted_intrinsics_path=args.undistorted_intrinsics_path,
+        balance=args.balance,
+        crf=args.crf,
+        dev=args.dev,
+    )

--- a/reconstruction/modules/v2d_anycalib/lib/_anycalib.py
+++ b/reconstruction/modules/v2d_anycalib/lib/_anycalib.py
@@ -29,35 +29,25 @@ _CAM_ID_TO_DISTORTION: dict[str, tuple[str, int]] = {
 _model_cache: dict[str, object] = {}
 
 
-def _resolve_checkpoint(weights_path: str) -> str:
-    """Return a path AnyCalib can load (file or HF-style snapshot directory)."""
-    if not os.path.exists(weights_path):
-        raise FileNotFoundError(f"AnyCalib weights not found at {weights_path}")
-    if os.path.isfile(weights_path):
-        return weights_path
-    for name in ("model.safetensors", "pytorch_model.bin", "model.pt"):
-        candidate = os.path.join(weights_path, name)
-        if os.path.exists(candidate):
-            return weights_path  # AnyCalib loads the directory itself
-    return weights_path
-
-
 def _get_model(weights_path: str, model_id: str = "anycalib_gen"):
-    """Load (and cache) an AnyCalib model. ``model_id`` selects the checkpoint
-    variant (anycalib_pinhole / radial / gen / dist)."""
+    """Load (and cache) an AnyCalib model.
+
+    ``weights_path`` is treated as the ``TORCH_HOME`` cache directory (AnyCalib
+    pulls both its checkpoint and the DINOv2 backbone via ``torch.hub``).
+    ``model_id`` selects the variant (anycalib_pinhole / gen / dist / edit).
+    """
     cache_key = f"{model_id}::{weights_path}"
     if cache_key in _model_cache:
         return _model_cache[cache_key]
 
-    from anycalib import AnyCalib  # imported lazily so the lib is import-safe
+    weights_path = os.path.abspath(weights_path)
+    if not os.path.exists(weights_path):
+        raise FileNotFoundError(f"AnyCalib weights cache not found at {weights_path}")
+    os.environ["TORCH_HOME"] = weights_path
 
-    ckpt = _resolve_checkpoint(weights_path)
-    print(f"Loading AnyCalib ({model_id}) from {ckpt}")
-    model = AnyCalib(model_id=model_id)
-    state_loader = getattr(model, "load_pretrained", None)
-    if callable(state_loader):
-        state_loader(ckpt)
-    model = model.to("cuda").eval()
+    from anycalib import AnyCalib  # imported after TORCH_HOME is set
+    print(f"Loading AnyCalib '{model_id}' (TORCH_HOME={weights_path})")
+    model = AnyCalib(model_id=model_id).to("cuda").eval()
     _model_cache[cache_key] = model
     return model
 

--- a/reconstruction/modules/v2d_anycalib/lib/_anycalib.py
+++ b/reconstruction/modules/v2d_anycalib/lib/_anycalib.py
@@ -1,0 +1,158 @@
+"""AnyCalib model loader + thin inference helper.
+
+AnyCalib (Tirado-Garín & Civera, 2024) is a learned single-view camera
+calibrator that outputs intrinsics + distortion under a chosen camera model.
+We expose a single ``predict_calibration`` entry point that maps AnyCalib's
+output into our typed ``CameraIntrinsics`` + ``CameraDistortion`` pair.
+"""
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import torch
+
+from v2d.common.datatypes import CameraDistortion, CameraIntrinsics
+
+
+# AnyCalib cam_id → (CameraDistortion.model, distortion-coeff count).
+# The intrinsic head emits [fx, fy, cx, cy, *dist_params]; the distortion model
+# determines how the trailing params map onto OpenCV conventions.
+_CAM_ID_TO_DISTORTION: dict[str, tuple[str, int]] = {
+    "pinhole":    ("pinhole",        0),
+    "radial:1":   ("opencv",         1),  # k1
+    "radial:2":   ("opencv",         2),  # k1, k2
+    "radial:4":   ("opencv",         4),  # k1, k2, k3, k4
+    "kb:4":       ("opencv_fisheye", 4),  # k1, k2, k3, k4 (Kannala-Brandt)
+}
+
+_model_cache: dict[str, object] = {}
+
+
+def _resolve_checkpoint(weights_path: str) -> str:
+    """Return a path AnyCalib can load (file or HF-style snapshot directory)."""
+    if not os.path.exists(weights_path):
+        raise FileNotFoundError(f"AnyCalib weights not found at {weights_path}")
+    if os.path.isfile(weights_path):
+        return weights_path
+    for name in ("model.safetensors", "pytorch_model.bin", "model.pt"):
+        candidate = os.path.join(weights_path, name)
+        if os.path.exists(candidate):
+            return weights_path  # AnyCalib loads the directory itself
+    return weights_path
+
+
+def _get_model(weights_path: str, model_id: str = "anycalib_gen"):
+    """Load (and cache) an AnyCalib model. ``model_id`` selects the checkpoint
+    variant (anycalib_pinhole / radial / gen / dist)."""
+    cache_key = f"{model_id}::{weights_path}"
+    if cache_key in _model_cache:
+        return _model_cache[cache_key]
+
+    from anycalib import AnyCalib  # imported lazily so the lib is import-safe
+
+    ckpt = _resolve_checkpoint(weights_path)
+    print(f"Loading AnyCalib ({model_id}) from {ckpt}")
+    model = AnyCalib(model_id=model_id)
+    state_loader = getattr(model, "load_pretrained", None)
+    if callable(state_loader):
+        state_loader(ckpt)
+    model = model.to("cuda").eval()
+    _model_cache[cache_key] = model
+    return model
+
+
+def _to_input_tensor(image: np.ndarray) -> torch.Tensor:
+    """Convert HWC uint8 RGB image to NCHW float32 tensor in [0, 1] on CUDA."""
+    if image.dtype != np.uint8:
+        raise TypeError(f"Expected uint8 image, got {image.dtype}")
+    if image.ndim != 3 or image.shape[2] != 3:
+        raise ValueError(f"Expected HWC RGB image, got shape {image.shape}")
+    t = torch.from_numpy(image).permute(2, 0, 1).float() / 255.0
+    return t.unsqueeze(0).to("cuda")
+
+
+def cam_id_distortion_spec(cam_id: str) -> tuple[str, int]:
+    """Return (CameraDistortion.model, num_dist_params) for a given AnyCalib cam_id."""
+    if cam_id not in _CAM_ID_TO_DISTORTION:
+        raise ValueError(
+            f"Unsupported cam_id '{cam_id}'. Supported: {sorted(_CAM_ID_TO_DISTORTION)}"
+        )
+    return _CAM_ID_TO_DISTORTION[cam_id]
+
+
+def predict_calibration(
+    image: np.ndarray,
+    weights_path: str,
+    cam_id: str = "kb:4",
+    model_id: str = "anycalib_gen",
+) -> tuple[CameraIntrinsics, CameraDistortion]:
+    """Estimate intrinsics + distortion from a single RGB image.
+
+    Args:
+        image:        HWC uint8 RGB array.
+        weights_path: Path to AnyCalib checkpoint (file or HF snapshot dir).
+        cam_id:       AnyCalib camera-model id; default ``"kb:4"`` (4-param
+                      Kannala-Brandt fisheye). Other supported ids in
+                      ``_CAM_ID_TO_DISTORTION``.
+        model_id:     Which AnyCalib weights variant the checkpoint corresponds
+                      to. ``anycalib_gen`` accepts any cam_id; the more
+                      specialised variants are constrained.
+
+    Returns:
+        ``(CameraIntrinsics, CameraDistortion)`` for the camera that produced
+        the image. Both share the same image (width, height).
+    """
+    model = _get_model(weights_path, model_id=model_id)
+    h, w = image.shape[:2]
+    input_tensor = _to_input_tensor(image)
+
+    with torch.no_grad():
+        out = model.predict(input_tensor, cam_id=cam_id)
+
+    params = out["intrinsics"][0].detach().cpu().numpy().astype(np.float64)
+    if params.shape[0] < 4:
+        raise RuntimeError(f"AnyCalib returned {params.shape[0]} params, expected ≥ 4")
+
+    fx, fy, cx, cy = (float(v) for v in params[:4])
+    intrinsics = CameraIntrinsics(fx=fx, fy=fy, cx=cx, cy=cy, width=int(w), height=int(h))
+
+    dist_model, n_dist = cam_id_distortion_spec(cam_id)
+    dist_params = [float(v) for v in params[4:4 + n_dist]] if n_dist > 0 else []
+    distortion = CameraDistortion(model=dist_model, params=dist_params)
+    return intrinsics, distortion
+
+
+def aggregate_calibrations(
+    calibrations: list[tuple[CameraIntrinsics, CameraDistortion]],
+) -> tuple[CameraIntrinsics, CameraDistortion]:
+    """Combine multiple per-frame calibrations into one robust estimate (median)."""
+    if not calibrations:
+        raise ValueError("No calibrations to aggregate")
+
+    intrinsics_list = [c[0] for c in calibrations]
+    distortions = [c[1] for c in calibrations]
+
+    models = {d.model for d in distortions}
+    if len(models) != 1:
+        raise ValueError(f"Cannot aggregate mixed distortion models: {models}")
+    dist_model = next(iter(models))
+
+    width = intrinsics_list[0].width
+    height = intrinsics_list[0].height
+
+    fx = float(np.median([k.fx for k in intrinsics_list]))
+    fy = float(np.median([k.fy for k in intrinsics_list]))
+    cx = float(np.median([k.cx for k in intrinsics_list]))
+    cy = float(np.median([k.cy for k in intrinsics_list]))
+
+    if distortions[0].params:
+        stacked = np.stack([np.asarray(d.params, dtype=np.float64) for d in distortions])
+        dist_params = np.median(stacked, axis=0).tolist()
+    else:
+        dist_params = []
+
+    return (
+        CameraIntrinsics(fx=fx, fy=fy, cx=cx, cy=cy, width=width, height=height),
+        CameraDistortion(model=dist_model, params=dist_params),
+    )

--- a/reconstruction/modules/v2d_anycalib/lib/_undistort.py
+++ b/reconstruction/modules/v2d_anycalib/lib/_undistort.py
@@ -1,0 +1,84 @@
+"""OpenCV-based undistortion for the camera models AnyCalib emits.
+
+We support the two most common output models:
+- ``opencv``:         Brown-Conrady (radial+tangential) → ``cv2.undistort`` family
+- ``opencv_fisheye``: Kannala-Brandt (4 params)         → ``cv2.fisheye`` family
+
+For ``pinhole`` we short-circuit (no remap needed).
+"""
+from __future__ import annotations
+
+import numpy as np
+import cv2
+
+from v2d.common.datatypes import CameraDistortion, CameraIntrinsics
+
+
+def _opencv_dist_coeffs(distortion: CameraDistortion) -> np.ndarray:
+    """OpenCV ``cv2.undistort`` accepts (4|5|8|12|14)-element coefficient
+    vectors. Pad shorter param lists out to length 4 with zeros."""
+    p = list(distortion.params)
+    if len(p) < 4:
+        p = p + [0.0] * (4 - len(p))
+    return np.asarray(p, dtype=np.float64).reshape(-1, 1)
+
+
+def build_undistort_maps(
+    intrinsics: CameraIntrinsics,
+    distortion: CameraDistortion,
+    balance: float = 0.0,
+) -> tuple[np.ndarray, np.ndarray, CameraIntrinsics]:
+    """Compute (map1, map2) for ``cv2.remap`` plus the new pinhole intrinsics
+    matching the rectified output.
+
+    Args:
+        intrinsics: Original (distorted) camera intrinsics.
+        distortion: Distortion description (model + params).
+        balance:    Fisheye-only. 0 → crop tightly (no black borders).
+                    1 → keep the full FoV (visible black corners).
+    """
+    K = intrinsics.to_matrix().astype(np.float64)
+    size = (intrinsics.width, intrinsics.height)
+
+    if distortion.model == "pinhole":
+        raise ValueError("No undistortion needed for pinhole cameras")
+
+    if distortion.model == "opencv_fisheye":
+        D = np.asarray(distortion.params, dtype=np.float64).reshape(-1, 1)
+        if D.shape[0] != 4:
+            raise ValueError(f"opencv_fisheye expects 4 params, got {D.shape[0]}")
+        new_K = cv2.fisheye.estimateNewCameraMatrixForUndistortRectify(
+            K, D, size, np.eye(3), balance=balance,
+        )
+        map1, map2 = cv2.fisheye.initUndistortRectifyMap(
+            K, D, np.eye(3), new_K, size, cv2.CV_16SC2,
+        )
+    elif distortion.model == "opencv":
+        D = _opencv_dist_coeffs(distortion)
+        new_K, _ = cv2.getOptimalNewCameraMatrix(K, D, size, alpha=balance, newImgSize=size)
+        map1, map2 = cv2.initUndistortRectifyMap(K, D, np.eye(3), new_K, size, cv2.CV_16SC2)
+    else:
+        raise NotImplementedError(
+            f"Undistortion not implemented for model '{distortion.model}'. "
+            "Supported: 'opencv', 'opencv_fisheye'."
+        )
+
+    new_intrinsics = CameraIntrinsics(
+        fx=float(new_K[0, 0]), fy=float(new_K[1, 1]),
+        cx=float(new_K[0, 2]), cy=float(new_K[1, 2]),
+        width=intrinsics.width, height=intrinsics.height,
+    )
+    return map1, map2, new_intrinsics
+
+
+def undistort_image(
+    image: np.ndarray,
+    intrinsics: CameraIntrinsics,
+    distortion: CameraDistortion,
+    balance: float = 0.0,
+) -> tuple[np.ndarray, CameraIntrinsics]:
+    """Undistort a single HWC image. Returns (rectified_image, new_intrinsics)."""
+    map1, map2, new_intrinsics = build_undistort_maps(intrinsics, distortion, balance)
+    rectified = cv2.remap(image, map1, map2, interpolation=cv2.INTER_LINEAR,
+                          borderMode=cv2.BORDER_CONSTANT)
+    return rectified, new_intrinsics

--- a/reconstruction/modules/v2d_anycalib/lib/download_weights.py
+++ b/reconstruction/modules/v2d_anycalib/lib/download_weights.py
@@ -1,27 +1,40 @@
-"""Download AnyCalib model weights from Hugging Face."""
+"""Pre-download AnyCalib weights into a torch hub cache directory.
+
+AnyCalib auto-fetches its checkpoint from GitHub Releases on first instantiation
+(`AnyCalib(model_id=...)`). The DINOv2 backbone is similarly pulled via
+``torch.hub``. We pre-warm both caches under ``TORCH_HOME=output_dir`` so the
+container can run offline afterwards.
+"""
+from __future__ import annotations
+
 import argparse
 import os
-import subprocess
 
-# Hugging Face repo for the general distortion-aware AnyCalib checkpoint.
-# Variants: anycalib_pinhole, anycalib_radial, anycalib_gen, anycalib_dist.
-DEFAULT_MODEL_ID = "javrtg/anycalib_gen"
+DEFAULT_MODEL_ID = "anycalib_gen"
+AVAILABLE_MODEL_IDS = ("anycalib_pinhole", "anycalib_gen", "anycalib_dist", "anycalib_edit")
 
 
 def download_anycalib(output_dir: str | None = None, model_id: str = DEFAULT_MODEL_ID) -> None:
+    if model_id not in AVAILABLE_MODEL_IDS:
+        raise ValueError(f"Unknown model_id '{model_id}'. Choices: {AVAILABLE_MODEL_IDS}")
     if output_dir is None:
         output_dir = os.environ.get("CHECKPOINT_DIR")
         if output_dir is None:
             raise ValueError("CHECKPOINT_DIR environment variable must be set")
+    output_dir = os.path.abspath(output_dir)
     os.makedirs(output_dir, exist_ok=True)
-    subprocess.run(["hf", "download", model_id, "--local-dir", output_dir], check=True)
-    print(f"AnyCalib checkpoint ({model_id}) downloaded to {output_dir}")
+    os.environ["TORCH_HOME"] = output_dir
+
+    from anycalib import AnyCalib  # imported after TORCH_HOME is set
+    print(f"Downloading AnyCalib '{model_id}' (and DINOv2 backbone) into {output_dir}")
+    AnyCalib(model_id=model_id)  # side effect: torch.hub downloads both checkpoints
+    print("Done.")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Download AnyCalib checkpoint")
     parser.add_argument("--output_dir", type=str, default=None)
     parser.add_argument("--model_id", type=str, default=DEFAULT_MODEL_ID,
-                        help="HF repo id (default: javrtg/anycalib_gen)")
+                        choices=AVAILABLE_MODEL_IDS)
     args = parser.parse_args()
     download_anycalib(output_dir=args.output_dir, model_id=args.model_id)

--- a/reconstruction/modules/v2d_anycalib/lib/download_weights.py
+++ b/reconstruction/modules/v2d_anycalib/lib/download_weights.py
@@ -1,0 +1,27 @@
+"""Download AnyCalib model weights from Hugging Face."""
+import argparse
+import os
+import subprocess
+
+# Hugging Face repo for the general distortion-aware AnyCalib checkpoint.
+# Variants: anycalib_pinhole, anycalib_radial, anycalib_gen, anycalib_dist.
+DEFAULT_MODEL_ID = "javrtg/anycalib_gen"
+
+
+def download_anycalib(output_dir: str | None = None, model_id: str = DEFAULT_MODEL_ID) -> None:
+    if output_dir is None:
+        output_dir = os.environ.get("CHECKPOINT_DIR")
+        if output_dir is None:
+            raise ValueError("CHECKPOINT_DIR environment variable must be set")
+    os.makedirs(output_dir, exist_ok=True)
+    subprocess.run(["hf", "download", model_id, "--local-dir", output_dir], check=True)
+    print(f"AnyCalib checkpoint ({model_id}) downloaded to {output_dir}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Download AnyCalib checkpoint")
+    parser.add_argument("--output_dir", type=str, default=None)
+    parser.add_argument("--model_id", type=str, default=DEFAULT_MODEL_ID,
+                        help="HF repo id (default: javrtg/anycalib_gen)")
+    args = parser.parse_args()
+    download_anycalib(output_dir=args.output_dir, model_id=args.model_id)

--- a/reconstruction/modules/v2d_anycalib/lib/image_folder_to_calibration.py
+++ b/reconstruction/modules/v2d_anycalib/lib/image_folder_to_calibration.py
@@ -1,0 +1,113 @@
+"""AnyCalib: estimate intrinsics + distortion from a folder of images, then
+optionally write undistorted copies of every image to an output folder.
+
+The folder is treated as one camera — per-image AnyCalib estimates are
+aggregated (median) into a single calibration.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import cv2
+import numpy as np
+from PIL import Image
+
+from v2d.anycalib.lib._anycalib import (
+    aggregate_calibrations,
+    predict_calibration,
+)
+from v2d.anycalib.lib._undistort import build_undistort_maps
+
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif", ".webp"}
+
+
+def _list_images(folder: str) -> list[Path]:
+    files = sorted(p for p in Path(folder).iterdir() if p.suffix.lower() in IMAGE_EXTENSIONS)
+    if not files:
+        raise FileNotFoundError(f"No image files found in {folder}")
+    return files
+
+
+def _select_sample_indices(total: int, num_samples: int) -> list[int]:
+    if num_samples >= total:
+        return list(range(total))
+    return np.linspace(0, total - 1, num_samples, dtype=int).tolist()
+
+
+def image_folder_to_calibration(
+    image_folder: str,
+    intrinsics_path: str,
+    distortion_path: str,
+    weights_path: str,
+    cam_id: str = "kb:4",
+    model_id: str = "anycalib_gen",
+    num_samples: int = 16,
+    undistorted_folder: str | None = None,
+    undistorted_intrinsics_path: str | None = None,
+    balance: float = 0.0,
+) -> None:
+    files = _list_images(image_folder)
+    sample_indices = _select_sample_indices(len(files), num_samples)
+
+    calibrations = []
+    for k, idx in enumerate(sample_indices, start=1):
+        image = np.asarray(Image.open(files[idx]).convert("RGB"))
+        calibrations.append(predict_calibration(
+            image, weights_path=weights_path, cam_id=cam_id, model_id=model_id,
+        ))
+        print(f"  sampled {files[idx].name} ({k}/{len(sample_indices)})")
+
+    intrinsics, distortion = aggregate_calibrations(calibrations)
+
+    os.makedirs(os.path.dirname(os.path.abspath(intrinsics_path)), exist_ok=True)
+    os.makedirs(os.path.dirname(os.path.abspath(distortion_path)), exist_ok=True)
+    intrinsics.save(intrinsics_path)
+    distortion.save(distortion_path)
+    print(f"Saved intrinsics → {intrinsics_path}")
+    print(f"Saved distortion ({distortion.model}) → {distortion_path}")
+
+    if undistorted_folder is not None:
+        map1, map2, new_intrinsics = build_undistort_maps(intrinsics, distortion, balance=balance)
+        os.makedirs(undistorted_folder, exist_ok=True)
+        for path in files:
+            bgr = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
+            if bgr is None:
+                print(f"  skipping unreadable {path.name}")
+                continue
+            rectified = cv2.remap(bgr, map1, map2, interpolation=cv2.INTER_LINEAR,
+                                  borderMode=cv2.BORDER_CONSTANT)
+            cv2.imwrite(os.path.join(undistorted_folder, path.name), rectified)
+        print(f"Saved {len(files)} undistorted images → {undistorted_folder}")
+        if undistorted_intrinsics_path is not None:
+            os.makedirs(os.path.dirname(os.path.abspath(undistorted_intrinsics_path)), exist_ok=True)
+            new_intrinsics.save(undistorted_intrinsics_path)
+            print(f"Saved undistorted intrinsics → {undistorted_intrinsics_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Estimate camera calibration from a folder of images")
+    parser.add_argument("--image_folder", required=True)
+    parser.add_argument("--intrinsics_path", required=True)
+    parser.add_argument("--distortion_path", required=True)
+    parser.add_argument("--weights_path", required=True)
+    parser.add_argument("--cam_id", type=str, default="kb:4")
+    parser.add_argument("--model_id", type=str, default="anycalib_gen")
+    parser.add_argument("--num_samples", type=int, default=16)
+    parser.add_argument("--undistorted_folder", type=str, default=None)
+    parser.add_argument("--undistorted_intrinsics_path", type=str, default=None)
+    parser.add_argument("--balance", type=float, default=0.0)
+    args = parser.parse_args()
+    image_folder_to_calibration(
+        image_folder=args.image_folder,
+        intrinsics_path=args.intrinsics_path,
+        distortion_path=args.distortion_path,
+        weights_path=args.weights_path,
+        cam_id=args.cam_id,
+        model_id=args.model_id,
+        num_samples=args.num_samples,
+        undistorted_folder=args.undistorted_folder,
+        undistorted_intrinsics_path=args.undistorted_intrinsics_path,
+        balance=args.balance,
+    )

--- a/reconstruction/modules/v2d_anycalib/lib/image_to_calibration.py
+++ b/reconstruction/modules/v2d_anycalib/lib/image_to_calibration.py
@@ -1,0 +1,83 @@
+"""AnyCalib: estimate intrinsics + distortion from a single image, optionally
+write an undistorted copy of the input.
+
+Usage:
+    python -m v2d.anycalib.lib.image_to_calibration \
+        --image_path /data/in.jpg \
+        --intrinsics_path /data/intrinsics.json \
+        --distortion_path /data/distortion.json \
+        --weights_path /data/weights \
+        [--undistorted_image_path /data/out.jpg \
+         --undistorted_intrinsics_path /data/undistorted_intrinsics.json]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+
+import numpy as np
+from PIL import Image
+
+from v2d.anycalib.lib._anycalib import predict_calibration
+from v2d.anycalib.lib._undistort import undistort_image
+
+
+def image_to_calibration(
+    image_path: str,
+    intrinsics_path: str,
+    distortion_path: str,
+    weights_path: str,
+    cam_id: str = "kb:4",
+    model_id: str = "anycalib_gen",
+    undistorted_image_path: str | None = None,
+    undistorted_intrinsics_path: str | None = None,
+    balance: float = 0.0,
+) -> None:
+    image = np.asarray(Image.open(image_path).convert("RGB"))
+    intrinsics, distortion = predict_calibration(
+        image, weights_path=weights_path, cam_id=cam_id, model_id=model_id,
+    )
+
+    os.makedirs(os.path.dirname(os.path.abspath(intrinsics_path)), exist_ok=True)
+    os.makedirs(os.path.dirname(os.path.abspath(distortion_path)), exist_ok=True)
+    intrinsics.save(intrinsics_path)
+    distortion.save(distortion_path)
+    print(f"Saved intrinsics → {intrinsics_path}")
+    print(f"Saved distortion ({distortion.model}) → {distortion_path}")
+
+    if undistorted_image_path is not None:
+        rectified, new_intrinsics = undistort_image(image, intrinsics, distortion, balance=balance)
+        os.makedirs(os.path.dirname(os.path.abspath(undistorted_image_path)), exist_ok=True)
+        Image.fromarray(rectified).save(undistorted_image_path)
+        print(f"Saved undistorted image → {undistorted_image_path}")
+        if undistorted_intrinsics_path is not None:
+            os.makedirs(os.path.dirname(os.path.abspath(undistorted_intrinsics_path)), exist_ok=True)
+            new_intrinsics.save(undistorted_intrinsics_path)
+            print(f"Saved undistorted intrinsics → {undistorted_intrinsics_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Estimate camera calibration from a single image")
+    parser.add_argument("--image_path", required=True)
+    parser.add_argument("--intrinsics_path", required=True)
+    parser.add_argument("--distortion_path", required=True)
+    parser.add_argument("--weights_path", required=True)
+    parser.add_argument("--cam_id", type=str, default="kb:4",
+                        help="AnyCalib camera model id (default: kb:4 = 4-param fisheye)")
+    parser.add_argument("--model_id", type=str, default="anycalib_gen")
+    parser.add_argument("--undistorted_image_path", type=str, default=None)
+    parser.add_argument("--undistorted_intrinsics_path", type=str, default=None)
+    parser.add_argument("--balance", type=float, default=0.0,
+                        help="Fisheye undistort FoV/crop balance: 0 = crop, 1 = full FoV with borders")
+    args = parser.parse_args()
+    image_to_calibration(
+        image_path=args.image_path,
+        intrinsics_path=args.intrinsics_path,
+        distortion_path=args.distortion_path,
+        weights_path=args.weights_path,
+        cam_id=args.cam_id,
+        model_id=args.model_id,
+        undistorted_image_path=args.undistorted_image_path,
+        undistorted_intrinsics_path=args.undistorted_intrinsics_path,
+        balance=args.balance,
+    )

--- a/reconstruction/modules/v2d_anycalib/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_anycalib/lib/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "v2d-anycalib-lib"
+version = "0.1.0"
+description = "AnyCalib-based monocular camera calibration and undistortion"
+requires-python = ">=3.10"
+dependencies = [
+    "numpy",
+    "Pillow",
+    "opencv-python",
+    "anycalib @ git+https://github.com/javrtg/AnyCalib.git",
+    "v2d-common",
+]
+
+[tool.setuptools]
+packages = ["v2d.anycalib.lib"]
+
+[tool.setuptools.package-dir]
+"v2d.anycalib.lib" = "."

--- a/reconstruction/modules/v2d_anycalib/lib/video_to_calibration.py
+++ b/reconstruction/modules/v2d_anycalib/lib/video_to_calibration.py
@@ -1,0 +1,184 @@
+"""AnyCalib: estimate intrinsics + distortion from a video, optionally write an
+undistorted copy of the video.
+
+Strategy: sample up to ``num_samples`` frames evenly across the video, run
+AnyCalib on each, take the per-parameter median for robustness. If an
+undistorted output video is requested, every frame is remapped through the
+aggregated calibration and re-encoded with ffmpeg.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+
+import cv2
+import numpy as np
+
+from v2d.anycalib.lib._anycalib import (
+    aggregate_calibrations,
+    predict_calibration,
+)
+from v2d.anycalib.lib._undistort import build_undistort_maps
+
+
+def _sample_frame_indices(total: int, num_samples: int) -> list[int]:
+    if total <= 0:
+        raise ValueError("Empty video")
+    if num_samples >= total:
+        return list(range(total))
+    return np.linspace(0, total - 1, num_samples, dtype=int).tolist()
+
+
+def _video_meta(cap: cv2.VideoCapture) -> tuple[int, int, int, float]:
+    width  = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    total  = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    fps    = float(cap.get(cv2.CAP_PROP_FPS)) or 30.0
+    return width, height, total, fps
+
+
+def _estimate_calibration(
+    video_path: str,
+    weights_path: str,
+    cam_id: str,
+    model_id: str,
+    num_samples: int,
+):
+    cap = cv2.VideoCapture(video_path)
+    try:
+        _, _, total, _ = _video_meta(cap)
+        sample_indices = _sample_frame_indices(total, num_samples)
+        calibrations = []
+        for idx in sample_indices:
+            cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
+            ok, frame = cap.read()
+            if not ok:
+                continue
+            rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            calibrations.append(predict_calibration(
+                rgb, weights_path=weights_path, cam_id=cam_id, model_id=model_id,
+            ))
+            print(f"  sampled frame {idx} ({len(calibrations)}/{len(sample_indices)})")
+    finally:
+        cap.release()
+
+    if not calibrations:
+        raise RuntimeError(f"Could not read any frames from {video_path}")
+    return aggregate_calibrations(calibrations)
+
+
+def _remap_video_to_ffmpeg(
+    video_path: str,
+    output_path: str,
+    map1: np.ndarray,
+    map2: np.ndarray,
+    fps: float,
+    width: int,
+    height: int,
+    crf: int,
+) -> None:
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    proc = subprocess.Popen(
+        [
+            "ffmpeg", "-y",
+            "-f", "rawvideo", "-vcodec", "rawvideo",
+            "-s", f"{width}x{height}", "-pix_fmt", "bgr24",
+            "-r", str(fps), "-i", "-",
+            "-c:v", "libx264", "-crf", str(crf),
+            "-pix_fmt", "yuv420p",
+            output_path,
+        ],
+        stdin=subprocess.PIPE,
+    )
+    cap = cv2.VideoCapture(video_path)
+    try:
+        n = 0
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+            rectified = cv2.remap(frame, map1, map2, interpolation=cv2.INTER_LINEAR,
+                                  borderMode=cv2.BORDER_CONSTANT)
+            proc.stdin.write(rectified.tobytes())
+            n += 1
+            if n % 100 == 0:
+                print(f"  remapped {n} frames...")
+        print(f"  remapped {n} frames total")
+    finally:
+        cap.release()
+        if proc.stdin:
+            proc.stdin.close()
+        proc.wait()
+        if proc.returncode != 0:
+            raise RuntimeError(f"ffmpeg failed with return code {proc.returncode}")
+
+
+def video_to_calibration(
+    video_path: str,
+    intrinsics_path: str,
+    distortion_path: str,
+    weights_path: str,
+    cam_id: str = "kb:4",
+    model_id: str = "anycalib_gen",
+    num_samples: int = 16,
+    undistorted_video_path: str | None = None,
+    undistorted_intrinsics_path: str | None = None,
+    balance: float = 0.0,
+    crf: int = 17,
+) -> None:
+    intrinsics, distortion = _estimate_calibration(
+        video_path, weights_path, cam_id, model_id, num_samples,
+    )
+
+    os.makedirs(os.path.dirname(os.path.abspath(intrinsics_path)), exist_ok=True)
+    os.makedirs(os.path.dirname(os.path.abspath(distortion_path)), exist_ok=True)
+    intrinsics.save(intrinsics_path)
+    distortion.save(distortion_path)
+    print(f"Saved intrinsics → {intrinsics_path}")
+    print(f"Saved distortion ({distortion.model}) → {distortion_path}")
+
+    if undistorted_video_path is not None:
+        map1, map2, new_intrinsics = build_undistort_maps(intrinsics, distortion, balance=balance)
+        cap = cv2.VideoCapture(video_path)
+        width, height, _, fps = _video_meta(cap)
+        cap.release()
+        _remap_video_to_ffmpeg(
+            video_path, undistorted_video_path, map1, map2,
+            fps=fps, width=width, height=height, crf=crf,
+        )
+        print(f"Saved undistorted video → {undistorted_video_path}")
+        if undistorted_intrinsics_path is not None:
+            os.makedirs(os.path.dirname(os.path.abspath(undistorted_intrinsics_path)), exist_ok=True)
+            new_intrinsics.save(undistorted_intrinsics_path)
+            print(f"Saved undistorted intrinsics → {undistorted_intrinsics_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Estimate camera calibration from a video")
+    parser.add_argument("--video_path", required=True)
+    parser.add_argument("--intrinsics_path", required=True)
+    parser.add_argument("--distortion_path", required=True)
+    parser.add_argument("--weights_path", required=True)
+    parser.add_argument("--cam_id", type=str, default="kb:4")
+    parser.add_argument("--model_id", type=str, default="anycalib_gen")
+    parser.add_argument("--num_samples", type=int, default=16,
+                        help="Number of frames to sample for the calibration estimate")
+    parser.add_argument("--undistorted_video_path", type=str, default=None)
+    parser.add_argument("--undistorted_intrinsics_path", type=str, default=None)
+    parser.add_argument("--balance", type=float, default=0.0)
+    parser.add_argument("--crf", type=int, default=17, help="x264 CRF for the output video")
+    args = parser.parse_args()
+    video_to_calibration(
+        video_path=args.video_path,
+        intrinsics_path=args.intrinsics_path,
+        distortion_path=args.distortion_path,
+        weights_path=args.weights_path,
+        cam_id=args.cam_id,
+        model_id=args.model_id,
+        num_samples=args.num_samples,
+        undistorted_video_path=args.undistorted_video_path,
+        undistorted_intrinsics_path=args.undistorted_intrinsics_path,
+        balance=args.balance,
+        crf=args.crf,
+    )

--- a/reconstruction/modules/v2d_common/datatypes.py
+++ b/reconstruction/modules/v2d_common/datatypes.py
@@ -76,6 +76,39 @@ class CameraIntrinsics:
             [0, 0, 1]
         ], dtype=np.float32)
 
+
+@dataclass
+class CameraDistortion:
+    """Camera lens distortion parameters.
+
+    Companion to ``CameraIntrinsics`` (which only carries pinhole fx/fy/cx/cy).
+    The model name follows OpenCV conventions:
+
+    - ``"pinhole"``        — no distortion (``params == []``)
+    - ``"opencv"``         — Brown-Conrady ``[k1, k2, p1, p2, k3, ...]``
+                             (4, 5, 8, 12, or 14 coefficients accepted)
+    - ``"opencv_fisheye"`` — Kannala-Brandt fisheye ``[k1, k2, k3, k4]``
+    """
+    model: str
+    params: list[float]
+
+    def to_dict(self) -> dict:
+        return {"model": self.model, "params": list(self.params)}
+
+    @staticmethod
+    def from_dict(d: dict) -> 'CameraDistortion':
+        return CameraDistortion(model=d["model"], params=list(d["params"]))
+
+    def save(self, path: str) -> None:
+        with open(path, 'w') as f:
+            json.dump(self.to_dict(), f, indent=4)
+
+    @staticmethod
+    def load(path: str) -> 'CameraDistortion':
+        with open(path) as f:
+            return CameraDistortion.from_dict(json.load(f))
+
+
 @dataclass
 class Transform3d:
     rotation: list[float]

--- a/reconstruction/modules/v2d_hand_alignment/lib/align_world_results.py
+++ b/reconstruction/modules/v2d_hand_alignment/lib/align_world_results.py
@@ -11,6 +11,10 @@ and stores them in both camera and world frame.
 Output schema: all original world_results fields plus:
   trans_aligned     (B, T, 3)  depth-aligned translation, same world units as trans
   intrins_aligned   (4,)       [fx,fy,cx,cy] of the depth image used for alignment
+  hand_scale        ()         constant uniform mesh scale that makes the
+                               aligned hand silhouette match the image under
+                               the depth intrinsics (n_pixels-weighted median
+                               of per-frame depth_image / rendered_depth)
   object_pose_cam   (T, 4, 4)  object-to-camera SE(3) [present if --object_poses_dir]
   object_pose_world (T, 4, 4)  object-to-world SE(3)  [present if --object_poses_dir]
 
@@ -75,33 +79,65 @@ def align_world_results(
     )
 
     # ------------------------------------------------------------------
-    # Per-hand per-frame depth offset → trans_aligned
+    # Per-hand per-frame depth offset → trans_aligned + per-frame scales
     # ------------------------------------------------------------------
-    # HandObjectAlignment._compute_hand does NOT apply world_scale, so
-    # compute_offset returns a delta in the same camera-space units as the
-    # rendered verts.  Rotating back with cam_R.T gives a world-space delta
-    # in those same units, which can be added directly to trans.
-    print("\nComputing per-frame depth offsets (reprojected)...")
+    # One render pass per (hand, frame) yields both the offset (used for
+    # trans_aligned) and the per-frame depth-vs-render scale (aggregated into
+    # a single global hand_scale below).
+    print("\nComputing per-frame depth alignment (offset + scale)...")
     trans_aligned = trans.copy()
-    offsets = np.full((B, T), np.nan)
+    offsets       = np.full((B, T), np.nan)
+    scales        = np.full((B, T), np.nan)
+    pixels        = np.zeros((B, T), dtype=np.int64)
 
     for h in range(B):
         side = 1 if is_right_track[h] else 0
+        # The renderer mirrors v_world.x AFTER adding trans for the left hand
+        # (render_dynhamr_video.py: `v_world[:, :, 0] = -v_world[:, :, 0]`),
+        # so for left hands we must mirror the world-space delta to keep the
+        # cam-space shift equal to delta_cam.  Derivation:
+        #   v_cam = cam_R · M · (verts_local + trans) + cam_t      # left
+        #   ⇒ delta_world = M · cam_R.T · delta_cam,   M = diag(-1, 1, 1)
         for f in tqdm(range(T), desc=f"  hand {h} ({'right' if is_right_track[h] else 'left'})",
                       unit="frame", ncols=80):
             try:
-                delta_cam   = alignment.compute_offset_reprojected(side, f)
-                delta_world = cam_R[h, f].T @ delta_cam
+                a = alignment.compute_alignment(side, f)
+                delta_world = cam_R[h, f].T @ a["offset_reprojected"]
+                if side == 0:
+                    delta_world[0] = -delta_world[0]
                 trans_aligned[h, f] += delta_world
-                offsets[h, f] = delta_cam[2]
+                offsets[h, f] = a["offset_reprojected"][2]
+                scales[h, f]  = a["scale"]
+                pixels[h, f]  = a["n_pixels"]
             except Exception as e:
-                tqdm.write(f"  hand {h} frame {f}: offset failed ({e})")
+                tqdm.write(f"  hand {h} frame {f}: alignment failed ({e})")
 
     for h in range(B):
         side = 'right' if is_right_track[h] else 'left'
         n_valid = int(np.sum(np.isfinite(offsets[h])))
-        med = float(np.nanmedian(offsets[h])) if n_valid > 0 else float('nan')
-        print(f"  hand {h} ({side}): {n_valid}/{T} valid  median dz={med:.4f}")
+        med_dz  = float(np.nanmedian(offsets[h])) if n_valid > 0 else float('nan')
+        med_s   = float(np.nanmedian(scales[h]))  if n_valid > 0 else float('nan')
+        print(f"  hand {h} ({side}): {n_valid}/{T} valid  median dz={med_dz:.4f}  median scale={med_s:.4f}")
+
+    # ------------------------------------------------------------------
+    # Aggregate per-frame scales → single global hand_scale (n_pixels-weighted)
+    # ------------------------------------------------------------------
+    # Reject frames with very small masks (occluded / clipped) or absurd
+    # scale values (a fully-occluded hand can yield wild ratios).
+    valid = (pixels >= 256) & np.isfinite(scales) & (scales > 0.2) & (scales < 5.0)
+    if valid.any():
+        s_vals = scales[valid].astype(np.float64)
+        w_vals = pixels[valid].astype(np.float64)
+        order  = np.argsort(s_vals)
+        s_sorted = s_vals[order]
+        w_cum    = np.cumsum(w_vals[order])
+        cutoff   = w_cum[-1] / 2.0
+        hand_scale = float(s_sorted[int(np.searchsorted(w_cum, cutoff))])
+        print(f"\nGlobal hand_scale = {hand_scale:.4f}  "
+              f"(weighted median over {int(valid.sum())}/{B*T} frames)")
+    else:
+        hand_scale = 1.0
+        print("\nGlobal hand_scale = 1.0  (no valid frames; alignment will not rescale)")
 
     # ------------------------------------------------------------------
     # Optional temporal smoothing of trans_aligned
@@ -129,6 +165,7 @@ def align_world_results(
     # ------------------------------------------------------------------
     out = {k: wr[k] for k in wr.files}
     out['trans_aligned'] = trans_aligned.astype(np.float32)
+    out['hand_scale']    = np.float32(hand_scale)
 
     # Store the depth intrinsics used for alignment so renderers can use them
     depth_intr = alignment.get_depth_intrinsics()   # [fx, fy, cx, cy]
@@ -175,6 +212,7 @@ def align_world_results(
     print(f"\nSaved → {output_hand_data}")
     print(f"  trans_aligned: depth-aligned world units"
           + (f", smoothed (sigma={smooth_sigma})" if smooth_sigma > 0 else ""))
+    print(f"  hand_scale:    {hand_scale:.4f}")
     if 'object_pose_cam' in out:
         print(f"  object_pose_cam / object_pose_world: {out['object_pose_cam'].shape}")
 

--- a/reconstruction/modules/v2d_hand_alignment/lib/hand_object_alignment.py
+++ b/reconstruction/modules/v2d_hand_alignment/lib/hand_object_alignment.py
@@ -170,37 +170,6 @@ class HandObjectAlignment:
     # Alignment
     # ------------------------------------------------------------------
 
-    def compute_offset(self, side: int, t: int) -> np.ndarray:
-        """Camera-space [dx, dy, dz] to shift the hand to match the depth image.
-
-        Renders the hand using DynHaMR intrinsics, computes the median depth
-        difference over visible, non-occluded pixels, then scales dx/dy so the
-        centroid moves along the camera ray.
-
-        Returns:
-            offset (3,) float64 in the same units as verts_cam (DynHaMR world
-            units, since _compute_hand does not apply world_scale).
-        """
-        mesh         = self.get_mesh(side, t)
-        depth_image  = self.get_depth_image(t)
-        occ_mask     = self.get_occlusion_mask(t)
-        h, w         = depth_image.shape
-        _, depth     = self.render_mesh(mesh, (w, h), self.pose_data['intrins'])
-
-        hand_mask = depth != 0
-        if occ_mask is not None:
-            hand_mask &= ~occ_mask
-
-        dz = float(np.median(depth_image[hand_mask] - depth[hand_mask]))
-
-        z = float(np.mean(mesh.vertices[:, 2]))
-        x = float(np.mean(mesh.vertices[:, 0]))
-        y = float(np.mean(mesh.vertices[:, 1]))
-        z_p = z + dz
-        return np.array([x / z * z_p - x,
-                         y / z * z_p - y,
-                         dz], dtype=np.float64)
-
     def _reproject(self, v: np.ndarray, src_intrinsics, target_intrinsics) -> np.ndarray:
         """Reproject camera-space point(s) from src to target intrinsics (z unchanged)."""
         fx,   fy,   cx,   cy   = src_intrinsics
@@ -210,41 +179,81 @@ class HandObjectAlignment:
         y_p = (z / fy_p) * (y / z * fy + cy - cy_p)
         return np.stack([x_p, y_p, np.broadcast_to(z, x_p.shape)], axis=-1)
 
-    def compute_offset_reprojected(self, side: int, t: int) -> np.ndarray:
-        """Camera-space [dx, dy, dz] accounting for DynHaMR vs depth intrinsics.
+    def compute_alignment(self, side: int, t: int) -> dict:
+        """Single render pass; returns offset, offset_reprojected, scale, n_pixels.
 
-        compute_offset renders with DynHaMR intrinsics, but the target depth image
-        was produced with different intrinsics (MoGe / ViPE).  This method applies
-        the raw depth offset to the hand centroid, then reprojects from DynHaMR
-        pixel space into depth pixel space so the x/y shift is expressed in the
-        depth image's coordinate system.
+        Renders the hand under DynHaMR (ViPE) intrinsics once and derives:
+          offset             — cam-space [dx, dy, dz] under ViPE intrinsics that
+                               shifts the hand centroid to match the depth image
+                               along its camera ray.
+          offset_reprojected — same shift but expressed in depth-image cam
+                               coordinates (used when depth intrinsics differ
+                               from ViPE).
+          scale              — median(depth_image / rendered_depth) over hand
+                               pixels.  Constant across time when the depth
+                               source disagrees with DynHaMR by a uniform scale,
+                               which is the dominant monocular failure mode.
+          n_pixels           — number of valid hand-mask pixels (use as a weight
+                               when aggregating across frames).
 
-        Returns:
-            offset (3,) float64 in depth-intrinsics camera space.
+        Raises if the hand mask is empty (e.g. fully occluded or off-image).
         """
-        offset = self.compute_offset(side, t)          # (3,) under DynHaMR intrinsics
+        mesh        = self.get_mesh(side, t)
+        depth_image = self.get_depth_image(t)
+        occ_mask    = self.get_occlusion_mask(t)
+        h, w        = depth_image.shape
+        _, rendered = self.render_mesh(mesh, (w, h), self.pose_data['intrins'])
 
-        verts   = self.right_verts_cam if side == 1 else self.left_verts_cam
-        centroid = verts[t].numpy().mean(axis=0)        # (3,) original cam-space centroid
+        hand_mask = rendered != 0
+        if occ_mask is not None:
+            hand_mask &= ~occ_mask
 
-        shifted  = centroid + offset                    # centroid after depth shift
+        n_pixels = int(hand_mask.sum())
+        if n_pixels == 0:
+            raise RuntimeError(f"empty hand mask (side={side}, t={t})")
 
-        reproj = self._reproject(
+        di = depth_image[hand_mask]
+        dr = rendered[hand_mask]
+
+        dz = float(np.median(di - dr))
+        scale = float(np.median(di / dr))
+
+        # Offset along the camera ray: shift centroid by (dx, dy, dz) so its
+        # pixel projection is unchanged but its depth becomes z + dz.
+        z = float(np.mean(mesh.vertices[:, 2]))
+        x = float(np.mean(mesh.vertices[:, 0]))
+        y = float(np.mean(mesh.vertices[:, 1]))
+        z_p = z + dz
+        offset = np.array([x / z * z_p - x,
+                           y / z * z_p - y,
+                           dz], dtype=np.float64)
+
+        # Reproject the depth-shifted centroid into the depth-image cam frame.
+        verts    = self.right_verts_cam if side == 1 else self.left_verts_cam
+        centroid = verts[t].numpy().mean(axis=0)
+        shifted  = centroid + offset
+        reproj   = self._reproject(
             shifted.reshape(1, 3),
             self.pose_data['intrins'],
             self.get_depth_intrinsics(),
         ).reshape(3)
+        offset_reprojected = (reproj - centroid).astype(np.float64)
 
-        return (reproj - centroid).astype(np.float64)
+        return {
+            "offset":             offset,
+            "offset_reprojected": offset_reprojected,
+            "scale":              scale,
+            "n_pixels":           n_pixels,
+        }
+
+    def compute_offset(self, side: int, t: int) -> np.ndarray:
+        """Backward-compat shim; prefer :meth:`compute_alignment`."""
+        return self.compute_alignment(side, t)["offset"]
+
+    def compute_offset_reprojected(self, side: int, t: int) -> np.ndarray:
+        """Backward-compat shim; prefer :meth:`compute_alignment`."""
+        return self.compute_alignment(side, t)["offset_reprojected"]
 
     def compute_scale(self, side: int, t: int) -> float:
-        """Depth scale factor: median(depth_image / rendered_depth) over hand pixels."""
-        mesh         = self.get_mesh(side, t)
-        depth_image  = self.get_depth_image(t)
-        occ_mask     = self.get_occlusion_mask(t)
-        h, w         = depth_image.shape
-        _, depth     = self.render_mesh(mesh, (w, h), self.pose_data['intrins'])
-        hand_mask = depth != 0
-        if occ_mask is not None:
-            hand_mask &= ~occ_mask
-        return float(np.median(depth_image[hand_mask] / depth[hand_mask]))
+        """Backward-compat shim; prefer :meth:`compute_alignment`."""
+        return self.compute_alignment(side, t)["scale"]

--- a/reconstruction/modules/v2d_hand_alignment/lib/render_dynhamr_video.py
+++ b/reconstruction/modules/v2d_hand_alignment/lib/render_dynhamr_video.py
@@ -127,6 +127,17 @@ def render_dynhamr_video(
         trans       = wr['trans'].astype(np.float32)
         trans_label = 'trans'
 
+    # When rendering the depth-aligned hand under depth intrinsics, scale the
+    # MANO mesh by the constant hand_scale produced by align_world_results so
+    # the silhouette matches the image (compensates for fx mismatch and
+    # MoGe-vs-DynHaMR depth disagreement).  Apply only to aligned renders;
+    # raw `trans` is image-correct under ViPE intrinsics with scale = 1.
+    if use_trans_aligned and 'hand_scale' in wr.files:
+        hand_scale = float(wr['hand_scale'])
+    else:
+        hand_scale = 1.0
+    print(f"  hand_scale = {hand_scale:.4f}")
+
     B, T = root_orient.shape[:2]
     is_right_track = is_right.mean(axis=1) > 0.5
 
@@ -157,6 +168,13 @@ def render_dynhamr_video(
         hand_betas  = torch.from_numpy(np.tile(betas[h], (T, 1)))
         mano_out    = mano_layer(hand_pose, hand_betas)
         verts_local = mano_out.verts.detach().numpy()  # (T, 778, 3)
+
+        # Scale around the per-frame centroid so the centroid pixel is preserved
+        # (trans_aligned already places it correctly) while the silhouette grows
+        # or shrinks to match the image under the depth intrinsics.
+        if hand_scale != 1.0:
+            c = verts_local.mean(axis=1, keepdims=True)        # (T, 1, 3)
+            verts_local = (verts_local - c) * hand_scale + c
 
         v_world = verts_local + trans[h, :, None, :]  # DynHaMR world units (no world_scale)
         if left:

--- a/reconstruction/modules/v2d_nlf/docker/Dockerfile
+++ b/reconstruction/modules/v2d_nlf/docker/Dockerfile
@@ -35,7 +35,8 @@ RUN pip3 install warp-lang
 
 COPY . /workspace
 
-RUN pip install -e /workspace/v2d_common \
+RUN pip install -e "/workspace/v2d_mv[io,math]" \
+    -e /workspace/v2d_common \
     -e /workspace/v2d_mesh/lib \
     -e /workspace/v2d_foundation_pose/lib \
     -e /workspace/v2d_nlf/lib

--- a/reconstruction/modules/v2d_pipelines/run_v2d_ego_e2e.py
+++ b/reconstruction/modules/v2d_pipelines/run_v2d_ego_e2e.py
@@ -579,6 +579,8 @@ def run_v2d_ego_e2e(
 
     # -----------------------------------------------------------------------
     # Step 13: Render unaligned result (trans) for comparison
+    # Raw DynHaMR `trans` was optimized under ViPE intrinsics, so we must
+    # project it through ViPE intrinsics regardless of --depth_source.
     # -----------------------------------------------------------------------
     if not _step(f"Render unaligned (trans, {ds})", os.path.exists(render_unaligned)):
         run_render_dynhamr_video(
@@ -589,7 +591,7 @@ def run_v2d_ego_e2e(
             use_trans_aligned  = False,
             object_mesh_path   = mesh_scaled,
             object_poses_dir   = poses_smooth_dir,
-            intrinsics_path    = active_intrinsics,
+            intrinsics_path    = intrinsics_vipe,
             dev                = dev,
         )
 

--- a/reconstruction/scripts/build_containers.sh
+++ b/reconstruction/scripts/build_containers.sh
@@ -6,7 +6,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
-MODULES=(unidepth moge sam2 sam3d grounding_dino foundation_stereo foundation_pose nlf)
+MODULES=(unidepth moge anycalib sam2 sam3d grounding_dino foundation_stereo foundation_pose nlf)
 
 for module in "${MODULES[@]}"; do
   echo "Building v2d_${module}..."

--- a/reconstruction/scripts/install_packages.sh
+++ b/reconstruction/scripts/install_packages.sh
@@ -11,6 +11,7 @@ pip install -e modules/v2d_sam2/docker \
   -e modules/v2d_sam3d/docker \
   -e modules/v2d_unidepth/docker \
   -e modules/v2d_moge/docker \
+  -e modules/v2d_anycalib/docker \
   -e modules/v2d_nlf/docker \
   -e modules/v2d_foundation_pose/docker \
   -e modules/v2d_foundation_stereo/docker \


### PR DESCRIPTION
# Add v2d_anycalib + fisheye-aware hand alignment

## Summary

- New `v2d_anycalib` module: single-view camera calibration (intrinsics + distortion) and undistortion via AnyCalib, for image / image folder / video inputs. Lets the e2e pipeline run on undistorted frames so ViPE/MoGe/FoundationPose/DynHaMR don't fight the fisheye.
- Fixes for `v2d_hand_alignment` aligned/unaligned renders on fisheye footage: intrinsics misuse, left-hand mirror, and missing per-vertex size correction under depth-source intrinsics.

## Changes

**`v2d_anycalib`** — `lib/` calibration + undistortion, `docker/` host-side wrappers (image, image folder, video, shell, weights download), Dockerfile, pyproject, `v2d_common.datatypes` fields for distortion + undistorted intrinsics.

**`v2d_hand_alignment`**
- `run_v2d_ego_e2e.render_unaligned` now passes `intrinsics_vipe` (raw `trans/cam_R/cam_t` were optimized against ViPE's pinhole; depth-source intrinsics break it).
- `align_world_results` mirrors `delta_world.x` for left hands — the renderer flips x *after* adding `trans`, so the world-space delta must match.
- `HandObjectAlignment.compute_alignment(side, t)` does one render pass and returns `{offset, offset_reprojected, scale, n_pixels}`. Old methods are thin shims.
- `align_world_results` aggregates per-frame scales into a constant `hand_scale` (`n_pixels`-weighted median, rejecting <256-pixel or out-of-`[0.2, 5.0]` frames) and saves it on `world_results_aligned_*.npz`. MANO has no native scale knob, so a post-MANO scalar is the right schema.
- `render_dynhamr_video` applies `hand_scale` around the per-frame centroid only when `use_trans_aligned=True`; falls back to 1.0 when absent (backward-compat).

**Misc** — `v2d_nlf` Docker build fix.

## Why

`hand_scale = (fx_vipe / fx_moge) × (z_moge / z_vipe)` resolves both the ViPE-vs-MoGe focal mismatch (wrong silhouette size) and the MoGe-vs-DynHaMR depth disagreement (centroid at wrong depth). Approximately constant across time, so a single global value works.

## Test plan

- [ ] `run_v2d_ego_e2e` on raw fisheye and AnyCalib-undistorted inputs.
- [ ] `render_unaligned_moge.mp4` matches DynHaMR `*_src_cam.mp4` modulo OneEuro smoothing (known).
- [ ] `render_aligned_moge.mp4` hand silhouette overlays image hand at correct size.
- [ ] `world_results_aligned_*.npz` contains `hand_scale`; old npzs without it still render.
- [ ] `mano.ipynb`: scaled hand sits on depth point cloud, not just along its ray.
- [ ] AnyCalib end-to-end: per-frame `dz` smaller on undistorted stream than on raw fisheye.
