### PR TITLE
[robotic_grounding] feat: prepare TPV whole-body training set

### DIFF
--- a/robotic_grounding/experiments/recon_body_blue_trash_can_drag_007/config.yaml
+++ b/robotic_grounding/experiments/recon_body_blue_trash_can_drag_007/config.yaml
@@ -1,0 +1,37 @@
+# ReconBody: Blue trash can dragging with whole-body tracking
+#
+# Usage:
+#   python robotic_grounding/experiments/run_experiment.py recon_body_blue_trash_can_drag_007 --local
+id: recon_body_blue_trash_can_drag_007
+description: "ReconBody blue trash can dragging with SONIC JOINT_RESIDUAL"
+run_name: recon_body_blue_trash_can_drag_007
+task: SonicG1-ReconBody-v0
+# Use the explicit repo-relative partition path because whole_body/soma does not
+# follow the 4-part dataset/dataset_retargeted/sequence_id/robot shorthand.
+motion_file: source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-20_17-37-45_blue_trash_can_drag_007/robot_name=g1
+video: true
+num_envs: 4096
+max_iterations: 20000
+zero_actor: true
+logger: wandb
+log_project_name: v2d-whole-body-tpv
+
+train_overrides:
+  env.commands.motion.reset_freeze_steps: 50
+  env.commands.motion.voc_decay_steps: 10
+  env.commands.motion.voc_reset_scale: 1.0
+  env.commands.motion.initial_virtual_object_control_curriculum_scale: 1.0
+  env.episode_length_s: 5.0
+
+  # Frame range of the source motion to train on. -1 for motion_end_frame
+  # means run to the end of the sequence.
+  # Use replay_motion_viser.py to visualize the motion and get the frame range.
+  env.commands.motion.motion_start_frame: 0
+  env.commands.motion.motion_end_frame: 250
+  # Reset the shoulder spread to 0.2
+  env.commands.motion.reset_shoulder_spread: 0.2
+
+osmo:
+  build_image: false
+  # Reuse the current whole-body training image so submits don't fall back to :latest.
+  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple

--- a/robotic_grounding/experiments/recon_body_dark_blue_book_pick_handover_place_02/config.yaml
+++ b/robotic_grounding/experiments/recon_body_dark_blue_book_pick_handover_place_02/config.yaml
@@ -1,0 +1,37 @@
+# ReconBody: Dark blue book pick-handover-place with whole-body tracking
+#
+# Usage:
+#   python robotic_grounding/experiments/run_experiment.py recon_body_dark_blue_book_pick_handover_place_02 --local
+id: recon_body_dark_blue_book_pick_handover_place_02
+description: "ReconBody dark blue book pick-handover-place with SONIC JOINT_RESIDUAL"
+run_name: recon_body_dark_blue_book_pick_handover_place_02
+task: SonicG1-ReconBody-v0
+# Use the explicit repo-relative partition path because whole_body/soma does not
+# follow the 4-part dataset/dataset_retargeted/sequence_id/robot shorthand.
+motion_file: source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-06_11-00-48_dark_blue_book_pick_handover_place_02/robot_name=g1
+video: true
+num_envs: 4096
+max_iterations: 20000
+zero_actor: true
+logger: wandb
+log_project_name: v2d-whole-body-tpv
+
+train_overrides:
+  env.commands.motion.reset_freeze_steps: 50
+  env.commands.motion.voc_decay_steps: 10
+  env.commands.motion.voc_reset_scale: 1.0
+  env.commands.motion.initial_virtual_object_control_curriculum_scale: 1.0
+  env.episode_length_s: 5.0
+
+  # Frame range of the source motion to train on. -1 for motion_end_frame
+  # means run to the end of the sequence.
+  # Use replay_motion_viser.py to visualize the motion and get the frame range.
+  env.commands.motion.motion_start_frame: 360
+  env.commands.motion.motion_end_frame: 680
+  # Reset the shoulder spread to 0.2
+  env.commands.motion.reset_shoulder_spread: 0.2
+
+osmo:
+  build_image: false
+  # Reuse the current whole-body training image so submits don't fall back to :latest.
+  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple

--- a/robotic_grounding/experiments/recon_body_shalin_bottle_1/config.yaml
+++ b/robotic_grounding/experiments/recon_body_shalin_bottle_1/config.yaml
@@ -20,7 +20,7 @@ train_overrides:
   env.commands.motion.reset_freeze_steps: 50
   env.commands.motion.voc_decay_steps: 10
   env.commands.motion.voc_reset_scale: 1.0
-  env.commands.motion.initial_virtual_object_control_curriculum_scale: 0.0
+  env.commands.motion.initial_virtual_object_control_curriculum_scale: 1.0
   env.episode_length_s: 5.0
 
 osmo:

--- a/robotic_grounding/experiments/recon_body_snack_box_pick_and_place_01/config.yaml
+++ b/robotic_grounding/experiments/recon_body_snack_box_pick_and_place_01/config.yaml
@@ -1,0 +1,36 @@
+# ReconBody: Snack box pick-and-place with whole-body tracking
+#
+# Usage:
+#   python robotic_grounding/experiments/run_experiment.py recon_body_snack_box_pick_and_place_01 --local
+id: recon_body_snack_box_pick_and_place_01
+description: "ReconBody snack box pick-and-place with SONIC JOINT_RESIDUAL"
+run_name: recon_body_snack_box_pick_and_place_01
+task: SonicG1-ReconBody-v0
+# Use the explicit repo-relative partition path because whole_body/soma does not
+# follow the 4-part dataset/dataset_retargeted/sequence_id/robot shorthand.
+motion_file: source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-06_10-24-18_snack_box_pick_and_place_01/robot_name=g1
+video: true
+num_envs: 4096
+max_iterations: 20000
+zero_actor: true
+logger: wandb
+log_project_name: v2d-whole-body-tpv
+
+train_overrides:
+  env.commands.motion.reset_freeze_steps: 50
+  env.commands.motion.voc_decay_steps: 10
+  env.commands.motion.voc_reset_scale: 1.0
+  env.commands.motion.initial_virtual_object_control_curriculum_scale: 1.0
+  # Frame range of the source motion to train on. -1 for motion_end_frame
+  # means run to the end of the sequence.
+  # Use replay_motion_viser.py to visualize the motion and get the frame range.
+  env.commands.motion.motion_start_frame: 250
+  env.commands.motion.motion_end_frame: 500
+  env.episode_length_s: 5.0
+  # Reset the shoulder spread to 0.2
+  env.commands.motion.reset_shoulder_spread: 0.2
+
+osmo:
+  build_image: false
+  # Reuse the current whole-body training image so submits don't fall back to :latest.
+  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple

--- a/robotic_grounding/experiments/registry.yaml
+++ b/robotic_grounding/experiments/registry.yaml
@@ -13,6 +13,9 @@ two_stage: example_two_stage
 # Whole-body experiments:
 recon_body_apple: recon_body_apple_pick
 recon_body_shalin_bottle_1: recon_body_shalin_bottle_1
+recon_body_snack_box_pick_and_place_01: recon_body_snack_box_pick_and_place_01
+recon_body_dark_blue_book_pick_handover_place_02: recon_body_dark_blue_book_pick_handover_place_02
+recon_body_blue_trash_can_drag_007: recon_body_blue_trash_can_drag_007
 
 # Private experiments: create experiments/registry.local.yaml (gitignored) with your entries:
 # exp41: exp41_my_experiment

--- a/robotic_grounding/experiments/run_experiment.py
+++ b/robotic_grounding/experiments/run_experiment.py
@@ -1004,6 +1004,11 @@ def main() -> None:
         help="Print generated OSMO entry script (train command) without submitting",
     )
     parser.add_argument(
+        "--run-name",
+        default=None,
+        help="Override the config's run_name (the W&B run name will be {timestamp}_{run_name}).",
+    )
+    parser.add_argument(
         "--run-name-prefix",
         default=None,
         help="Prefix to prepend to W&B run names (e.g. 'exp48_')",
@@ -1038,6 +1043,8 @@ def main() -> None:
 
     _, config = load_experiment_config(args.exp_id)
 
+    if args.run_name is not None:
+        config["run_name"] = args.run_name
     if args.run_name_prefix is not None:
         config["run_name_prefix"] = args.run_name_prefix
 

--- a/robotic_grounding/scripts/replay_motion.py
+++ b/robotic_grounding/scripts/replay_motion.py
@@ -45,6 +45,18 @@ parser.add_argument(
     help="Stop at the last frame instead of looping (default: loop).",
 )
 parser.add_argument("--num_envs", type=int, default=1, help="Number of environments.")
+parser.add_argument(
+    "--start_frame",
+    type=int,
+    default=0,
+    help="First frame of the source motion to play (inclusive).",
+)
+parser.add_argument(
+    "--end_frame",
+    type=int,
+    default=None,
+    help="One past the last frame to play. Default: end of sequence.",
+)
 AppLauncher.add_app_launcher_args(parser)
 args_cli = parser.parse_args()
 
@@ -184,6 +196,8 @@ class Trajectory:
         motion_file: str,
         device: torch.device,
         spawn_root_z: float = 0.0,
+        start_frame: int = 0,
+        end_frame: int | None = None,
     ) -> None:
         """Load trajectory arrays from Parquet into GPU tensors.
 
@@ -192,8 +206,12 @@ class Trajectory:
             device: Target torch device.
             spawn_root_z: Initial root Z from the spawned robot cfg used to
                 calibrate the height offset so the robot stands on the ground.
+            start_frame: First frame to keep (motion_v1 only).
+            end_frame: One past the last frame to keep. None = full.
         """
-        replay = load_replay_trajectory(motion_file)
+        replay = load_replay_trajectory(
+            motion_file, start_frame=start_frame, end_frame=end_frame
+        )
         self.fps = replay.fps
         self.num_frames = replay.num_frames
         self.robot_layout = replay.robot_layout
@@ -417,7 +435,13 @@ class ContactOverlay:
     stays False and the marker for that side will never be shown.
     """
 
-    def __init__(self, motion_file: str, device: torch.device) -> None:
+    def __init__(
+        self,
+        motion_file: str,
+        device: torch.device,
+        start_frame: int = 0,
+        end_frame: int | None = None,
+    ) -> None:
         """Load contact overlay data, or no-op if the parquet lacks the fields."""
         self.has_left: bool = False
         self.has_right: bool = False
@@ -428,6 +452,7 @@ class ContactOverlay:
 
         try:
             md = load_motion_data_parquet(motion_file, device=str(device))
+            md = md.trim(start_frame, end_frame)
         except Exception as exc:
             print(f"[WARN] Contact overlay disabled (motion_v1 load failed): {exc}")
             return
@@ -527,7 +552,13 @@ def main() -> None:
     device = env.device
 
     spawn_root_z = _get_spawn_root_z(cfg)
-    traj = Trajectory(args_cli.motion_file, device, spawn_root_z=spawn_root_z)
+    traj = Trajectory(
+        args_cli.motion_file,
+        device,
+        spawn_root_z=spawn_root_z,
+        start_frame=args_cli.start_frame,
+        end_frame=args_cli.end_frame,
+    )
 
     # Resolve object handle by scene-config name (not hardcoded "object")
     object_names = cfg.events.setup_collision_groups.params.get("object_names", [])
@@ -562,7 +593,12 @@ def main() -> None:
 
     # Contact overlay (motion_v1 parquets only). Anchors at each wrist; shows
     # while the per-frame contact-active mask is on.
-    contact_overlay = ContactOverlay(args_cli.motion_file, device)
+    contact_overlay = ContactOverlay(
+        args_cli.motion_file,
+        device,
+        start_frame=args_cli.start_frame,
+        end_frame=args_cli.end_frame,
+    )
     if traj.height_offset != 0.0:
         # Apply the same Z lift the replay loader used so markers sit on the
         # actual kinematic wrists (legacy whole-body data only).

--- a/robotic_grounding/scripts/rsl_rl/viewer_utils.py
+++ b/robotic_grounding/scripts/rsl_rl/viewer_utils.py
@@ -8,8 +8,9 @@ def autoframe_viewer(env_cfg, motion_file: str) -> None:
 
     Reads object_body_position and robot_{side}_wrist_position from the parquet,
     computes the scene centroid + extent, and positions the camera at a
-    135°-azimuth / ~30°-elevation offset capped at 2 m.  Falls back silently
-    if the parquet is missing or the required fields are absent.
+    135°-azimuth / ~30°-elevation offset with a 6 m minimum distance so the
+    cloned env grid stays visible in training video. Falls back silently if the
+    parquet is missing or the required fields are absent.
     """
     import logging
 
@@ -37,7 +38,7 @@ def autoframe_viewer(env_cfg, motion_file: str) -> None:
         lo, hi = all_pts.min(axis=0), all_pts.max(axis=0)
         center = 0.5 * (lo + hi)
         extent = max(float(np.linalg.norm(hi - lo)), 0.3)
-        dist = min(2.5 * extent, 2.0)
+        dist = max(2.5 * extent, 6.0)
         eye = center + dist * np.array([-0.60, 0.60, 0.57])
         env_cfg.viewer.lookat = tuple(float(c) for c in center)
         env_cfg.viewer.eye = tuple(float(c) for c in eye)

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/reconstructed_stage/2026-03-06_10-24-18_snack_box_pick_and_place_01_support.usda
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/reconstructed_stage/2026-03-06_10-24-18_snack_box_pick_and_place_01_support.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a31d46961bbc4d502fafa09f397f153dc3ad07362850e890e25e960cfd29678
+size 569

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-20_17-37-45_blue_trash_can_drag_007/object/material.mtl
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-20_17-37-45_blue_trash_can_drag_007/object/material.mtl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d90fe7d688a6da0b82b0f8053231a1c8986de34aa839f8113ed53a610c09227
+size 198

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-20_17-37-45_blue_trash_can_drag_007/object/material_0.png
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-20_17-37-45_blue_trash_can_drag_007/object/material_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa4501f8153f19e7ea8c6ada1bc05f7eeca6a03493fa2df0ffb907788eb8c0b9
+size 10100589

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-20_17-37-45_blue_trash_can_drag_007/object/textured_mesh.obj
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-20_17-37-45_blue_trash_can_drag_007/object/textured_mesh.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce533749b88e8cfaacc92bf5375c7b8c525dba1f581cea34040587adee41a745
+size 19278770

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-20_17-37-45_blue_trash_can_drag_007/object/textured_mesh.urdf
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-20_17-37-45_blue_trash_can_drag_007/object/textured_mesh.urdf
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<robot name="retarget_object">
+  <link name="object">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.0"/>
+      <inertia ixx="0.01" ixy="0.0" ixz="0.0" iyy="0.01" iyz="0.0" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="textured_mesh.obj"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="textured_mesh.obj"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-20_17-37-45_blue_trash_can_drag_007/robot_name=g1/data.parquet
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-20_17-37-45_blue_trash_can_drag_007/robot_name=g1/data.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4cea0a72c3235f1f2d2b42f0c83b785e82fdebe37d0f02fdc8a8c26b03bf2c5
+size 3554045

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-06_10-24-18_snack_box_pick_and_place_01/object/material.mtl
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-06_10-24-18_snack_box_pick_and_place_01/object/material.mtl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d90fe7d688a6da0b82b0f8053231a1c8986de34aa839f8113ed53a610c09227
+size 198

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-06_10-24-18_snack_box_pick_and_place_01/object/material_0.png
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-06_10-24-18_snack_box_pick_and_place_01/object/material_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e2d7fa813eba126345723dca5ab52b11b773f015d99968f7b7172e6bae4d265
+size 9037738

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-06_10-24-18_snack_box_pick_and_place_01/object/textured_mesh.obj
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-06_10-24-18_snack_box_pick_and_place_01/object/textured_mesh.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:380248270cb7e23aed66c33e74d100e1e4dd5e329ff3d8d63ac85753c859066a
+size 22108986

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-06_10-24-18_snack_box_pick_and_place_01/object/textured_mesh.urdf
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-06_10-24-18_snack_box_pick_and_place_01/object/textured_mesh.urdf
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<robot name="retarget_object">
+  <link name="object">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.0"/>
+      <inertia ixx="0.01" ixy="0.0" ixz="0.0" iyy="0.01" iyz="0.0" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="textured_mesh.obj"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="textured_mesh.obj"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-06_10-24-18_snack_box_pick_and_place_01/robot_name=g1/data.parquet
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-06_10-24-18_snack_box_pick_and_place_01/robot_name=g1/data.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04f55c50a6dfc04826b73b22cc42cde90d9209e003d242b3d300b0a631c9671d
+size 3688593

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/motion_schema/schema.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/motion_schema/schema.py
@@ -29,7 +29,7 @@ Design notes:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 import pyarrow as pa
@@ -380,6 +380,124 @@ class MotionData:
     # Kept so the training loader preserves the legacy `file_joint_names`
     # semantic (alias of `robot_joint_names` for joint reordering).
     file_joint_names: list[str] | None = None
+
+    # ------------------------------------------------------------------
+    # Time-axis subsetting
+    # ------------------------------------------------------------------
+
+    # Field names whose first axis is the time axis T. Used by `trim()` so
+    # the schema stays the single source of truth for time-axis layout.
+    # Not annotated → class attribute only, not a dataclass field.
+    _TIME_AXIS_TENSOR_FIELDS = (
+        "robot_root_position",
+        "robot_root_wxyz",
+        "robot_joint_positions",
+        "ee_pose_w",
+        "ee_pos_w",
+        "ee_quat_w",
+        "object_articulation",
+        "object_root_axis_angle",
+        "object_root_position",
+        "object_body_position",
+        "object_body_wxyz",
+        "object_pos_w",
+        "object_quat_w",
+        "left_wrist_position",
+        "left_wrist_wxyz",
+        "right_wrist_position",
+        "right_wrist_wxyz",
+        "left_finger_joints",
+        "right_finger_joints",
+        "left_hand_frames",
+        "right_hand_frames",
+        "left_link_contact_positions",
+        "left_object_contact_positions",
+        "right_link_contact_positions",
+        "right_object_contact_positions",
+        "left_link_contact_normals",
+        "left_object_contact_normals",
+        "right_link_contact_normals",
+        "right_object_contact_normals",
+        "left_object_contact_part_ids",
+        "right_object_contact_part_ids",
+        "left_hand_contact_active",
+        "right_hand_contact_active",
+        "ik_error_per_frame",
+        "ik_num_iterations",
+        "frame_task_errors",
+    )
+
+    # List-of-tensor fields where each element is `(T, ...)` and should be
+    # sliced per-element.
+    _TIME_AXIS_TENSOR_LIST_FIELDS = (
+        "hand_frames_w",
+        "hand_finger_joints",
+        "hand_link_contact_positions",
+        "hand_link_contact_normals",
+        "hand_object_contact_positions",
+        "hand_object_contact_normals",
+        "hand_object_contact_part_ids",
+        "hand_contact_active",
+    )
+
+    def num_frames(self) -> int:
+        """Return motion length T inferred from a required time-axis field."""
+        ref = self.robot_root_position
+        if ref is None:
+            return 0
+        return int(ref.shape[0])
+
+    def trim(self, start_frame: int = 0, end_frame: int | None = None) -> "MotionData":
+        """Return a copy of this MotionData restricted to ``[start, end)`` frames.
+
+        Slices every time-axis tensor (and per-element of every time-axis tensor
+        list) along axis 0. Non-tensor metadata is shared with the source.
+
+        Args:
+            start_frame: First frame to keep (inclusive). Must be ``>= 0``.
+            end_frame: One past the last frame to keep. ``None`` means the
+                end of the sequence.
+
+        Returns:
+            A new ``MotionData`` whose time-axis fields contain frames
+            ``[start_frame, end_frame)`` of the original.
+
+        Raises:
+            ValueError: If the range is empty or out of bounds.
+        """
+        total = self.num_frames()
+        if total == 0:
+            # Nothing to trim; return self to avoid masking a missing-field bug
+            # behind a silent no-op clone.
+            if start_frame == 0 and end_frame in (None, 0):
+                return self
+            raise ValueError(
+                f"Cannot trim MotionData with no time-axis tensors: requested "
+                f"[{start_frame}, {end_frame})."
+            )
+
+        end = total if end_frame is None else end_frame
+        if start_frame < 0 or end > total or start_frame >= end:
+            raise ValueError(
+                f"Invalid trim range [{start_frame}, {end}) for motion of length "
+                f"{total}. Require 0 <= start_frame < end_frame <= num_frames."
+            )
+
+        if start_frame == 0 and end == total:
+            return self
+
+        updates: dict[str, Any] = {}
+        for name in self._TIME_AXIS_TENSOR_FIELDS:
+            value = getattr(self, name)
+            if value is None:
+                continue
+            updates[name] = value[start_frame:end]
+        for name in self._TIME_AXIS_TENSOR_LIST_FIELDS:
+            value = getattr(self, name)
+            if not value:
+                continue
+            updates[name] = [None if v is None else v[start_frame:end] for v in value]
+        return replace(self, **updates)
 
 
 # ---------------------------------------------------------------------------

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/replay_data.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/replay_data.py
@@ -231,8 +231,17 @@ def _sharpa_to_dual_hand(data: ManoSharpaData) -> DualHandTrajectory:
 def load_replay_trajectory(
     motion_file: str,
     trajectory_id: int = 0,
+    start_frame: int = 0,
+    end_frame: int | None = None,
 ) -> ReplayTrajectory:
-    """Load replay trajectory from a motion parquet path for known schemas."""
+    """Load replay trajectory from a motion parquet path for known schemas.
+
+    Args:
+        motion_file: Parquet file or partition directory.
+        trajectory_id: Trajectory index (legacy ManoSharpaData only).
+        start_frame: First frame to keep (motion_v1 only). Default 0.
+        end_frame: One past the last frame (motion_v1 only). None = full.
+    """
     resolved, filters = _resolve_path_and_filters(motion_file)
 
     resolved_path = Path(resolved)
@@ -253,6 +262,7 @@ def load_replay_trajectory(
                 f"Unsupported motion schema version: {md.schema_version!r}. "
                 f"Run scripts/motion_schema/migrate_to_v1.py to upgrade."
             )
+        md = md.trim(start_frame, end_frame)
         return _motion_v1_to_replay(md)
 
     # Legacy: ManoSharpaData (dual-hand V2P pipeline, not yet on motion_v1).

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/hand_object_commands.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p/mdp/commands/hand_object_commands.py
@@ -1923,9 +1923,9 @@ class DualHandsObjectTrackingCommand(CommandTerm):
         #     self.object_body_wxyz_command_e,
         # ).mean(dim=-1)
 
+        # Log the per-env VOC scale actually applied to the object controller.
         self.metrics["virtual_object_controller_scale_factor"] = (
-            self.virtual_object_controller_scale_factor
-            * torch.ones(self.num_envs, device=self.device)
+            self.virtual_object_controller_scale_factor_per_env.squeeze(-1)
         )
 
         if not self.cfg.enable_additional_metrics:

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/config/sonic/g1/g1_sonic_env_cfg.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/config/sonic/g1/g1_sonic_env_cfg.py
@@ -1,5 +1,6 @@
 import isaaclab.envs.mdp as il_mdp
 from isaaclab.envs.mdp import observations
+from isaaclab.managers import CurriculumTermCfg as CurrTerm
 from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import RewardTermCfg as RewTerm
@@ -19,6 +20,9 @@ from robotic_grounding.tasks.v2p_whole_body.mdp import observations as obs
 from robotic_grounding.tasks.v2p_whole_body.mdp.actions import (
     SONICActionCfg,
     SONICActionType,
+)
+from robotic_grounding.tasks.v2p_whole_body.mdp.curriculum import (
+    WholeBodyFixedTimestepVOCCurriculum,
 )
 from robotic_grounding.tasks.v2p_whole_body.mdp.rewards import (
     contact_rewards,
@@ -388,7 +392,11 @@ class G1SonicReconBodyRewardsCfg(G1SonicRewardsCfg):
     motion_joint_pos_error_exp = RewTerm(
         func=tracking_rewards.motion_joint_pos_error_exp,
         weight=5.0,
-        params={"command_name": "motion", "std": 1.0},
+        params={
+            "command_name": "motion",
+            "std": 1.0,
+            "joint_names": G1_SONIC_JOINT_NAMES,
+        },
     )
     motion_object_position_error_exp = RewTerm(
         func=tracking_rewards.motion_object_position_error_exp,
@@ -419,10 +427,42 @@ class G1SonicReconBodyRewardsCfg(G1SonicRewardsCfg):
 
 
 @configclass
+class G1SonicReconBodyVOCCurriculumCfg:
+    """Fixed-timestep curriculum that decays the VOC target scale over PPO updates.
+
+    The schedule is expressed in PPO update indices and converted to env steps
+    via ``num_steps_per_env``. Reward weights are intentionally not scheduled
+    here; see ``WholeBodyFixedTimestepVOCCurriculum`` for the rationale.
+    """
+
+    voc_curriculum = CurrTerm(
+        func=WholeBodyFixedTimestepVOCCurriculum,
+        params={
+            "command_name": "motion",
+            # Match num_steps_per_env in agents/rsl_rl_ppo_cfg.py::G1SonicRslRlPpoCfg.
+            "num_steps_per_env": 24,
+            # PPO update indices (not seconds, not raw env steps).
+            "timestep_schedule": [0, 2000, 4000, 6000, 8000, 10000, 12000],
+            # VOC target scale per stage; final stage drives VOC fully off.
+            "virtual_object_control_scale_factor": [
+                1.0,
+                0.75,
+                0.5,
+                0.25,
+                0.1,
+                0.05,
+                0.0,
+            ],
+        },
+    )
+
+
+@configclass
 class G1SonicReconBodyEnvCfg(G1SonicEnvCfg):
     """Body-accurate reference env (MHR pipeline)."""
 
     rewards: G1SonicReconBodyRewardsCfg = G1SonicReconBodyRewardsCfg()
+    curriculum: G1SonicReconBodyVOCCurriculumCfg = G1SonicReconBodyVOCCurriculumCfg()
 
     def __post_init__(self) -> None:
         """Set residual scales for body-accurate tracking."""

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/__init__.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/__init__.py
@@ -7,6 +7,7 @@
 from . import (  # noqa: F401
     actions,
     commands,
+    curriculum,
     events,
     observations,
     rewards,

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/commands/tracking_command.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/commands/tracking_command.py
@@ -55,6 +55,7 @@ class TrackingCommand(CommandTerm):
         self._init_scene_references(cfg, env)
         self._load_and_process_motion(cfg)
         self._init_buffers(cfg)
+        self._init_metrics()
         self._init_hand_data(cfg)
         self._init_contact_data()
         self._precompute_hand_keypoints_in_object_frame()
@@ -245,6 +246,35 @@ class TrackingCommand(CommandTerm):
             [[1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1]],
             dtype=torch.float32,
             device=self.device,
+        )
+
+    def _init_metrics(self) -> None:
+        """Allocate per-env tracking metric buffers."""
+        self.metrics["anchor_position_error"] = torch.zeros(
+            self.num_envs, device=self.device
+        )
+        self.metrics["anchor_wxyz_error"] = torch.zeros(
+            self.num_envs, device=self.device
+        )
+        self.metrics["joint_pos_error"] = torch.zeros(self.num_envs, device=self.device)
+        for side in ("left", "right"):
+            self.metrics[f"{side}_hand_wrist_position_error"] = torch.zeros(
+                self.num_envs, device=self.device
+            )
+            self.metrics[f"{side}_hand_wrist_wxyz_error"] = torch.zeros(
+                self.num_envs, device=self.device
+            )
+            self.metrics[f"{side}_hand_finger_joints_error"] = torch.zeros(
+                self.num_envs, device=self.device
+            )
+        self.metrics["object_body_position_error"] = torch.zeros(
+            self.num_envs, device=self.device
+        )
+        self.metrics["object_body_wxyz_error"] = torch.zeros(
+            self.num_envs, device=self.device
+        )
+        self.metrics["virtual_object_controller_scale_factor"] = torch.zeros(
+            self.num_envs, device=self.device
         )
 
     def _init_hand_data(self, cfg: TrackingCommandCfg) -> None:
@@ -1149,7 +1179,70 @@ class TrackingCommand(CommandTerm):
 
     def _update_metrics(self) -> None:
         """Track per-step errors for logging."""
-        pass  # TODO: port metric tracking
+        self.metrics["anchor_position_error"] = torch.norm(
+            self.robot_anchor_pos_w - self.command_anchor_pos_w, dim=-1
+        )
+        self.metrics["anchor_wxyz_error"] = math_utils.quat_error_magnitude(
+            self.robot_anchor_quat_w, self.command_anchor_quat_w
+        )
+        self.metrics["joint_pos_error"] = torch.norm(
+            self.robot_joint_pos - self.command_joint_pos, dim=-1
+        )
+
+        self.metrics["object_body_position_error"] = torch.norm(
+            self.object_position_e - self.object_body_position_command_e,
+            dim=-1,
+        ).mean(dim=-1)
+        self.metrics["object_body_wxyz_error"] = math_utils.quat_error_magnitude(
+            self.object_orientation_e,
+            self.object_body_wxyz_command_e,
+        ).mean(dim=-1)
+
+        wrist_metrics = (
+            (
+                "left",
+                self._left_wrist_body_id,
+                self.left_hand_wrist_position_e,
+                self.left_hand_wrist_pose_command_e,
+            ),
+            (
+                "right",
+                self._right_wrist_body_id,
+                self.right_hand_wrist_position_e,
+                self.right_hand_wrist_pose_command_e,
+            ),
+        )
+        for (
+            side,
+            wrist_body_id,
+            wrist_position_e,
+            wrist_pose_command_e,
+        ) in wrist_metrics:
+            self.metrics[f"{side}_hand_wrist_position_error"] = torch.norm(
+                wrist_position_e - wrist_pose_command_e[:, :3],
+                dim=-1,
+            )
+            if wrist_body_id is not None:
+                self.metrics[f"{side}_hand_wrist_wxyz_error"] = (
+                    math_utils.quat_error_magnitude(
+                        self.robot.data.body_quat_w[:, wrist_body_id],
+                        wrist_pose_command_e[:, 3:],
+                    )
+                )
+            else:
+                self.metrics[f"{side}_hand_wrist_wxyz_error"].zero_()
+
+        self.metrics["left_hand_finger_joints_error"] = torch.norm(
+            self.left_hand_finger_joint_pos - self.left_hand_finger_joint_pos_command,
+            dim=-1,
+        )
+        self.metrics["right_hand_finger_joints_error"] = torch.norm(
+            self.right_hand_finger_joint_pos - self.right_hand_finger_joint_pos_command,
+            dim=-1,
+        )
+        self.metrics["virtual_object_controller_scale_factor"] = (
+            self.virtual_object_controller_scale_factor_per_env.squeeze(-1)
+        )
 
     def _set_debug_vis_impl(self, debug_vis: bool = True) -> None:
         """Enable/disable debug visualization of tracking targets."""

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/commands/tracking_command_cfg.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/commands/tracking_command_cfg.py
@@ -33,6 +33,17 @@ class TrackingCommandCfg(CommandTermCfg):
     motion_file: str = ""
     """Path to the `motion_v1` parquet file or Hive-partitioned directory."""
 
+    motion_start_frame: int = 0
+    """First frame of the source motion to use (inclusive). 0 = beginning."""
+
+    motion_end_frame: int = -1
+    """One past the last frame to use. ``-1`` means end of sequence.
+
+    Stored as int (not ``int | None``) because Isaac Lab's
+    ``update_class_from_dict`` infers the expected override type from the
+    current value, so a ``None`` default would reject int Hydra overrides.
+    """
+
     # Offsets applied to loaded trajectories
     object_pos_offset: list[float] = [0.0, 0.0, 0.0]
     """Offset applied to object position trajectory."""
@@ -138,4 +149,17 @@ class TrackingCommandCfg(CommandTermCfg):
     pose_visualizer_cfg.markers["frame"].scale = (0.15, 0.15, 0.15)
 
     resampling_time_range: tuple[float, float] = (1e6, 1e6)
-    """No time-based resampling."""
+    """Disable Isaac Lab's mid-episode command resampling.
+
+    The base ``CommandManager`` decrements a per-env ``time_left`` by ``dt``
+    each step and calls ``_resample`` whenever ``time_left <= 0``. For
+    trajectory tracking we never want a mid-episode resample: episode
+    termination (timeout or tracking-error) already drives a reset through
+    ``command_manager.reset(env_ids)``, and the reset event picks a fresh
+    frame in ``[0, num_timesteps)`` of the (trimmed) motion.
+
+    Setting both bounds to ``1e6`` means each call to ``_resample`` writes
+    ``time_left = 1e6`` (≈ 11 days of sim time), so the time-based path
+    cannot re-fire during any realistic ``episode_length_s``. Do not lower
+    this without also overriding ``compute()``.
+    """

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/commands/tracking_utils.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/commands/tracking_utils.py
@@ -59,6 +59,9 @@ def load_motion_data(
             f"or `replay_data.load_replay_trajectory`."
         )
 
+    end_frame = None if cfg.motion_end_frame < 0 else cfg.motion_end_frame
+    md = md.trim(cfg.motion_start_frame, end_frame)
+
     if md.ee_link_names:
         ee_link_ids, _ = robot.find_bodies(list(md.ee_link_names))
         md.ee_link_ids = ee_link_ids

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/curriculum/__init__.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/curriculum/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Curriculum terms for whole-body tracking tasks."""
+
+from .curriculum import WholeBodyFixedTimestepVOCCurriculum
+
+__all__ = ["WholeBodyFixedTimestepVOCCurriculum"]

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/curriculum/curriculum.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/curriculum/curriculum.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Curriculum terms for whole-body tracking tasks.
+
+Currently exposes a fixed-timestep curriculum that mutates the global VOC
+target on the whole-body :class:`TrackingCommand` (see
+``tracking_command.py``). The per-env applied scale follows the global target
+through the existing per-step decay in ``TrackingCommand._update_command``.
+
+Reward-weight scheduling is intentionally out of scope here to avoid
+hard-coding reward parameter names like the v2p hand variant does.
+"""
+
+from __future__ import annotations
+
+import bisect
+from collections.abc import Sequence
+
+import torch
+from isaaclab.envs import ManagerBasedRLEnv
+from isaaclab.managers import CurriculumTermCfg, ManagerTermBase
+
+
+class WholeBodyFixedTimestepVOCCurriculum(ManagerTermBase):
+    """Fixed-timestep curriculum that schedules the VOC target scale.
+
+    The schedule is expressed in PPO update indices and converted to env
+    steps via ``num_steps_per_env``. The active stage is selected with
+    ``bisect_right`` against ``env.common_step_counter``; stage transitions
+    overwrite the global VOC scale on the configured command term.
+    """
+
+    def __init__(self, cfg: CurriculumTermCfg, env: ManagerBasedRLEnv) -> None:
+        """Resolve the command term and pre-compute env-step thresholds."""
+        super().__init__(cfg, env)
+
+        self._command = env.command_manager.get_term(cfg.params["command_name"])
+
+        num_steps_per_env = int(cfg.params["num_steps_per_env"])
+        timestep_schedule: list[int] = list(cfg.params["timestep_schedule"])
+        scale_schedule: list[float] = list(
+            cfg.params["virtual_object_control_scale_factor"]
+        )
+        if len(timestep_schedule) != len(scale_schedule):
+            raise ValueError(
+                "timestep_schedule and virtual_object_control_scale_factor must have the "
+                f"same length, got {len(timestep_schedule)} and {len(scale_schedule)}."
+            )
+
+        self._env_step_schedule = [
+            ppo_step * num_steps_per_env for ppo_step in timestep_schedule
+        ]
+        self._scale_schedule = scale_schedule
+        self._last_schedule_index: int = -1
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        env_ids: Sequence[int],
+        command_name: str,
+        num_steps_per_env: int,
+        timestep_schedule: list[int],
+        virtual_object_control_scale_factor: list[float],
+    ) -> torch.Tensor:
+        """Set the global VOC target if the active stage changed.
+
+        Args:
+            env: The RL environment instance.
+            env_ids: Environment ids being reset (unused; the schedule is global).
+            command_name: Name of the command term to mutate.
+            num_steps_per_env: PPO ``num_steps_per_env`` from the agent config.
+            timestep_schedule: PPO update indices at which the VOC scale changes.
+            virtual_object_control_scale_factor: VOC target scale per stage.
+
+        Returns:
+            The current global VOC scale tensor on the command term.
+        """
+        del env_ids, command_name  # Bound at __init__; ignored here.
+        del num_steps_per_env, timestep_schedule  # Pre-computed in __init__.
+        del virtual_object_control_scale_factor  # Pre-computed in __init__.
+
+        sim_step_counter = self._env.common_step_counter
+        current_schedule_index = min(
+            bisect.bisect_right(self._env_step_schedule, sim_step_counter) - 1,
+            len(self._scale_schedule) - 1,
+        )
+        current_schedule_index = max(current_schedule_index, 0)
+
+        if current_schedule_index == self._last_schedule_index:
+            return self._command.virtual_object_controller_scale_factor
+
+        self._last_schedule_index = current_schedule_index
+        new_scale = float(self._scale_schedule[current_schedule_index])
+
+        # Preserve dtype/device of the existing (1,) tensor.
+        self._command.virtual_object_controller_scale_factor = (
+            0.0 * self._command.virtual_object_controller_scale_factor + new_scale
+        )
+
+        return self._command.virtual_object_controller_scale_factor

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/rewards/tracking_rewards.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/rewards/tracking_rewards.py
@@ -1,5 +1,7 @@
 import torch
 from isaaclab.envs import ManagerBasedEnv
+from isaaclab.managers import ManagerTermBase
+from isaaclab.managers.manager_term_cfg import RewardTermCfg
 from isaaclab.utils.math import quat_error_magnitude
 
 from robotic_grounding.tasks.v2p.mdp.utils import chamfer_distance
@@ -114,25 +116,67 @@ def motion_ee_orientation_error_exp(
     return torch.exp(-error / std**2)
 
 
-def motion_joint_pos_error_exp(
-    env: ManagerBasedEnv, command_name: str, std: float
-) -> torch.Tensor:
-    """
-    Reward for tracking the joint positions using exponential kernel.
+class motion_joint_pos_error_exp(ManagerTermBase):  # noqa: N801
+    """Reward for tracking joint positions using an exponential kernel."""
 
-    Args:
-        env: The environment object.
-        command_name: Name of the tracking command term.
-        std: Standard deviation of the exponential kernel.
+    def __init__(self, cfg: RewardTermCfg, env: ManagerBasedEnv) -> None:
+        """Resolve optional joint filters once when the reward term is created."""
+        super().__init__(cfg, env)
 
-    Returns:
-        Reward tensor of shape (num_envs,).
-    """
-    command = env.command_manager.get_term(command_name)
-    error = torch.sum(
-        torch.square(command.command_joint_pos - command.robot_joint_pos), dim=-1
-    )
-    return torch.exp(-error / std**2)
+        self._command = env.command_manager.get_term(cfg.params["command_name"])
+        joint_names: list[str] | None = cfg.params.get("joint_names")
+        self._joint_ids: torch.Tensor | None = None
+
+        if joint_names is not None:
+            _, resolved_joint_names = self._command.robot.find_joints(joint_names)
+            tracked_joint_name_to_idx = {
+                name: idx for idx, name in enumerate(self._command._tracked_joint_names)
+            }
+            missing_joint_names = [
+                name
+                for name in resolved_joint_names
+                if name not in tracked_joint_name_to_idx
+            ]
+            if missing_joint_names:
+                raise ValueError(
+                    "Reward joint_names must be included in the tracking command joints. "
+                    f"Missing joints: {missing_joint_names}"
+                )
+            self._joint_ids = torch.tensor(
+                [tracked_joint_name_to_idx[name] for name in resolved_joint_names],
+                device=env.device,
+                dtype=torch.long,
+            )
+
+    def __call__(
+        self,
+        env: ManagerBasedEnv,
+        command_name: str,
+        std: float,
+        joint_names: list[str] | None = None,
+    ) -> torch.Tensor:
+        """
+        Compute joint position tracking reward.
+
+        Args:
+            env: The environment object.
+            command_name: Name of the tracking command term.
+            std: Standard deviation of the exponential kernel.
+            joint_names: Optional list of joint names or name patterns to track. If not
+                provided, all joints tracked by the command are used.
+
+        Returns:
+            Reward tensor of shape (num_envs,).
+        """
+        del env, command_name, joint_names
+        command_joint_pos = self._command.command_joint_pos
+        robot_joint_pos = self._command.robot_joint_pos
+        if self._joint_ids is not None:
+            command_joint_pos = command_joint_pos[:, self._joint_ids]
+            robot_joint_pos = robot_joint_pos[:, self._joint_ids]
+
+        error = torch.sum(torch.square(command_joint_pos - robot_joint_pos), dim=-1)
+        return torch.exp(-error / std**2)
 
 
 def motion_object_position_error_exp(

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/tests/test_commands.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/tests/test_commands.py
@@ -219,6 +219,53 @@ class TestTrackingCommand(unittest.TestCase):
             f"Timesteps should stay at end till reset. Got: {self.tracking_cmd.timestep}",
         )
 
+    def test_update_metrics_populates_expected_metric_shapes(self) -> None:
+        """Test that update_metrics fills the expected per-env metric tensors."""
+        self.tracking_cmd._update_metrics()
+
+        expected_metric_names = [
+            "anchor_position_error",
+            "anchor_wxyz_error",
+            "joint_pos_error",
+            "left_hand_wrist_position_error",
+            "left_hand_wrist_wxyz_error",
+            "left_hand_finger_joints_error",
+            "right_hand_wrist_position_error",
+            "right_hand_wrist_wxyz_error",
+            "right_hand_finger_joints_error",
+            "object_body_position_error",
+            "object_body_wxyz_error",
+            "virtual_object_controller_scale_factor",
+        ]
+
+        for metric_name in expected_metric_names:
+            self.assertIn(metric_name, self.tracking_cmd.metrics)
+            metric = self.tracking_cmd.metrics[metric_name]
+            self.assertEqual(
+                metric.shape,
+                (self.env.num_envs,),
+                f"{metric_name} should be shape {(self.env.num_envs,)}",
+            )
+            self.assertTrue(
+                torch.isfinite(metric).all(),
+                f"{metric_name} should contain only finite values",
+            )
+
+    def test_update_metrics_tracks_per_env_voc_scale(self) -> None:
+        """Test that VOC metric mirrors the currently applied per-env scale."""
+        expected = torch.tensor([[0.25], [0.75]], device=self.env.device)
+        self.tracking_cmd.virtual_object_controller_scale_factor_per_env[:] = expected
+
+        self.tracking_cmd._update_metrics()
+
+        self.assertTrue(
+            torch.allclose(
+                self.tracking_cmd.metrics["virtual_object_controller_scale_factor"],
+                expected.squeeze(-1),
+            ),
+            "VOC metric should match per-env applied VOC scale",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Bundles the changes needed to launch whole-body ReconBody training on the new soma TPV sequences (snack_box pick-and-place, dark_blue_book pick-handover-place, blue_trash_can drag) and bring across the VOC and metric infrastructure they depend on.

Feature work:
- MotionData.trim(start, end) at the schema layer; consumed by the whole-body TrackingCommand loader and by load_replay_trajectory so train, eval, and replay all subset motions consistently.
- TrackingCommandCfg gains motion_start_frame / motion_end_frame (int sentinel for end so Hydra int overrides aren't rejected).
- scripts/replay_motion.py exposes --start_frame / --end_frame and threads them through Trajectory and ContactOverlay.
- WholeBodyFixedTimestepVOCCurriculum + G1SonicReconBodyVOCCurriculumCfg port the VOC scale schedule onto v2p_whole_body.
- TrackingCommand allocates and populates per-env tracking metrics including virtual_object_controller_scale_factor.
- DualHandsObjectTrackingCommand logs the per-env VOC scale.
- motion_joint_pos_error_exp converted to ManagerTermBase so configs can pass joint_names; G1SonicReconBodyRewardsCfg now scopes the joint-pos reward to G1_SONIC_JOINT_NAMES.
- Strengthens resampling_time_range docstring to spell out how the (1e6, 1e6) sentinel disables IsaacLab's mid-episode resample, since the trim feature relies on that path staying off.

Experiments + assets:
- New experiment configs recon_body_snack_box_pick_and_place_01 and recon_body_dark_blue_book_pick_handover_place_02, registered in experiments/registry.yaml.
- snack_box config drives motion_start_frame=250 / motion_end_frame=500 and reset_shoulder_spread=0.2 as a working example of the trim + shoulder-spread reset combo.
- Adds soma sequence assets for snack_box_pick_and_place_01 and blue_trash_can_drag_007 (mesh + URDF + parquet) plus the reconstructed_stage USDA referenced by the snack_box scene.

Tests:
- v2p_whole_body command tests cover update_metrics shape contract and the per-env VOC scale propagation.