### PR TITLE
[robotic_grounding] feat: add TPV whole-body workflow driver

### DIFF
--- a/robotic_grounding/experiments/recon_body_blue_trash_can_drag_007/config.yaml
+++ b/robotic_grounding/experiments/recon_body_blue_trash_can_drag_007/config.yaml
@@ -26,8 +26,8 @@ train_overrides:
   # Frame range of the source motion to train on. -1 for motion_end_frame
   # means run to the end of the sequence.
   # Use replay_motion_viser.py to visualize the motion and get the frame range.
-  env.commands.motion.motion_start_frame: 0
-  env.commands.motion.motion_end_frame: 250
+  env.commands.motion.motion_start_frame: 50
+  env.commands.motion.motion_end_frame: 400
   # Reset the shoulder spread to 0.2
   env.commands.motion.reset_shoulder_spread: 0.2
 

--- a/robotic_grounding/experiments/recon_body_corn_can_right_left_handover_01/config.yaml
+++ b/robotic_grounding/experiments/recon_body_corn_can_right_left_handover_01/config.yaml
@@ -1,0 +1,27 @@
+# ReconBody: recon_body_corn_can_right_left_handover_01 (TPV whole-body)
+#
+# Usage:
+#   python robotic_grounding/experiments/run_experiment.py recon_body_corn_can_right_left_handover_01 --local
+id: recon_body_corn_can_right_left_handover_01
+description: ReconBody recon_body_corn_can_right_left_handover_01 with SONIC JOINT_RESIDUAL
+run_name: recon_body_corn_can_right_left_handover_01
+task: SonicG1-ReconBody-v0
+motion_file: source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-23_18-10-01_corn_can_right_left_handover_01/robot_name=g1
+video: true
+num_envs: 4096
+max_iterations: 20000
+zero_actor: true
+logger: wandb
+log_project_name: v2d-whole-body-tpv
+train_overrides:
+  env.commands.motion.reset_freeze_steps: 50
+  env.commands.motion.voc_decay_steps: 10
+  env.commands.motion.voc_reset_scale: 1.0
+  env.commands.motion.initial_virtual_object_control_curriculum_scale: 1.0
+  env.commands.motion.motion_start_frame: 630
+  env.commands.motion.motion_end_frame: -1
+  env.episode_length_s: 5.0
+  env.commands.motion.reset_shoulder_spread: 0.2
+osmo:
+  build_image: false
+  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple

--- a/robotic_grounding/experiments/recon_body_sit_skinny_wood_chair_01/config.yaml
+++ b/robotic_grounding/experiments/recon_body_sit_skinny_wood_chair_01/config.yaml
@@ -1,0 +1,27 @@
+# ReconBody: recon_body_sit_skinny_wood_chair_01 (TPV whole-body)
+#
+# Usage:
+#   python robotic_grounding/experiments/run_experiment.py recon_body_sit_skinny_wood_chair_01 --local
+id: recon_body_sit_skinny_wood_chair_01
+description: ReconBody recon_body_sit_skinny_wood_chair_01 with SONIC JOINT_RESIDUAL
+run_name: recon_body_sit_skinny_wood_chair_01
+task: SonicG1-ReconBody-v0
+motion_file: source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-27_16-25-23_sit_skinny_wood_chair_01/robot_name=g1
+video: true
+num_envs: 4096
+max_iterations: 20000
+zero_actor: true
+logger: wandb
+log_project_name: v2d-whole-body-tpv
+train_overrides:
+  env.commands.motion.reset_freeze_steps: 50
+  env.commands.motion.voc_decay_steps: 10
+  env.commands.motion.voc_reset_scale: 1.0
+  env.commands.motion.initial_virtual_object_control_curriculum_scale: 1.0
+  env.commands.motion.motion_start_frame: 120
+  env.commands.motion.motion_end_frame: 300
+  env.episode_length_s: 5.0
+  env.commands.motion.reset_shoulder_spread: 0.2
+osmo:
+  build_image: false
+  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple

--- a/robotic_grounding/experiments/recon_body_snack_box_pick_and_place_01/config.yaml
+++ b/robotic_grounding/experiments/recon_body_snack_box_pick_and_place_01/config.yaml
@@ -24,8 +24,8 @@ train_overrides:
   # Frame range of the source motion to train on. -1 for motion_end_frame
   # means run to the end of the sequence.
   # Use replay_motion_viser.py to visualize the motion and get the frame range.
-  env.commands.motion.motion_start_frame: 250
-  env.commands.motion.motion_end_frame: 500
+  env.commands.motion.motion_start_frame: 300
+  env.commands.motion.motion_end_frame: -1
   env.episode_length_s: 5.0
   # Reset the shoulder spread to 0.2
   env.commands.motion.reset_shoulder_spread: 0.2

--- a/robotic_grounding/experiments/registry.yaml
+++ b/robotic_grounding/experiments/registry.yaml
@@ -11,11 +11,13 @@ stage2: example_stage2
 two_stage: example_two_stage
 
 # Whole-body experiments:
+recon_body_corn_can_right_left_handover_01: recon_body_corn_can_right_left_handover_01
 recon_body_apple: recon_body_apple_pick
 recon_body_shalin_bottle_1: recon_body_shalin_bottle_1
 recon_body_snack_box_pick_and_place_01: recon_body_snack_box_pick_and_place_01
 recon_body_dark_blue_book_pick_handover_place_02: recon_body_dark_blue_book_pick_handover_place_02
 recon_body_blue_trash_can_drag_007: recon_body_blue_trash_can_drag_007
+recon_body_sit_skinny_wood_chair_01: recon_body_sit_skinny_wood_chair_01
 
 # Private experiments: create experiments/registry.local.yaml (gitignored) with your entries:
 # exp41: exp41_my_experiment

--- a/robotic_grounding/experiments/run_experiment.py
+++ b/robotic_grounding/experiments/run_experiment.py
@@ -43,6 +43,7 @@ from experiments.utils import (  # noqa: E402
     DEFAULT_OSMO_IMAGE_REPO,
     DEFAULT_OSMO_PIPELINE_IMAGE,
     DEFAULT_WANDB_ENTITY,
+    build_eval_command,
     build_train_command,
     make_entry_script,
     overrides_to_cli,
@@ -102,15 +103,29 @@ def get_effective_overrides(
 
 
 def run_local(
-    exp_id: str, config: dict, variant: str | None = None, dry_run: bool = False
+    exp_id: str,
+    config: dict,
+    variant: str | None = None,
+    dry_run: bool = False,
+    *,
+    num_envs_override: int | None = None,
+    max_iterations_override: int | None = None,
+    logger_override: str | None = None,
+    extra_overrides: dict[str, str] | None = None,
 ) -> int:
     """Run experiment locally via train.py."""
     run_name = config.get("run_name", f"{exp_id}_run")
     overrides = dict(config.get("train_overrides", {}))
+    if extra_overrides:
+        overrides.update(extra_overrides)
     resume_from = config.get("resume_from")
     seed = config.get("seed")
     motion_file = config.get("motion_file")
-    max_iterations = config.get("max_iterations")
+    max_iterations = (
+        max_iterations_override
+        if max_iterations_override is not None
+        else config.get("max_iterations")
+    )
     # Stage 1 (osmo_multi_task): pick first sequence, derive motion_file.
     if "osmo_multi_task" in config:
         seq_ids = config["osmo_multi_task"].get("sequence_ids", [])
@@ -153,7 +168,10 @@ def run_local(
             print(f"[WARNING] No workflow.py found for {exp_id}; variant flag ignored.")
 
     video = config.get("video", True)
-    num_envs = config.get("num_envs")
+    num_envs = (
+        num_envs_override if num_envs_override is not None else config.get("num_envs")
+    )
+    logger = logger_override if logger_override is not None else config.get("logger")
     cmd = build_train_command(
         run_name,
         overrides,
@@ -164,9 +182,60 @@ def run_local(
         max_iterations=max_iterations,
         video=video,
         task=config.get("task", "Sharpa-V2P-v0"),
-        logger=config.get("logger"),
+        logger=logger,
         log_project_name=config.get("log_project_name"),
         zero_actor=config.get("zero_actor", False),
+    )
+    cmd_str = " ".join(cmd)
+    print(f"Running: {cmd_str}")
+    if dry_run:
+        return 0
+    result = subprocess.run(cmd_str, shell=True, check=False)
+    return result.returncode
+
+
+def run_eval(
+    exp_id: str,
+    config: dict,
+    *,
+    checkpoint: str | None = None,
+    num_envs: int | None = None,
+    video: bool = False,
+    video_length: int | None = None,
+    eval_episodes: int | None = None,
+    real_time: bool = False,
+    extra_overrides: dict[str, str] | None = None,
+    dry_run: bool = False,
+) -> int:
+    """Run eval.py for the given experiment using its config.yaml as source of truth.
+
+    Pulls motion_file, task, and the same train_overrides block used by training
+    so train + eval stay in sync (frame range, freeze steps, etc.). CLI flags
+    layered on top via run_experiment.py override config values.
+    """
+    motion_file = config.get("motion_file")
+    overrides = dict(config.get("train_overrides", {}))
+    if extra_overrides:
+        overrides.update(extra_overrides)
+
+    if num_envs is None:
+        num_envs = config.get("num_envs")
+    seed = config.get("seed")
+
+    cmd = build_eval_command(
+        overrides,
+        checkpoint=checkpoint,
+        seed=seed,
+        motion_file=motion_file,
+        num_envs=num_envs,
+        video=video,
+        video_length=video_length,
+        eval_episodes=eval_episodes,
+        task=config.get("task", "Sharpa-V2P-v0"),
+        logger=config.get("logger"),
+        log_project_name=config.get("log_project_name"),
+        use_primitive_urdfs=config.get("use_primitive_urdfs", False),
+        real_time=real_time,
     )
     cmd_str = " ".join(cmd)
     print(f"Running: {cmd_str}")
@@ -967,6 +1036,44 @@ def main() -> None:
     parser.add_argument("--local", action="store_true", help="Run locally via train.py")
     parser.add_argument("--osmo", action="store_true", help="Submit to OSMO")
     parser.add_argument(
+        "--eval",
+        action="store_true",
+        help="Run eval.py locally with the experiment's motion_file + train_overrides.",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        default=None,
+        help="(--eval) Path to the policy checkpoint to evaluate.",
+    )
+    parser.add_argument(
+        "--num-envs",
+        type=int,
+        default=None,
+        help="(--eval) Override num_envs from config.",
+    )
+    parser.add_argument(
+        "--video",
+        action="store_true",
+        help="(--eval) Record an evaluation video.",
+    )
+    parser.add_argument(
+        "--video-length",
+        type=int,
+        default=None,
+        help="(--eval) Number of steps in the recorded video.",
+    )
+    parser.add_argument(
+        "--eval-episodes",
+        type=int,
+        default=None,
+        help="(--eval) Stop after this many completed episodes and print stats.",
+    )
+    parser.add_argument(
+        "--real-time",
+        action="store_true",
+        help="(--eval) Run eval at real time, sleeping between sim steps.",
+    )
+    parser.add_argument(
         "--wandb-sweep-create",
         action="store_true",
         help="Create wandb sweep config (exp6 only)",
@@ -1018,6 +1125,26 @@ def main() -> None:
         default="",
         help="Label appended to the OSMO workflow name for descriptive identification (e.g. 'init', 'rerun_2')",
     )
+    parser.add_argument(
+        "--max-iterations",
+        type=int,
+        default=None,
+        help="(--local) Override max_iterations from config (useful for smoke tests).",
+    )
+    parser.add_argument(
+        "--logger",
+        default=None,
+        help="(--local) Override logger from config, e.g. tensorboard for offline smoke tests.",
+    )
+    parser.add_argument(
+        "-O",
+        "--override",
+        action="append",
+        default=[],
+        metavar="KEY=VAL",
+        help="Hydra-style override appended to train_overrides / eval overrides. Repeatable. "
+        "Example: -O env.episode_length_s=2.0 -O env.commands.motion.voc_decay_steps=2",
+    )
     args = parser.parse_args()
 
     if args.list:
@@ -1036,6 +1163,7 @@ def main() -> None:
     if (
         not args.local
         and not args.osmo
+        and not args.eval
         and not args.wandb_sweep_create
         and not args.print_workflow
     ):
@@ -1048,6 +1176,13 @@ def main() -> None:
     if args.run_name_prefix is not None:
         config["run_name_prefix"] = args.run_name_prefix
 
+    extra_overrides: dict[str, str] = {}
+    for item in args.override:
+        if "=" not in item:
+            parser.error(f"--override expects KEY=VAL, got: {item!r}")
+        k, v = item.split("=", 1)
+        extra_overrides[k.strip()] = v.strip()
+
     if args.print_workflow:
         _print_workflow(args.exp_id, config)
         return
@@ -1057,9 +1192,33 @@ def main() -> None:
         run_pipeline(args.exp_id, config, args)
         return
 
+    if args.eval:
+        sys.exit(
+            run_eval(
+                args.exp_id,
+                config,
+                checkpoint=args.checkpoint,
+                num_envs=args.num_envs,
+                video=args.video,
+                video_length=args.video_length,
+                eval_episodes=args.eval_episodes,
+                real_time=args.real_time,
+                extra_overrides=extra_overrides or None,
+                dry_run=args.dry_run,
+            )
+        )
     if args.local:
         sys.exit(
-            run_local(args.exp_id, config, variant=args.variant, dry_run=args.dry_run)
+            run_local(
+                args.exp_id,
+                config,
+                variant=args.variant,
+                dry_run=args.dry_run,
+                num_envs_override=args.num_envs,
+                max_iterations_override=args.max_iterations,
+                logger_override=args.logger,
+                extra_overrides=extra_overrides or None,
+            )
         )
     elif args.osmo:
         # Use --build-image from CLI, or osmo.build_image from config (e.g. exp9 needs it for contact_force)

--- a/robotic_grounding/experiments/utils.py
+++ b/robotic_grounding/experiments/utils.py
@@ -119,6 +119,58 @@ def build_train_command(
     return cmd
 
 
+def build_eval_command(
+    overrides: dict[str, Any],
+    *,
+    checkpoint: str | None = None,
+    seed: int | None = None,
+    motion_file: str | None = None,
+    num_envs: int | None = None,
+    video: bool = False,
+    video_length: int | None = None,
+    eval_episodes: int | None = None,
+    task: str = "Sharpa-V2P-v0",
+    logger: str | None = None,
+    log_project_name: str | None = None,
+    use_primitive_urdfs: bool = False,
+    real_time: bool = False,
+) -> list[str]:
+    """Build eval.py command as list of args.
+
+    Mirrors build_train_command but only forwards flags eval.py understands.
+    Hydra-style train_overrides are forwarded verbatim so configs can scope
+    e.g. motion_start_frame / motion_end_frame uniformly across train + eval.
+    """
+    cmd = [
+        "python",
+        "scripts/rsl_rl/eval.py",
+        "--video" if video else "",
+        "--use_primitive_urdfs" if use_primitive_urdfs else "",
+        "--real-time" if real_time else "",
+        "--task",
+        task,
+    ]
+    cmd = [c for c in cmd if c]
+    if checkpoint:
+        cmd.extend(["--checkpoint", checkpoint])
+    if seed is not None:
+        cmd.extend(["--seed", str(seed)])
+    if motion_file is not None:
+        cmd.extend(["--motion_file", motion_file])
+    if num_envs is not None:
+        cmd.extend(["--num_envs", str(num_envs)])
+    if video_length is not None:
+        cmd.extend(["--video_length", str(video_length)])
+    if eval_episodes is not None:
+        cmd.extend(["--eval_episodes", str(eval_episodes)])
+    if logger:
+        cmd.extend(["--logger", logger])
+    if log_project_name:
+        cmd.extend(["--log_project_name", log_project_name])
+    cmd.extend(overrides_to_cli(overrides))
+    return cmd
+
+
 def make_entry_script(
     run_name: str,
     overrides: dict[str, Any],

--- a/robotic_grounding/scripts/retarget/create_soma_task.py
+++ b/robotic_grounding/scripts/retarget/create_soma_task.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+
+"""Scaffold a ReconBody experiment for a retargeted SOMA sequence.
+
+Given a SOMA ``sequence_id`` (and optionally a robot name + soma subdir),
+this script:
+
+1. Writes ``experiments/<exp_id>/config.yaml`` from the same template used
+   by the existing ``recon_body_*`` whole-body experiments (e.g.
+   ``experiments/recon_body_snack_box_pick_and_place_01/config.yaml``).
+2. Idempotently registers ``<exp_id>`` in ``experiments/registry.yaml``,
+   inserting it under the ``# Whole-body experiments:`` section and
+   preserving every existing comment / blank line.
+
+The script is invoked by ``scripts/retarget/process_soma_sequence.sh``
+(stage 6) but is also runnable standalone:
+
+    python scripts/retarget/create_soma_task.py 2026-03-06_10-24-18_snack_box_pick_and_place_01
+
+By default the experiment id is derived from the sequence id by stripping
+the leading ``YYYY-MM-DD_HH-MM-SS_`` timestamp and prepending
+``recon_body_`` (so the example above becomes
+``recon_body_snack_box_pick_and_place_01``). Use ``--experiment-id`` to
+override.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXPERIMENTS_DIR = REPO_ROOT / "experiments"
+REGISTRY_PATH = EXPERIMENTS_DIR / "registry.yaml"
+DEFAULT_MOTION_ROOT_REL = (
+    "source/robotic_grounding/robotic_grounding/assets/human_motion_data"
+)
+DEFAULT_SOMA_SUBDIR = "soma"
+DEFAULT_ROBOT_NAME = "g1"
+
+# Matches the leading "YYYY-MM-DD_HH-MM-SS_" timestamp on every known SOMA
+# sequence id (e.g. "2026-03-06_10-24-18_snack_box_pick_and_place_01").
+_TIMESTAMP_PREFIX = re.compile(r"^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}_")
+
+# Matches the "# Whole-body experiments" section header in registry.yaml.
+_WHOLE_BODY_HEADER = re.compile(r"^\s*#\s*Whole-body experiments")
+
+
+def default_experiment_id(sequence_id: str) -> str:
+    """Derive ``recon_body_<short_name>`` from a SOMA sequence id.
+
+    Strips the leading ``YYYY-MM-DD_HH-MM-SS_`` timestamp prefix when
+    present; otherwise falls back to using the full sequence id as the
+    short name.
+    """
+    short = _TIMESTAMP_PREFIX.sub("", sequence_id)
+    return f"recon_body_{short}"
+
+
+def motion_file_relpath(
+    sequence_id: str,
+    *,
+    robot_name: str = DEFAULT_ROBOT_NAME,
+    soma_subdir: str = DEFAULT_SOMA_SUBDIR,
+    motion_root_rel: str = DEFAULT_MOTION_ROOT_REL,
+) -> str:
+    """Build the repo-relative motion-file partition path used by experiments."""
+    return (
+        f"{motion_root_rel}/whole_body/{soma_subdir}/"
+        f"sequence_id={sequence_id}/robot_name={robot_name}"
+    )
+
+
+def render_config_yaml(
+    *,
+    exp_id: str,
+    sequence_id: str,
+    robot_name: str,
+    soma_subdir: str,
+    motion_root_rel: str,
+) -> str:
+    """Render the YAML body for ``experiments/<exp_id>/config.yaml``.
+
+    Mirrors the format of the existing ``recon_body_*`` configs so newly
+    scaffolded experiments are visually indistinguishable from
+    hand-authored ones.
+    """
+    motion_file = motion_file_relpath(
+        sequence_id,
+        robot_name=robot_name,
+        soma_subdir=soma_subdir,
+        motion_root_rel=motion_root_rel,
+    )
+    return (
+        f"# ReconBody: {exp_id} (auto-scaffolded from create_soma_task.py)\n"
+        "#\n"
+        "# Usage:\n"
+        f"#   python robotic_grounding/experiments/run_experiment.py {exp_id} --local\n"
+        f"id: {exp_id}\n"
+        f'description: "ReconBody {exp_id} with SONIC JOINT_RESIDUAL"\n'
+        f"run_name: {exp_id}\n"
+        "task: SonicG1-ReconBody-v0\n"
+        f"# Use the explicit repo-relative partition path because whole_body/{soma_subdir} does not\n"
+        "# follow the 4-part dataset/dataset_retargeted/sequence_id/robot shorthand.\n"
+        f"motion_file: {motion_file}\n"
+        "video: true\n"
+        "num_envs: 4096\n"
+        "max_iterations: 20000\n"
+        "zero_actor: true\n"
+        "logger: wandb\n"
+        "log_project_name: v2d-whole-body-tpv\n"
+        "\n"
+        "train_overrides:\n"
+        "  env.commands.motion.reset_freeze_steps: 50\n"
+        "  env.commands.motion.voc_decay_steps: 10\n"
+        "  env.commands.motion.voc_reset_scale: 1.0\n"
+        "  env.commands.motion.initial_virtual_object_control_curriculum_scale: 1.0\n"
+        "  # Frame range of the source motion to train on. -1 for motion_end_frame\n"
+        "  # means run to the end of the sequence.\n"
+        "  # Use replay_motion_viser.py to visualize the motion and get the frame range.\n"
+        "  env.commands.motion.motion_start_frame: 0\n"
+        "  env.commands.motion.motion_end_frame: -1\n"
+        "  env.episode_length_s: 5.0\n"
+        "  # Reset the shoulder spread to 0.2\n"
+        "  env.commands.motion.reset_shoulder_spread: 0.2\n"
+        "\n"
+        "osmo:\n"
+        "  build_image: false\n"
+        "  # Reuse the current whole-body training image so submits don't fall back to :latest.\n"
+        "  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple\n"
+    )
+
+
+@dataclass(frozen=True)
+class ConfigWriteResult:
+    """Outcome of writing an experiment config.yaml."""
+
+    path: Path
+    # One of "wrote", "overwrote", "kept-existing".
+    action: str
+
+
+def write_experiment_config(
+    *,
+    exp_id: str,
+    sequence_id: str,
+    robot_name: str,
+    soma_subdir: str,
+    motion_root_rel: str,
+    overwrite: bool,
+    experiments_dir: Path = EXPERIMENTS_DIR,
+) -> ConfigWriteResult:
+    """Materialize ``experiments/<exp_id>/config.yaml``.
+
+    Creates the parent directory if needed. When the config already
+    exists, only overwrites it when ``overwrite=True`` so callers can
+    keep the operation safe-by-default.
+    """
+    exp_dir = experiments_dir / exp_id
+    exp_config = exp_dir / "config.yaml"
+    if exp_config.exists() and not overwrite:
+        return ConfigWriteResult(path=exp_config, action="kept-existing")
+
+    exp_dir.mkdir(parents=True, exist_ok=True)
+    body = render_config_yaml(
+        exp_id=exp_id,
+        sequence_id=sequence_id,
+        robot_name=robot_name,
+        soma_subdir=soma_subdir,
+        motion_root_rel=motion_root_rel,
+    )
+    pre_existed = exp_config.exists()
+    exp_config.write_text(body, encoding="utf-8")
+    return ConfigWriteResult(
+        path=exp_config,
+        action="overwrote" if pre_existed else "wrote",
+    )
+
+
+@dataclass(frozen=True)
+class RegistryUpdateResult:
+    """Outcome of updating experiments/registry.yaml for a sequence."""
+
+    path: Path
+    # One of "noop", "updated-in-place", "inserted-in-section",
+    # "appended-at-end".
+    action: str
+    previous_value: str | None = None
+
+
+def _parse_top_level_value(line: str) -> str | None:
+    """Return the right-hand value of a ``key: value`` line, ignoring comments.
+
+    Returns ``None`` if the line is not a top-level mapping entry.
+    """
+    if not line or line.startswith((" ", "\t", "#")):
+        return None
+    if ":" not in line:
+        return None
+    rhs = line.split(":", 1)[1].strip()
+    if "#" in rhs:
+        rhs = rhs.split("#", 1)[0].strip()
+    return rhs
+
+
+def update_registry(
+    *,
+    exp_id: str,
+    exp_dir_name: str | None = None,
+    registry_path: Path = REGISTRY_PATH,
+) -> RegistryUpdateResult:
+    """Idempotently add / update ``exp_id`` in ``registry.yaml``.
+
+    Behavior:
+    - If ``registry.yaml`` already maps ``exp_id`` to ``exp_dir_name``,
+      this is a no-op.
+    - If ``exp_id`` exists with a different value, the line is rewritten
+      in place (preserving every other line).
+    - Otherwise the new entry is inserted at the end of the contiguous
+      block of entries that follows the ``# Whole-body experiments:``
+      section header. If that header is missing the entry is appended at
+      EOF instead.
+    """
+    if exp_dir_name is None:
+        exp_dir_name = exp_id
+
+    text = registry_path.read_text(encoding="utf-8")
+    # Preserve the trailing-newline policy of whatever was on disk so the
+    # rewrite is minimally disruptive (matches the rest of the file's
+    # formatting conventions).
+    trailing_newline = text.endswith("\n")
+    lines = text.splitlines()
+    key_prefix = f"{exp_id}:"
+
+    found_idx = None
+    found_value = None
+    for i, line in enumerate(lines):
+        if line.startswith(key_prefix):
+            value = _parse_top_level_value(line)
+            if value is not None:
+                found_idx = i
+                found_value = value
+                break
+
+    if found_idx is not None:
+        if found_value == exp_dir_name:
+            return RegistryUpdateResult(
+                path=registry_path,
+                action="noop",
+                previous_value=found_value,
+            )
+        lines[found_idx] = f"{exp_id}: {exp_dir_name}"
+        _write_lines(registry_path, lines, trailing_newline)
+        return RegistryUpdateResult(
+            path=registry_path,
+            action="updated-in-place",
+            previous_value=found_value,
+        )
+
+    new_line = f"{exp_id}: {exp_dir_name}"
+    header_idx = next(
+        (i for i, line in enumerate(lines) if _WHOLE_BODY_HEADER.match(line)),
+        None,
+    )
+
+    if header_idx is not None:
+        # Append at the end of the contiguous block of top-level entries
+        # that follows the header (stop at first blank line or comment).
+        insert_idx = header_idx + 1
+        while insert_idx < len(lines):
+            stripped = lines[insert_idx].strip()
+            if stripped == "" or stripped.startswith("#"):
+                break
+            insert_idx += 1
+        lines.insert(insert_idx, new_line)
+        _write_lines(registry_path, lines, trailing_newline)
+        return RegistryUpdateResult(path=registry_path, action="inserted-in-section")
+
+    if lines and lines[-1].strip() != "":
+        lines.append("")
+    lines.append(new_line)
+    _write_lines(registry_path, lines, trailing_newline)
+    return RegistryUpdateResult(path=registry_path, action="appended-at-end")
+
+
+def _write_lines(path: Path, lines: list[str], trailing_newline: bool) -> None:
+    """Write ``lines`` back to ``path`` with a controlled trailing newline."""
+    text = "\n".join(lines) + ("\n" if trailing_newline else "")
+    path.write_text(text, encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """CLI args."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scaffold experiments/<exp_id>/config.yaml for a retargeted "
+            "SOMA sequence and register it in experiments/registry.yaml."
+        ),
+    )
+    parser.add_argument(
+        "sequence_id",
+        type=str,
+        help=(
+            "SOMA sequence id, e.g. "
+            "'2026-03-06_10-24-18_snack_box_pick_and_place_01'."
+        ),
+    )
+    parser.add_argument(
+        "--experiment-id",
+        type=str,
+        default=None,
+        help=(
+            "Override the experiment id (also used as the directory name "
+            "and run_name). Default: 'recon_body_<short_name>' where "
+            "<short_name> is <sequence_id> with the leading "
+            "YYYY-MM-DD_HH-MM-SS_ timestamp stripped."
+        ),
+    )
+    parser.add_argument(
+        "--robot-name",
+        type=str,
+        default=DEFAULT_ROBOT_NAME,
+        help=f"Robot config name (default: {DEFAULT_ROBOT_NAME}).",
+    )
+    parser.add_argument(
+        "--soma-subdir",
+        type=str,
+        default=DEFAULT_SOMA_SUBDIR,
+        help=(
+            "Schema subfolder under <motion-root>/whole_body "
+            f"(default: {DEFAULT_SOMA_SUBDIR})."
+        ),
+    )
+    parser.add_argument(
+        "--motion-root-rel",
+        type=str,
+        default=DEFAULT_MOTION_ROOT_REL,
+        help=(
+            "Repo-relative motion-data root encoded into config.motion_file "
+            f"(default: {DEFAULT_MOTION_ROOT_REL})."
+        ),
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help=(
+            "If the experiment config already exists, overwrite it. "
+            "Without this flag, an existing config is kept and only the "
+            "registry entry is reconciled."
+        ),
+    )
+    parser.add_argument(
+        "--registry-path",
+        type=Path,
+        default=REGISTRY_PATH,
+        help=f"Path to registry.yaml (default: {REGISTRY_PATH}).",
+    )
+    parser.add_argument(
+        "--experiments-dir",
+        type=Path,
+        default=EXPERIMENTS_DIR,
+        help=f"Path to experiments/ directory (default: {EXPERIMENTS_DIR}).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point."""
+    args = parse_args(argv)
+
+    exp_id = args.experiment_id or default_experiment_id(args.sequence_id)
+
+    print(f"[create_soma_task] sequence_id   : {args.sequence_id}")
+    print(f"[create_soma_task] experiment_id : {exp_id}")
+    print(f"[create_soma_task] robot_name    : {args.robot_name}")
+    print(f"[create_soma_task] soma_subdir   : {args.soma_subdir}")
+
+    cfg_result = write_experiment_config(
+        exp_id=exp_id,
+        sequence_id=args.sequence_id,
+        robot_name=args.robot_name,
+        soma_subdir=args.soma_subdir,
+        motion_root_rel=args.motion_root_rel,
+        overwrite=args.overwrite,
+        experiments_dir=args.experiments_dir,
+    )
+    if cfg_result.action == "wrote":
+        print(f"[create_soma_task] wrote {cfg_result.path}")
+    elif cfg_result.action == "overwrote":
+        print(f"[create_soma_task] overwrote {cfg_result.path}")
+    else:
+        print(
+            f"[create_soma_task] kept existing {cfg_result.path} "
+            "(pass --overwrite to replace)"
+        )
+
+    reg_result = update_registry(
+        exp_id=exp_id,
+        registry_path=args.registry_path,
+    )
+    if reg_result.action == "noop":
+        print(
+            f"[create_soma_task] registry already has '{exp_id}: {exp_id}'; "
+            "nothing to do."
+        )
+    elif reg_result.action == "updated-in-place":
+        print(
+            f"[create_soma_task] updated existing entry to '{exp_id}: {exp_id}' "
+            f"(was '{reg_result.previous_value}')."
+        )
+    elif reg_result.action == "inserted-in-section":
+        print(
+            f"[create_soma_task] inserted '{exp_id}: {exp_id}' under the "
+            "Whole-body experiments block in "
+            f"{reg_result.path}."
+        )
+    else:
+        print(
+            f"[create_soma_task] appended '{exp_id}: {exp_id}' at end of "
+            f"{reg_result.path} (no Whole-body header found)."
+        )
+
+    print(
+        "[create_soma_task] launch with: "
+        f"python robotic_grounding/experiments/run_experiment.py {exp_id} --local"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robotic_grounding/scripts/rsl_rl/eval.py
+++ b/robotic_grounding/scripts/rsl_rl/eval.py
@@ -75,6 +75,18 @@ parser.add_argument(
     help="Motion file to load.",
 )
 parser.add_argument(
+    "--motion_start_frame",
+    type=int,
+    default=None,
+    help="First frame of the source motion to use (inclusive). 0 = beginning.",
+)
+parser.add_argument(
+    "--motion_end_frame",
+    type=int,
+    default=None,
+    help="One past the last frame to use. -1 means end of sequence.",
+)
+parser.add_argument(
     "--wandb_id",
     type=str,
     default=None,
@@ -149,6 +161,27 @@ from isaaclab_tasks.utils.hydra import hydra_task_config
 # PLACEHOLDER: Extension template (do not remove this comment)
 
 
+def _apply_eval_defaults(env_cfg) -> None:
+    """Force deterministic eval behaviour: frame 0 reset, VOC fully off.
+
+    Eval should reproduce the policy's behaviour against the reference
+    trajectory, not exercise the training-time exploration helpers. We:
+    - Reset every env to frame 0 (`always_reset_to_first_frame`).
+    - Zero out the virtual-object-control scale + reset target so the policy
+      drives the object on its own.
+    - Disable the curriculum entirely so it cannot bump VOC back up the way
+      it does at training step 0 (see G1SonicReconBodyVOCCurriculumCfg).
+    """
+    if hasattr(env_cfg, "commands") and hasattr(env_cfg.commands, "motion"):
+        motion_cfg = env_cfg.commands.motion
+        motion_cfg.always_reset_to_first_frame = True
+        motion_cfg.initial_virtual_object_control_curriculum_scale = 0.0
+        motion_cfg.voc_reset_scale = 0.0
+        motion_cfg.voc_decay_steps = 0
+    if hasattr(env_cfg, "curriculum"):
+        env_cfg.curriculum = None
+
+
 @hydra_task_config(args_cli.task, args_cli.agent)
 def main(
     env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg,
@@ -181,6 +214,16 @@ def main(
             env_cfg, scene_config, use_primitive_urdfs=args_cli.use_primitive_urdfs
         )
         autoframe_viewer(env_cfg, scene_config.motion_file)
+
+    # Apply optional motion frame range overrides.
+    if hasattr(env_cfg, "commands") and hasattr(env_cfg.commands, "motion"):
+        if args_cli.motion_start_frame is not None:
+            env_cfg.commands.motion.motion_start_frame = args_cli.motion_start_frame
+        if args_cli.motion_end_frame is not None:
+            env_cfg.commands.motion.motion_end_frame = args_cli.motion_end_frame
+
+    # Eval-mode safety: deterministic reset + VOC off.
+    _apply_eval_defaults(env_cfg)
 
     # set the environment seed
     # note: certain randomizations occur in the environment initialization so we set the seed here

--- a/robotic_grounding/scripts/train_tpv_wholebody_workflow.sh
+++ b/robotic_grounding/scripts/train_tpv_wholebody_workflow.sh
@@ -1,0 +1,729 @@
+#!/usr/bin/env bash
+# train_tpv_wholebody_workflow.sh
+#
+# !!! RUN THIS ON THE HOST, NOT INSIDE THE DOCKER CONTAINER !!!
+#
+# This script orchestrates Docker (`./workflow/run.sh exec`) and OSMO submission
+# (`python .../run_experiment.py --osmo`), neither of which work from inside the
+# container (osmo CLI is not installed there, and `docker exec` from a container
+# would target the host's docker daemon). The script aborts at startup if it
+# detects it's running inside the container.
+#
+# Driver for the recurring third-person-view (TPV) whole-body ReconBody training
+# flow. There are two ways to use it:
+#
+# A) Interactive driver `run` (recommended for a new dataset):
+#    Walks through all four stages below in order, prompting before each one
+#    so any stage can be skipped or re-prompted. Detected state is shown so
+#    the prompt defaults are sensible: e.g. init defaults to "skip" if a
+#    config already exists, set-frames pre-fills the current frame range and
+#    you can press Enter to keep it, etc. Resumable from any stage by
+#    re-running `run <exp_id>`.
+#      Examples:
+#        ./scripts/train_tpv_wholebody_workflow.sh run                        # asks for input
+#        ./scripts/train_tpv_wholebody_workflow.sh run <motion_file_path>     # new dataset
+#        ./scripts/train_tpv_wholebody_workflow.sh run <exp_id>               # existing exp
+#        ./scripts/train_tpv_wholebody_workflow.sh run --dry-run --yes ...    # auto-accept defaults, no exec
+#
+# B) Per-stage subcommands (for re-running just one step or scripting):
+#
+#   1. init         [host]         Create experiments/<exp_id>/config.yaml from
+#                                  a template and add it to registry.yaml.
+#   2. replay       [host->ctnr]   Calls `./workflow/run.sh exec ...` to run
+#                                  scripts/replay_motion_viser.py inside the
+#                                  already-running container.
+#   3. set-frames   [host]         Edit the chosen frames into the YAML.
+#   4. submit       [host]         Submit the OSMO job via run_experiment.py.
+#
+# This script is intentionally scoped to whole-body TPV ReconBody training only
+# (see experiments/recon_body_*/config.yaml). It is NOT a general experiment
+# runner.
+#
+# Usage:
+#   ./scripts/train_tpv_wholebody_workflow.sh run [<exp_id_or_motion_file>] [--dry-run] [--yes]
+#   ./scripts/train_tpv_wholebody_workflow.sh init <motion_file_path> [--exp-id NAME] [--force]
+#   ./scripts/train_tpv_wholebody_workflow.sh replay <exp_id>
+#   ./scripts/train_tpv_wholebody_workflow.sh set-frames <exp_id> <start> <end>
+#   ./scripts/train_tpv_wholebody_workflow.sh submit <exp_id> [--build-image] [--run-name NAME] [--dry-run]
+#
+# Global flags (must come before the subcommand):
+#   --dry-run    Print every command but never execute (works for `run` too).
+#   --yes / -y   Auto-accept all interactive prompt defaults (CI-friendly).
+
+set -euo pipefail
+
+# --- Resolve repo paths ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+EXPERIMENTS_DIR="${REPO_ROOT}/experiments"
+REGISTRY_FILE="${EXPERIMENTS_DIR}/registry.yaml"
+TEMPLATE_CONFIG="${EXPERIMENTS_DIR}/recon_body_snack_box_pick_and_place_01/config.yaml"
+WORKFLOW_RUN_SH="${REPO_ROOT}/workflow/run.sh"
+REPLAY_SCRIPT="scripts/replay_motion_viser.py"
+RUN_EXPERIMENT_SCRIPT="experiments/run_experiment.py"
+# Container target — must match what `./workflow/run.sh start` produces. Both
+# values are also positionally required by `./workflow/run.sh exec` (see
+# workflow/run.sh, the `exec` case `shift 3`s blindly), so we pass them
+# explicitly when invoking exec to avoid the "robotic-grounding----gpupython"
+# corruption when the placeholders are omitted.
+CONTAINER_VERSION="${CONTAINER_VERSION:-latest}"
+CONTAINER_GPU="${CONTAINER_GPU:-0}"
+CONTAINER_NAME="robotic-grounding-${CONTAINER_VERSION}-gpu${CONTAINER_GPU}"
+
+# --- Global flags (set by parse_global_flags) ---
+DRY_RUN=0
+ASSUME_YES=0
+
+# --- Host-vs-container guard ---
+# Returns 0 if running inside a Docker container, 1 otherwise. Used to refuse
+# to run the workflow script from inside the container shell, where docker exec
+# and the OSMO CLI both fail.
+running_inside_container() {
+    [[ -f /.dockerenv ]] && return 0
+    if [[ -r /proc/1/cgroup ]] && grep -qE 'docker|containerd|kubepods' /proc/1/cgroup 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+# --- Pretty output helpers ---
+_color() {
+    if [[ -t 1 ]]; then printf '\033[%sm%s\033[0m' "$1" "$2"; else printf '%s' "$2"; fi
+}
+log_info()   { echo "[$(_color '36' INFO)] $*"; }
+log_warn()   { echo "[$(_color '33' WARN)] $*" >&2; }
+log_error()  { echo "[$(_color '31' ERROR)] $*" >&2; }
+log_stage()  {
+    echo
+    echo "$(_color '1;34' "===== $* =====")"
+}
+log_cmd()    { echo "$(_color '90' '+') $*"; }
+
+die() { log_error "$*"; exit 1; }
+
+# Run a command, echoing it first. Honors --dry-run.
+run_cmd() {
+    log_cmd "$*"
+    if (( DRY_RUN )); then
+        log_info "(dry-run) skipping execution"
+        return 0
+    fi
+    eval "$@"
+}
+
+# --- Prompt helpers (interactive) ---
+
+# prompt_yn <question> <default y|n> -> echoes "y" or "n"
+prompt_yn() {
+    local question="$1" default="${2:-y}" answer suffix
+    if [[ "${default}" == "y" ]]; then suffix="[Y/n]"; else suffix="[y/N]"; fi
+    if (( ASSUME_YES )); then
+        echo "${default}"
+        return 0
+    fi
+    while true; do
+        read -r -p "${question} ${suffix} " answer < /dev/tty || answer=""
+        answer="${answer:-${default}}"
+        case "${answer,,}" in
+            y|yes) echo "y"; return 0 ;;
+            n|no)  echo "n"; return 0 ;;
+            q|quit) die "user quit" ;;
+            *)     echo "Please answer y, n, or q." >&2 ;;
+        esac
+    done
+}
+
+# prompt_value <question> <default> -> echoes user value or default if empty.
+prompt_value() {
+    local question="$1" default="$2" answer
+    if (( ASSUME_YES )); then
+        echo "${default}"
+        return 0
+    fi
+    read -r -p "${question} [${default}] " answer < /dev/tty || answer=""
+    echo "${answer:-${default}}"
+}
+
+# --- Path / id derivation ---
+
+# Strip trailing slash, then derive a short sequence name from a motion_file path
+# Example: source/.../sequence_id=2026-02-27_16-25-23_sit_skinny_wood_chair_01/robot_name=g1
+#          -> sit_skinny_wood_chair_01
+derive_seq_name() {
+    local p="${1%/}"
+    # Drop trailing /robot_name=*
+    p="${p%/robot_name=*}"
+    local base="${p##*/}"
+    # Strip leading sequence_id=
+    base="${base#sequence_id=}"
+    # Strip leading date/time prefix YYYY-MM-DD_HH-MM-SS_ if present
+    base="$(echo "${base}" | sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}-[0-9]{2}_//')"
+    echo "${base}"
+}
+
+derive_exp_id_from_motion() {
+    local motion_file="$1"
+    echo "recon_body_$(derive_seq_name "${motion_file}")"
+}
+
+# Ensure a motion_file path points at a robot_name=* partition (a directory that
+# pyarrow can read as a parquet dataset). If the input already contains
+# /robot_name=*, return it unchanged. Otherwise look under the path for a
+# single robot_name=* subdir and append it.
+#
+# Why: pq.read_table() walks every file under the given path. If the path is
+# the parent sequence_id=* dir, pyarrow tries to parse object/material.mtl,
+# textured_mesh.obj, etc. as parquet and dies.
+normalize_motion_file_to_robot_partition() {
+    local mf="${1%/}"
+    if [[ "${mf}" == */robot_name=* ]]; then
+        echo "${mf}"
+        return 0
+    fi
+    local candidate_root=""
+    if [[ -d "${mf}" ]]; then
+        candidate_root="${mf}"
+    elif [[ -d "${REPO_ROOT}/${mf}" ]]; then
+        candidate_root="${REPO_ROOT}/${mf}"
+    fi
+    if [[ -z "${candidate_root}" ]]; then
+        log_warn "motion_file does not contain '/robot_name=*' and the directory is not present locally; leaving as-is: ${mf}" >&2
+        echo "${mf}"
+        return 0
+    fi
+    local matches=()
+    while IFS= read -r d; do
+        [[ -n "${d}" ]] && matches+=("${d}")
+    done < <(find "${candidate_root}" -mindepth 1 -maxdepth 1 -type d -name 'robot_name=*' -printf '%f\n' 2>/dev/null | sort)
+    if (( ${#matches[@]} == 0 )); then
+        die "motion_file '${mf}' has no robot_name=* subdirectory under ${candidate_root}; expected layout: <sequence_id=...>/robot_name=<robot>"
+    fi
+    if (( ${#matches[@]} > 1 )); then
+        die "motion_file '${mf}' contains multiple robot_name=* subdirs (${matches[*]}); pass the specific one explicitly"
+    fi
+    echo "${mf}/${matches[0]}"
+}
+
+config_path_for() {
+    echo "${EXPERIMENTS_DIR}/$1/config.yaml"
+}
+
+# --- YAML helpers (Python inline) ---
+
+# Read a top-level scalar key (id, motion_file, run_name, ...) from a config.
+yaml_get_top() {
+    local config="$1" key="$2"
+    python3 - "$config" "$key" <<'PY'
+import sys, yaml
+path, key = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    data = yaml.safe_load(f) or {}
+val = data.get(key, "")
+print("" if val is None else val)
+PY
+}
+
+# Read train_overrides.<dotted_key> as a string.
+yaml_get_override() {
+    local config="$1" key="$2"
+    python3 - "$config" "$key" <<'PY'
+import sys, yaml
+path, key = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    data = yaml.safe_load(f) or {}
+overrides = data.get("train_overrides", {}) or {}
+val = overrides.get(key, "")
+print("" if val is None else val)
+PY
+}
+
+# Set the start/end frames in a config, preserving comments and key order via
+# a surgical line-by-line edit (only the two frame lines are rewritten).
+# A value of "-" for start/end keeps the existing line untouched.
+# If the key is missing entirely, it is appended under train_overrides.
+yaml_set_frames() {
+    local config="$1" start="$2" end="$3"
+    python3 - "$config" "$start" "$end" <<'PY'
+import re, sys
+path, start, end = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path) as f:
+    lines = f.readlines()
+
+KEY_START = "env.commands.motion.motion_start_frame"
+KEY_END = "env.commands.motion.motion_end_frame"
+
+def patch(lines, key, new_val):
+    pat = re.compile(rf"^(\s*){re.escape(key)}\s*:\s*([^#\n]*)(#.*)?$")
+    for i, line in enumerate(lines):
+        m = pat.match(line.rstrip("\n"))
+        if m:
+            indent = m.group(1)
+            trailing = m.group(3) or ""
+            sep = "  " if trailing else ""
+            lines[i] = f"{indent}{key}: {new_val}{sep}{trailing}\n"
+            return True
+    return False
+
+def append_under_train_overrides(lines, key, new_val):
+    for i, line in enumerate(lines):
+        if line.startswith("train_overrides:"):
+            j = i + 1
+            while j < len(lines) and (lines[j].startswith(" ") or lines[j].startswith("\t") or lines[j].strip() == ""):
+                j += 1
+            insert_at = j
+            lines.insert(insert_at, f"  {key}: {new_val}\n")
+            return True
+    lines.append("\ntrain_overrides:\n")
+    lines.append(f"  {key}: {new_val}\n")
+    return True
+
+if start != "-":
+    if not patch(lines, KEY_START, start):
+        append_under_train_overrides(lines, KEY_START, start)
+if end != "-":
+    if not patch(lines, KEY_END, end):
+        append_under_train_overrides(lines, KEY_END, end)
+
+with open(path, "w") as f:
+    f.writelines(lines)
+PY
+}
+
+# --- Container detection ---
+
+container_running() {
+    docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "${CONTAINER_NAME}"
+}
+
+# --- Stage: init ---
+
+cmd_init() {
+    local motion_file="" exp_id="" force=0
+    while (( $# )); do
+        case "$1" in
+            --exp-id) exp_id="$2"; shift 2 ;;
+            --force)  force=1; shift ;;
+            -*)       die "init: unknown flag: $1" ;;
+            *)
+                if [[ -z "${motion_file}" ]]; then motion_file="$1"; else die "init: unexpected arg: $1"; fi
+                shift
+                ;;
+        esac
+    done
+
+    [[ -n "${motion_file}" ]] || die "init: <motion_file_path> is required"
+    [[ -f "${TEMPLATE_CONFIG}" ]] || die "init: template config not found: ${TEMPLATE_CONFIG}"
+
+    if [[ -z "${exp_id}" ]]; then
+        exp_id="$(derive_exp_id_from_motion "${motion_file}")"
+    fi
+
+    # Normalize to a robot_name=* partition; pyarrow chokes on the parent dir.
+    local normalized_mf
+    normalized_mf="$(normalize_motion_file_to_robot_partition "${motion_file}")"
+    if [[ "${normalized_mf}" != "${motion_file}" ]]; then
+        log_info "Normalized motion_file: ${motion_file} -> ${normalized_mf}"
+        motion_file="${normalized_mf}"
+    fi
+
+    local target_dir="${EXPERIMENTS_DIR}/${exp_id}"
+    local target_config="${target_dir}/config.yaml"
+    log_info "Initializing experiment '${exp_id}'"
+    log_info "  motion_file: ${motion_file}"
+    log_info "  config:      ${target_config}"
+
+    if [[ -e "${target_config}" && "${force}" -eq 0 ]]; then
+        die "init: ${target_config} already exists (use --force to overwrite)"
+    fi
+
+    if (( DRY_RUN )); then
+        log_info "(dry-run) would create ${target_config}"
+        log_info "(dry-run) would ensure registry entry: ${exp_id}: ${exp_id}"
+        return 0
+    fi
+
+    mkdir -p "${target_dir}"
+    EXP_ID="${exp_id}" MOTION_FILE="${motion_file}" \
+    python3 - "${TEMPLATE_CONFIG}" "${target_config}" <<'PY'
+import os, sys, yaml
+src, dst = sys.argv[1], sys.argv[2]
+exp_id = os.environ["EXP_ID"]
+motion_file = os.environ["MOTION_FILE"]
+with open(src) as f:
+    data = yaml.safe_load(f)
+data["id"] = exp_id
+data["run_name"] = exp_id
+data["description"] = f"ReconBody {exp_id} with SONIC JOINT_RESIDUAL"
+data["motion_file"] = motion_file
+overrides = data.setdefault("train_overrides", {})
+overrides["env.commands.motion.motion_start_frame"] = 0
+overrides["env.commands.motion.motion_end_frame"] = -1
+with open(dst, "w") as f:
+    f.write("# ReconBody: " + exp_id + " (TPV whole-body)\n")
+    f.write("#\n")
+    f.write("# Usage:\n")
+    f.write(f"#   python robotic_grounding/experiments/run_experiment.py {exp_id} --local\n")
+    yaml.safe_dump(data, f, sort_keys=False, default_flow_style=False)
+PY
+    log_info "Wrote ${target_config}"
+
+    EXP_ID="${exp_id}" python3 - "${REGISTRY_FILE}" <<'PY'
+import os, sys
+exp_id = os.environ["EXP_ID"]
+path = sys.argv[1]
+with open(path) as f:
+    text = f.read()
+needle = f"{exp_id}: {exp_id}"
+if needle in text:
+    print(f"[INFO] registry already contains '{needle}', skipping")
+    sys.exit(0)
+lines = text.splitlines()
+inserted = False
+out = []
+for line in lines:
+    out.append(line)
+    if not inserted and line.startswith("# Whole-body experiments:"):
+        out.append(needle)
+        inserted = True
+if not inserted:
+    out.append("")
+    out.append("# Whole-body experiments:")
+    out.append(needle)
+out.append("")
+with open(path, "w") as f:
+    f.write("\n".join(line for line in out if line is not None))
+print(f"[INFO] added '{needle}' to {path}")
+PY
+}
+
+# --- Stage: replay ---
+
+cmd_replay() {
+    local exp_id="${1:-}"
+    [[ -n "${exp_id}" ]] || die "replay: <exp_id> is required"
+    local config; config="$(config_path_for "${exp_id}")"
+    [[ -f "${config}" ]] || die "replay: config not found: ${config}"
+
+    local motion_file; motion_file="$(yaml_get_top "${config}" motion_file)"
+    [[ -n "${motion_file}" ]] || die "replay: motion_file is empty in ${config}"
+
+    log_info "exp_id      : ${exp_id}"
+    log_info "motion_file : ${motion_file}"
+
+    if ! container_running; then
+        log_warn "container '${CONTAINER_NAME}' is not running."
+        log_warn "Start it first with:  ${WORKFLOW_RUN_SH} start"
+        if (( DRY_RUN )); then
+            log_warn "(dry-run) continuing anyway to print the resolved command"
+        else
+            die "replay: container is not running"
+        fi
+    fi
+
+    # NOTE: workflow/run.sh's `exec` case runs `shift 3` blindly, so the version
+    # and gpu placeholders MUST be passed positionally even if they are the
+    # defaults. Without them, $CONTAINER_NAME inside run.sh becomes
+    # "robotic-grounding----gpupython" and `docker exec` fails.
+    run_cmd "${WORKFLOW_RUN_SH} exec ${CONTAINER_VERSION} ${CONTAINER_GPU} -- python ${REPLAY_SCRIPT} --motion_file ${motion_file}"
+}
+
+# --- Stage: set-frames ---
+
+cmd_set_frames() {
+    local exp_id="${1:-}" start="${2:-}" end="${3:-}"
+    [[ -n "${exp_id}" && -n "${start}" && -n "${end}" ]] || die "set-frames: usage: set-frames <exp_id> <start> <end>"
+    local config; config="$(config_path_for "${exp_id}")"
+    [[ -f "${config}" ]] || die "set-frames: config not found: ${config}"
+
+    local cur_start cur_end
+    cur_start="$(yaml_get_override "${config}" env.commands.motion.motion_start_frame)"
+    cur_end="$(yaml_get_override "${config}" env.commands.motion.motion_end_frame)"
+    log_info "current motion_start_frame=${cur_start:-<unset>} motion_end_frame=${cur_end:-<unset>}"
+    log_info "new     motion_start_frame=${start} motion_end_frame=${end} (- means keep current)"
+
+    if (( DRY_RUN )); then
+        log_info "(dry-run) would update ${config}"
+        return 0
+    fi
+    yaml_set_frames "${config}" "${start}" "${end}"
+    log_info "Updated ${config}"
+}
+
+# --- Stage: submit ---
+
+cmd_submit() {
+    local exp_id="" run_name="" build_image=0 local_dry=0
+    while (( $# )); do
+        case "$1" in
+            --build-image) build_image=1; shift ;;
+            --run-name)    run_name="$2"; shift 2 ;;
+            --dry-run)     local_dry=1; shift ;;
+            -*)            die "submit: unknown flag: $1" ;;
+            *)
+                if [[ -z "${exp_id}" ]]; then exp_id="$1"; else die "submit: unexpected arg: $1"; fi
+                shift
+                ;;
+        esac
+    done
+    [[ -n "${exp_id}" ]] || die "submit: <exp_id> is required"
+    local config; config="$(config_path_for "${exp_id}")"
+    if [[ ! -f "${config}" ]]; then
+        if (( local_dry )) || (( DRY_RUN )); then
+            log_warn "config not found: ${config} (dry-run; continuing anyway)"
+        else
+            die "submit: config not found: ${config}"
+        fi
+    fi
+
+    [[ -n "${run_name}" ]] || run_name="${exp_id}_motion_data"
+
+    local cmd="python ${RUN_EXPERIMENT_SCRIPT} ${exp_id} --osmo --run-name ${run_name}"
+    if (( build_image )); then cmd+=" --build-image"; fi
+
+    log_info "exp_id     : ${exp_id}"
+    log_info "run_name   : ${run_name}"
+    log_info "build_image: $(( build_image ))"
+
+    if (( local_dry )) || (( DRY_RUN )); then
+        log_cmd "${cmd}"
+        log_info "(dry-run) skipping submission"
+        return 0
+    fi
+    run_cmd "${cmd}"
+}
+
+# --- Interactive driver: run ---
+
+cmd_run() {
+    local arg=""
+    while (( $# )); do
+        case "$1" in
+            -*) die "run: unknown flag: $1 (use --dry-run/--yes before the subcommand)" ;;
+            *)
+                if [[ -z "${arg}" ]]; then arg="$1"; else die "run: unexpected arg: $1"; fi
+                shift
+                ;;
+        esac
+    done
+
+    if [[ -z "${arg}" ]]; then
+        arg="$(prompt_value "Enter exp_id or motion_file path" "")"
+        [[ -n "${arg}" ]] || die "run: nothing to do"
+    fi
+
+    # Decide whether arg is a motion file path or an exp_id.
+    local exp_id="" motion_file=""
+    if [[ "${arg}" == */robot_name=* || -d "${REPO_ROOT}/${arg}" || -d "${arg}" ]]; then
+        motion_file="${arg}"
+        exp_id="$(derive_exp_id_from_motion "${motion_file}")"
+        log_info "Treating arg as motion_file path"
+        log_info "  motion_file -> ${motion_file}"
+        log_info "  derived exp_id -> ${exp_id}"
+    else
+        exp_id="${arg}"
+        log_info "Treating arg as exp_id: ${exp_id}"
+    fi
+
+    local config; config="$(config_path_for "${exp_id}")"
+
+    # ----- Stage 1: init -----
+    log_stage "Stage 1/4: init  [host]"
+    local needs_init=0 default_init="n"
+    if [[ ! -f "${config}" ]]; then
+        needs_init=1
+        default_init="y"
+        log_info "Config does not exist yet: ${config}"
+        if [[ -z "${motion_file}" ]]; then
+            motion_file="$(prompt_value "Enter motion_file path for ${exp_id}" "")"
+            [[ -n "${motion_file}" ]] || die "init: motion_file is required when config does not exist"
+        fi
+    else
+        log_info "Config already exists: ${config}"
+    fi
+
+    local ans; ans="$(prompt_yn "Run init for ${exp_id}?" "${default_init}")"
+    if [[ "${ans}" == "y" ]]; then
+        if [[ -z "${motion_file}" ]]; then
+            motion_file="$(yaml_get_top "${config}" motion_file)"
+            log_info "Using motion_file from existing config: ${motion_file}"
+        fi
+        local edited_exp_id; edited_exp_id="$(prompt_value "exp_id" "${exp_id}")"
+        exp_id="${edited_exp_id}"
+        config="$(config_path_for "${exp_id}")"
+        local force_args=()
+        if [[ -e "${config}" ]]; then
+            local overwrite; overwrite="$(prompt_yn "Overwrite existing ${config}?" "n")"
+            if [[ "${overwrite}" == "y" ]]; then force_args+=("--force"); else
+                log_info "Keeping existing config; skipping init."
+            fi
+        fi
+        if [[ ! -e "${config}" || ${#force_args[@]} -gt 0 ]]; then
+            cmd_init "${motion_file}" --exp-id "${exp_id}" "${force_args[@]+"${force_args[@]}"}"
+        fi
+    else
+        if (( needs_init )); then
+            die "run: cannot continue without a config (init was skipped)"
+        fi
+        log_info "init skipped"
+    fi
+
+    # ----- Stage 2: replay -----
+    log_stage "Stage 2/4: replay  [host -> container via ./workflow/run.sh exec]"
+    local mfile=""
+    if [[ -f "${config}" ]]; then
+        mfile="$(yaml_get_top "${config}" motion_file)"
+    elif (( DRY_RUN )) && [[ -n "${motion_file}" ]]; then
+        mfile="${motion_file}"
+        log_info "(dry-run) using in-memory motion_file (config not yet created)"
+    fi
+    log_info "motion_file: ${mfile:-<unknown>}"
+    if container_running; then
+        log_info "container '${CONTAINER_NAME}' is running"
+    else
+        log_warn "container '${CONTAINER_NAME}' is not running"
+        local start_it; start_it="$(prompt_yn "Start container with '${WORKFLOW_RUN_SH} start'?" "n")"
+        if [[ "${start_it}" == "y" ]]; then
+            log_warn "'./workflow/run.sh start' is interactive and drops you into a shell."
+            log_warn "Run it in another terminal, then come back and answer 'y' below."
+        fi
+    fi
+    ans="$(prompt_yn "Run replay (viser) for ${exp_id}?" "y")"
+    if [[ "${ans}" == "y" ]]; then
+        if [[ ! -f "${config}" ]]; then
+            log_warn "Skipping replay: ${config} not present (init was skipped or dry-run)"
+        elif container_running; then
+            cmd_replay "${exp_id}"
+            log_info "Replay finished. Note the start/end frames you want."
+        else
+            log_warn "Skipping replay: container is still not running"
+        fi
+    else
+        log_info "replay skipped — assuming frames are already chosen"
+    fi
+
+    # ----- Stage 3: set-frames -----
+    log_stage "Stage 3/4: set-frames  [host]"
+    local cur_start="" cur_end=""
+    if [[ -f "${config}" ]]; then
+        cur_start="$(yaml_get_override "${config}" env.commands.motion.motion_start_frame)"
+        cur_end="$(yaml_get_override "${config}" env.commands.motion.motion_end_frame)"
+        log_info "current motion_start_frame=${cur_start:-<unset>} motion_end_frame=${cur_end:-<unset>}"
+    elif (( DRY_RUN )); then
+        log_info "(dry-run) config not present yet; defaulting current frames to 0/-1"
+        cur_start="0"
+        cur_end="-1"
+    fi
+    ans="$(prompt_yn "Update frame range in ${config}?" "y")"
+    if [[ "${ans}" == "y" ]]; then
+        local new_start new_end
+        new_start="$(prompt_value "motion_start_frame" "${cur_start:-0}")"
+        new_end="$(prompt_value "motion_end_frame (-1 = end of motion)" "${cur_end:--1}")"
+        if [[ -f "${config}" ]]; then
+            if (( DRY_RUN )); then
+                log_info "(dry-run) would update ${config} -> motion_start_frame=${new_start} motion_end_frame=${new_end}"
+            else
+                yaml_set_frames "${config}" "${new_start}" "${new_end}"
+                log_info "Updated ${config}"
+            fi
+        else
+            log_warn "Skipping set-frames: ${config} not present"
+        fi
+    else
+        log_info "set-frames skipped"
+    fi
+
+    # ----- Stage 4: submit -----
+    log_stage "Stage 4/4: submit  [host -> OSMO; osmo CLI not in container]"
+    local default_run_name="${exp_id}_motion_data"
+    local run_name; run_name="$(prompt_value "OSMO --run-name" "${default_run_name}")"
+    local build_ans; build_ans="$(prompt_yn "Pass --build-image?" "n")"
+    local submit_args=("${exp_id}" --run-name "${run_name}")
+    if [[ "${build_ans}" == "y" ]]; then submit_args+=(--build-image); fi
+    local final_cmd="python ${RUN_EXPERIMENT_SCRIPT} ${exp_id} --osmo --run-name ${run_name}"
+    [[ "${build_ans}" == "y" ]] && final_cmd+=" --build-image"
+    log_info "Resolved command:"
+    log_cmd "${final_cmd}"
+    ans="$(prompt_yn "Submit now?" "y")"
+    if [[ "${ans}" == "y" ]]; then
+        cmd_submit "${submit_args[@]}"
+    else
+        log_info "submit skipped"
+    fi
+
+    log_stage "Done"
+}
+
+# --- Top-level CLI ---
+
+usage() {
+    sed -n '2,51p' "$0"
+}
+
+# Banner shown at the top of every real invocation so it's obvious where the
+# script runs. Suppressed for help/usage output to avoid duplicate text.
+print_host_banner() {
+    if running_inside_container; then
+        echo "$(_color '1;31' '!!! Running INSIDE the container, but this script is host-only !!!')"
+    else
+        echo "$(_color '1;32' '[host]') train_tpv_wholebody_workflow.sh — running on host (not in container)"
+    fi
+}
+
+# Abort if invoked from inside the container. Replay (docker exec) and submit
+# (osmo CLI) cannot work from there.
+require_host() {
+    if running_inside_container; then
+        log_error "This script must be run on the HOST, not inside the docker container."
+        log_error "Detected container indicators: /.dockerenv or docker cgroup."
+        log_error ""
+        log_error "Why: 'replay' shells out to './workflow/run.sh exec' (host-only docker"
+        log_error "command), and 'submit' calls the OSMO CLI which is not installed in"
+        log_error "the container image."
+        log_error ""
+        log_error "Fix: open a host shell (exit the container) and run again from:"
+        log_error "  ${REPO_ROOT}"
+        exit 2
+    fi
+}
+
+parse_global_flags() {
+    local out=()
+    for tok in "$@"; do
+        case "${tok}" in
+            --dry-run) DRY_RUN=1 ;;
+            --yes|-y)  ASSUME_YES=1 ;;
+            *)         out+=("${tok}") ;;
+        esac
+    done
+    REMAINING_ARGS=("${out[@]+"${out[@]}"}")
+}
+
+main() {
+    if (( $# == 0 )); then
+        usage
+        exit 1
+    fi
+    REMAINING_ARGS=()
+    parse_global_flags "$@"
+    set -- "${REMAINING_ARGS[@]+"${REMAINING_ARGS[@]}"}"
+    if (( $# == 0 )); then
+        usage
+        exit 1
+    fi
+    local sub="$1"; shift
+    case "${sub}" in
+        -h|--help|help) usage; exit 0 ;;
+    esac
+    require_host
+    print_host_banner
+    case "${sub}" in
+        run)        cmd_run "$@" ;;
+        init)       cmd_init "$@" ;;
+        replay)     cmd_replay "$@" ;;
+        set-frames) cmd_set_frames "$@" ;;
+        submit)     cmd_submit "$@" ;;
+        *)          log_error "unknown subcommand: ${sub}"; usage; exit 1 ;;
+    esac
+}
+
+main "$@"

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/mhr/sequence_id=apple_pick_optimized/robot_name=g1/f6a4439842f044cdbf8f85845955ba64-0.parquet
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/mhr/sequence_id=apple_pick_optimized/robot_name=g1/f6a4439842f044cdbf8f85845955ba64-0.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:05c9c6cc5d0a20d4017f97ec258d729dbfa7b0b9c81ed362a3292b8aa5894e59
-size 127307
+oid sha256:1d6e358d829be45c97ea0f4f8fb4257761ed08ed8c7bed96bf48b7340711ec87
+size 130060

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/reconstructed_stage/2026-03-23_18-10-01_corn_can_right_left_handover_01_support.usda
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/reconstructed_stage/2026-03-23_18-10-01_corn_can_right_left_handover_01_support.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c25529df26f73f7ba2ec205fdb9d54716d5591f2079c7901d1e1763d94e41631
+size 569

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-27_16-25-23_sit_skinny_wood_chair_01/object/material.mtl
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-27_16-25-23_sit_skinny_wood_chair_01/object/material.mtl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca4deadbb314a7d180f552345fc0411e5becebcbb61fac04171a2f364eb9f396
+size 198

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-27_16-25-23_sit_skinny_wood_chair_01/object/material_0.png
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-27_16-25-23_sit_skinny_wood_chair_01/object/material_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c867c5e480f4b61aadce2bc2b2c372b320d53fcc4debd0e5da70c0ec0450d54d
+size 127443

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-27_16-25-23_sit_skinny_wood_chair_01/object/textured_mesh.obj
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-27_16-25-23_sit_skinny_wood_chair_01/object/textured_mesh.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fc96684f9ca24707e651c6fa43a57b682d29c1389d0810a343f80956cd323e5
+size 8921546

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-27_16-25-23_sit_skinny_wood_chair_01/object/textured_mesh.urdf
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-27_16-25-23_sit_skinny_wood_chair_01/object/textured_mesh.urdf
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<robot name="retarget_object">
+  <link name="object">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.0"/>
+      <inertia ixx="0.01" ixy="0.0" ixz="0.0" iyy="0.01" iyz="0.0" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="textured_mesh.obj"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="textured_mesh.obj"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-27_16-25-23_sit_skinny_wood_chair_01/robot_name=g1/data.parquet
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-02-27_16-25-23_sit_skinny_wood_chair_01/robot_name=g1/data.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c1035be6582676c5266a9e78495c6245552b1804425738e3fbc34dca1f22dd7
+size 3629432

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-23_18-10-01_corn_can_right_left_handover_01/object/material.mtl
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-23_18-10-01_corn_can_right_left_handover_01/object/material.mtl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d90fe7d688a6da0b82b0f8053231a1c8986de34aa839f8113ed53a610c09227
+size 198

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-23_18-10-01_corn_can_right_left_handover_01/object/material_0.png
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-23_18-10-01_corn_can_right_left_handover_01/object/material_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:761c37d87ef450c163851089ce8c079a91e5758e3ef4234958278076fe7d25ce
+size 1023053

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-23_18-10-01_corn_can_right_left_handover_01/object/textured_mesh.obj
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-23_18-10-01_corn_can_right_left_handover_01/object/textured_mesh.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0668549cbcf73a9c7935b6690485a6a51e475fcbf2e68d73108be0eb5b532ed
+size 21210733

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-23_18-10-01_corn_can_right_left_handover_01/object/textured_mesh.urdf
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-23_18-10-01_corn_can_right_left_handover_01/object/textured_mesh.urdf
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<robot name="retarget_object">
+  <link name="object">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.0"/>
+      <inertia ixx="0.01" ixy="0.0" ixz="0.0" iyy="0.01" iyz="0.0" izz="0.01"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="textured_mesh.obj"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="textured_mesh.obj"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-23_18-10-01_corn_can_right_left_handover_01/robot_name=g1/data.parquet
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=2026-03-23_18-10-01_corn_can_right_left_handover_01/robot_name=g1/data.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1679e920f20cc741ffccaf8164a960bf46e1f124d670d7bddb2416ca6ea8b082
+size 4388992

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/config/sonic/g1/g1_sonic_env_cfg.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/config/sonic/g1/g1_sonic_env_cfg.py
@@ -35,6 +35,7 @@ from robotic_grounding.tasks.v2p_whole_body.mdp.terminations import (
     ee_quat_error,
     object_pos_error,
     object_quat_error,
+    timestep_termination,
 )
 
 POLICY_DIR = f"{POLICY_ASSET_DIR}/sonic"
@@ -315,7 +316,11 @@ class G1SonicRewardsCfg:
 class G1SonicTerminationsCfg:
     """Shared termination config."""
 
-    timeout = DoneTerm(func=il_mdp.time_out, time_out=True)
+    timeout = DoneTerm(
+        func=timestep_termination,
+        params={"command_name": "motion"},
+        time_out=True,
+    )
     anchor_pos_error = DoneTerm(
         func=anchor_pos_error,
         params={"command_name": "motion", "threshold": 0.70},


### PR DESCRIPTION
## Tooling (the bulk of this change):
- scripts/train_tpv_wholebody_workflow.sh: 729-line host-side driver for the TPV ReconBody training pipeline. Provides an interactive `run` mode that walks init -> replay -> set-frames -> submit with stage-skip detection, and per-stage subcommands (`init`, `replay`, `set-frames`, `submit`) for scripted reruns. Orchestrates Docker (`./workflow/run.sh exec`) and OSMO submission from the host; aborts if invoked inside the container.
- scripts/retarget/create_soma_task.py: 441-line scaffolder that writes `experiments/<exp_id>/config.yaml` from the existing recon_body_* template and idempotently registers the id in `experiments/registry.yaml` under the whole-body section, preserving comments/blank lines. Used by stage 6 of the workflow and runnable standalone.
- experiments/run_experiment.py (+169), experiments/utils.py (+52), scripts/rsl_rl/eval.py (+43): wiring needed by the workflow driver.

## Task config:
- v2p_whole_body/config/sonic/g1/g1_sonic_env_cfg.py: switch the timeout DoneTerm from `il_mdp.time_out` to `timestep_termination` keyed on the motion command, so episode length follows the per-motion frame range instead of a fixed wall-clock budget.

## New experiments + assets:
- experiments/recon_body_corn_can_right_left_handover_01 and experiments/recon_body_sit_skinny_wood_chair_01: config.yaml + registry entries, retargeted G1 motion_v1 parquet, and textured object meshes (.obj/.urdf/.mtl/.png) under the SOMA whole_body asset tree.

## Existing-config tweaks:
- recon_body_blue_trash_can_drag_007: motion frame range 0..250 -> 50..400.
- recon_body_snack_box_pick_and_place_01: motion frame range 250..500 ->
  300..-1, episode_length_s 5.0.


## Tests
- [x] Run the full data processing pipeline with `process_soma_sequnces.sh`
- [x] Run the task initialization and training pipeline with `train_tpv_wholebody_workflow.sh`
- [x] launched all five jobs in OSMO, [example 1](https://wandb.ai/nvidia-isaac/v2d-whole-body-tpv/runs/mxno4i5z?nw=nwuserhuihuaz), [example 2](https://wandb.ai/nvidia-isaac/v2d-whole-body-tpv/runs/qtgv5it3?nw=nwuserhuihuaz)