### PR TITLE
Move package-specific root config into subprojects + add hygiene CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,7 @@
-# Common binary types tracked with LFS
+# Universal LFS rules (used by 2+ packages). Package-specific path rules
+# live in each subproject's own .gitattributes.
+
+# 3D mesh formats
 *.obj filter=lfs diff=lfs merge=lfs -text
 *.stl filter=lfs diff=lfs merge=lfs -text
 *.STL filter=lfs diff=lfs merge=lfs -text
@@ -13,7 +16,7 @@
 *.h5 filter=lfs diff=lfs merge=lfs -text
 *.hdf5 filter=lfs diff=lfs merge=lfs -text
 *.parquet filter=lfs diff=lfs merge=lfs -text
-# NumPy/Pickle data
+# NumPy / Pickle data
 *.npy filter=lfs diff=lfs merge=lfs -text
 *.npz filter=lfs diff=lfs merge=lfs -text
 *.pkl filter=lfs diff=lfs merge=lfs -text
@@ -22,11 +25,3 @@
 *.onnx filter=lfs diff=lfs merge=lfs -text
 *.pt filter=lfs diff=lfs merge=lfs -text
 *.safetensors filter=lfs diff=lfs merge=lfs -text
-robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/arctic/** filter=lfs diff=lfs merge=lfs -text
-robotic_grounding/source/robotic_grounding/robotic_grounding/assets/meshes/oakink2/object_raw/** filter=lfs diff=lfs merge=lfs -text
-robotic_grounding/source/robotic_grounding/robotic_grounding/assets/meshes/oakink2/object_repair/** filter=lfs diff=lfs merge=lfs -text
-robotic_grounding/source/robotic_grounding/robotic_grounding/assets/meshes/hot3d/** filter=lfs diff=lfs merge=lfs -text
-robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/taco/taco_loaded/sequence_id=taco_empty__kettle__plate_20231031_060/**/*.parquet filter=lfs diff=lfs merge=lfs -text
-robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/taco/taco_processed/sequence_id=taco_empty__kettle__plate_20231031_060/**/*.parquet filter=lfs diff=lfs merge=lfs -text
-robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/taco/reconstructed_stage/taco_empty__kettle__plate_20231031_060_support.usda filter=lfs diff=lfs merge=lfs -text
-*.pkg filter=lfs diff=lfs merge=lfs -text

--- a/.github/scripts/agent_context_check.py
+++ b/.github/scripts/agent_context_check.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+"""Ensure agent-context files (CLAUDE.md, AGENTS.md) stay committable.
+
+Past incident: a top-level .gitignore rule for `CLAUDE.md` silently kept
+per-package CLAUDE.md files out of git, so freshly-cloned teammates had no
+agent guidance for the video_ingestion_agent package. This check scans the
+ROOT .gitignore (the only one that affects every package) for rules that
+would exclude these files and fails CI if any are found. Per-package
+gitignores are intentionally out of scope — they only affect their own
+subtree and may have legitimate local reasons.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROOT_GITIGNORE = REPO_ROOT / ".gitignore"
+
+FORBIDDEN_PATTERNS = {"CLAUDE.md", "AGENTS.md"}
+
+
+def _check_root_gitignore() -> list[str]:
+    if not ROOT_GITIGNORE.exists():
+        return []
+    rel = ROOT_GITIGNORE.relative_to(REPO_ROOT)
+    errors: list[str] = []
+    for lineno, raw in enumerate(ROOT_GITIGNORE.read_text().splitlines(), start=1):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        # A '!' prefix is a negation — it ALLOWS the file, which is fine.
+        if stripped.startswith("!"):
+            continue
+        # First whitespace token, then strip an anchored '/' prefix.
+        token = stripped.split()[0].lstrip("/")
+        if token in FORBIDDEN_PATTERNS:
+            errors.append(
+                f"{rel}:{lineno}: '{stripped}' ignores an agent-context "
+                f"file. CLAUDE.md and AGENTS.md must remain committable; "
+                f"remove this rule (or replace with a more specific pattern "
+                f"that doesn't match these files)."
+            )
+    return errors
+
+
+def main() -> int:
+    all_errors = _check_root_gitignore()
+    if all_errors:
+        print("agent_context_check FAILED:\n", file=sys.stderr)
+        for err in all_errors:
+            print(f"  - {err}", file=sys.stderr)
+        print(
+            "\nAgent-facing context files (CLAUDE.md, AGENTS.md) must be "
+            "trackable everywhere in the monorepo. Remove any .gitignore "
+            "rule that excludes them.",
+            file=sys.stderr,
+        )
+        return 1
+    print("agent_context_check OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_root_files.py
+++ b/.github/scripts/check_root_files.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+"""Enforce that root-level shared files don't carry package-specific rules.
+
+The monorepo intentionally keeps three subprojects (video_ingestion_agent,
+reconstruction, robotic_grounding) self-contained. Anything anchored to a
+specific subproject must live inside that subproject's own version of the
+shared file (.gitignore, .gitattributes, .pre-commit-config.yaml, .envrc),
+not at the repo root. This check enforces that rule on every PR.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PACKAGES = ("video_ingestion_agent", "reconstruction", "robotic_grounding")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Files that must not exist at repo root because their content is
+# package-specific. Move them under the relevant subproject.
+FORBIDDEN_AT_ROOT = (".pre-commit-config.yaml", ".envrc")
+
+
+def _iter_pattern_lines(path: Path):
+    """Yield (lineno, raw_line, pattern_token) for non-comment, non-blank lines.
+
+    gitignore patterns may be negated (leading '!') and/or anchored (leading
+    '/'); gitattributes lines are '<pattern> <attr>...' where the pattern is
+    the first whitespace-separated token. Both are normalized to a bare
+    pattern token here.
+    """
+    for lineno, raw in enumerate(path.read_text().splitlines(), start=1):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        token = stripped.split()[0].lstrip("!").lstrip("/")
+        yield lineno, stripped, token
+
+
+def _check_path_patterns(filename: str) -> list[str]:
+    path = REPO_ROOT / filename
+    if not path.exists():
+        return []
+    errors: list[str] = []
+    for lineno, raw_line, token in _iter_pattern_lines(path):
+        for pkg in PACKAGES:
+            if token == pkg or token.startswith(pkg + "/"):
+                errors.append(
+                    f"{filename}:{lineno}: '{raw_line}' is anchored to "
+                    f"'{pkg}/'. Move it into {pkg}/{filename} and drop the "
+                    f"'{pkg}/' prefix (the pattern is then relative to that "
+                    f"file's location)."
+                )
+                break
+    return errors
+
+
+def _check_forbidden_files() -> list[str]:
+    errors: list[str] = []
+    for name in FORBIDDEN_AT_ROOT:
+        if (REPO_ROOT / name).exists():
+            errors.append(
+                f"{name} exists at repo root but is package-specific. "
+                f"Move it under one of: "
+                f"{', '.join(p + '/' for p in PACKAGES)}."
+            )
+    return errors
+
+
+def main() -> int:
+    errors = (
+        _check_path_patterns(".gitignore")
+        + _check_path_patterns(".gitattributes")
+        + _check_forbidden_files()
+    )
+    if errors:
+        print("Monorepo hygiene check FAILED:\n", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        print(
+            "\nRoot-level shared files must not contain package-specific "
+            "rules. Move each flagged rule into the relevant subproject's "
+            "own version of the file.",
+            file=sys.stderr,
+        )
+        return 1
+    print("Monorepo hygiene check OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/monorepo_hygiene.yml
+++ b/.github/workflows/monorepo_hygiene.yml
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# Gates that root-level shared files (.gitignore, .gitattributes, ...) don't
+# accumulate package-specific rules. Package-specific rules belong in each
+# subproject's own copy of the file. See .github/scripts/check_root_files.py
+# for the enforced rules and how to fix violations.
+
+name: Monorepo Hygiene
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.gitignore'
+      - '.gitattributes'
+      - '.pre-commit-config.yaml'
+      - '.envrc'
+      - '.github/scripts/check_root_files.py'
+      - '.github/scripts/agent_context_check.py'
+      - '.github/workflows/monorepo_hygiene.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.gitignore'
+      - '.gitattributes'
+      - '.pre-commit-config.yaml'
+      - '.envrc'
+      - '.github/scripts/check_root_files.py'
+      - '.github/scripts/agent_context_check.py'
+      - '.github/workflows/monorepo_hygiene.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check_root_files:
+    name: check_root_files
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run check_root_files
+        run: python .github/scripts/check_root_files.py
+
+  agent_context_check:
+    name: agent_context_check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run agent_context_check
+        run: python .github/scripts/agent_context_check.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,9 @@
-*.venv
-data
-wandb/
-__pycache__
-**.egg-info
-CLAUDE.md
-# Ignore .claude/ wherever it appears...
-.claude/
-# ...but keep the root .claude/skills/ tracked (shared skills across packages).
-!/.claude/
-/.claude/*
-!/.claude/skills/
-!/.claude/skills/**
+# Root-only rules. Each subproject (reconstruction/, video_ingestion_agent/,
+# robotic_grounding/) has its own .gitignore for package-specific artifacts.
+**.egg-info 
+
+# Editor workspace files
 *.code-workspace
 
-# Auto-generated no-collision URDFs (created at pipeline runtime from *_rigid.urdf)
-**/*_no_collision.urdf
-
-# Local direnv overrides
+# Local direnv overrides (only meaningful at repo root)
 .envrc.local
-robotic_grounding/reconstructed_data/
-robotic_grounding/checkpoints/
-
-# Reconstruction
-reconstruction/soma_data/

--- a/reconstruction/.gitignore
+++ b/reconstruction/.gitignore
@@ -60,3 +60,6 @@ Thumbs.db
 # Logs
 *.log
 .venv
+
+# SOMA training data (large)
+/soma_data/

--- a/robotic_grounding/.envrc
+++ b/robotic_grounding/.envrc
@@ -9,4 +9,4 @@ if [ -f "$(pwd)/.envrc.local" ]; then
   source "$(pwd)/.envrc.local"
 fi
 
-source "$(pwd)/robotic_grounding/scripts/setup_css_env.sh"
+source "$(pwd)/scripts/setup_css_env.sh"

--- a/robotic_grounding/.gitattributes
+++ b/robotic_grounding/.gitattributes
@@ -42,3 +42,8 @@ source/robotic_grounding/robotic_grounding/assets/human_motion_data/hot3d_loaded
 source/robotic_grounding/robotic_grounding/assets/human_motion_data/hot3d_processed/** filter=lfs diff=lfs merge=lfs -text
 source/robotic_grounding/robotic_grounding/assets/meshes/hot3d/** filter=lfs diff=lfs merge=lfs -text
 source/robotic_grounding/robotic_grounding/assets/meshes/hot3d/instance.json !filter !diff !merge text
+# Migrated from root .gitattributes (taco support + Isaac Lab .pkg)
+source/robotic_grounding/robotic_grounding/assets/human_motion_data/taco/taco_loaded/sequence_id=taco_empty__kettle__plate_20231031_060/**/*.parquet filter=lfs diff=lfs merge=lfs -text
+source/robotic_grounding/robotic_grounding/assets/human_motion_data/taco/taco_processed/sequence_id=taco_empty__kettle__plate_20231031_060/**/*.parquet filter=lfs diff=lfs merge=lfs -text
+source/robotic_grounding/robotic_grounding/assets/human_motion_data/taco/reconstructed_stage/taco_empty__kettle__plate_20231031_060_support.usda filter=lfs diff=lfs merge=lfs -text
+*.pkg filter=lfs diff=lfs merge=lfs -text

--- a/robotic_grounding/.gitignore
+++ b/robotic_grounding/.gitignore
@@ -138,7 +138,7 @@ celerybeat.pid
 
 # Environments
 .env
-.envrc
+.envrc.local
 .venv
 env/
 venv/
@@ -218,6 +218,12 @@ outputs/
 wandb/
 .devcontainer/
 
+# RL training checkpoints (distinct from wandb_checkpoints/ below)
+/checkpoints/
+
+# Reconstructed data from the V2D upstream pipeline
+/reconstructed_data/
+
 .DS_Store
 
 .vscode/
@@ -230,7 +236,6 @@ core
 !.claude/commands/eval-record.md
 !.claude/commands/grid-video.md
 !.claude/commands/launch-two-stage.md
-CLAUDE.md
 *.code-workspace
 
 # Temporary usd files

--- a/robotic_grounding/.pre-commit-config.yaml
+++ b/robotic_grounding/.pre-commit-config.yaml
@@ -9,7 +9,10 @@
 default_stages: [pre-commit]
 default_install_hook_types: [pre-commit, pre-push]
 
-# Hook paths are evaluated from the git root, not this nested config directory.
+# Hook paths are evaluated from the git root, not from this file's location.
+# Pre-commit always runs hooks with cwd = git root and passes git-root-relative
+# paths to them, so excludes and `--config` flags need the `robotic_grounding/`
+# prefix even though the file lives inside that package.
 exclude: |
   (?x)^(
     robotic_grounding/workflow/.*\.yaml

--- a/robotic_grounding/README.md
+++ b/robotic_grounding/README.md
@@ -36,7 +36,8 @@ source scripts/setup_css_env.sh
 
 **Option B — direnv (automatic, recommended)**
 
-[direnv](https://direnv.net/) auto-loads credentials whenever you `cd` into the repo.
+[direnv](https://direnv.net/) auto-loads credentials whenever you `cd` into
+`robotic_grounding/`.
 
 Install:
 ```bash
@@ -45,19 +46,21 @@ sudo apt-get install direnv        # Ubuntu/Debian
 eval "$(direnv hook bash)"
 ```
 
-Create a **gitignored** `.envrc.local` in the **repo root** (`video_to_data/.envrc.local`):
+Create a **gitignored** `.envrc.local` inside this package
+(`robotic_grounding/.envrc.local`):
 ```bash
-# .envrc.local
+# robotic_grounding/.envrc.local
 export CSS_ACCESS_KEY="<your-access-key-id>"
 export CSS_SECRET_KEY="<your-secret-key>"
 ```
 
 Allow direnv to load it (one-time, per clone):
 ```bash
-direnv allow
+cd robotic_grounding && direnv allow
 ```
 
-Credentials are then injected automatically on every `cd` into the repo.
+Credentials are then injected automatically on every `cd` into
+`robotic_grounding/`.
 
 ## Docker Usage
 

--- a/video_ingestion_agent/CLAUDE.md
+++ b/video_ingestion_agent/CLAUDE.md
@@ -1,0 +1,157 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Video Ingestion Agent — entity-graph-based agentic workflow for collecting action clips from
+robot demonstration videos. The package lives under `src/video_ingestion_agent/` and is installed
+via `pyproject.toml` (uses a `src/` layout; install with `uv sync`, which honors the committed `uv.lock`).
+
+Full Sphinx docs are built under `docs/`. When changing something architectural or
+user-facing, check whether the relevant page in `docs/pages/` needs updating.
+
+## Common commands
+
+Tests, lint, formatting, and types (matches the pre-commit + CI config):
+
+```bash
+pytest                                         # full suite (coverage configured in pyproject)
+pytest tests/test_ingestion.py                 # one file
+pytest tests/test_ingestion.py::test_xxx -v    # one test
+
+ruff check . --fix
+ruff format .
+mypy src/video_ingestion_agent
+pre-commit run --all-files
+```
+
+Pipeline / agent entry points (all live under `scripts/`):
+
+```bash
+# vLLM server lifecycle (used by ingestion + retrieval when backend=vllm)
+python scripts/serve.py -c configs/ingestion.yaml      # start
+python scripts/serve.py --status | --logs | --stop
+
+# Single-video ingestion: segmentation -> verify/refine -> entity graph -> report
+python scripts/run_ingestion.py video.mp4 -c configs/ingestion.yaml
+#   --no-verify / --no-refine / --no-entity-graph / --no-report  toggle stages
+#   -o runs/<name>                                                override run dir
+
+# Multi-video ingestion (LPT sharded across GPUs, shared graph.db/vector.db via SQLite WAL)
+python scripts/run_batch_ingestion.py --input-dir <dir> -c configs/ingestion.yaml \
+    --output-dir runs/batch --num-shards 8 --resume
+
+# Retrieval agent against a built database directory
+python scripts/run_retrieval.py "<query>" -d outputs/ -c configs/retrieval.yaml
+
+# EPIC-KITCHENS-100 benchmark
+python scripts/run_benchmark.py -c configs/benchmark_epic_kitchens.yaml [--no-verify] [--resume] [--num-gpus N]
+
+# Gradio webapp (extras: webapp)
+python scripts/run_webapp.py [--port 7860] [--config FILE] [--share]
+```
+
+Docs:
+
+```bash
+cd docs && make html        # one-shot build into docs/_build/current/html/
+cd docs && make livehtml    # auto-reload server on :8000
+```
+
+## Architecture
+
+Two LangGraph state graphs sit at the center of the system. Anything you change in the
+ingestion or retrieval flow should fit into the existing graph structure rather than running
+as a side script — the graphs are the source of truth.
+
+### Ingestion pipeline (`src/video_ingestion_agent/ingestion/`)
+
+`ingestion_graph.create_pipeline_graph()` wires nodes into:
+
+```
+segment → extract_temp → verify → (refine loop) → cleanup_temp →
+entity_extract → frame_embed → entity_link → db_write → report
+```
+
+- State: `PipelineState` (TypedDict) carrying `clips: list[ClipContext]`,
+  `verifications`, `db_paths`, `iteration`, `status`, plus the `PipelineConfig`.
+- Nodes are split into `segmentation_nodes.py` (segment / verify / refine / cleanup) and
+  `entity_graph_nodes.py` (extract / embed / link / write / report).
+- Sub-packages: `segmentation/` (chunked VLM segmenter, critic, refiner, dedup
+  strategies — `heuristic` always-merge vs default `llm` ask-the-LLM); `entity_graph/`
+  (entity extractors, cross-clip linker, SQLite writer).
+- Stage toggles live on the config: `enable_verification`, `enable_refinement`,
+  `enable_entity_graph`, `enable_reporting`. The CLI `--no-*` flags flip these.
+- Temporary `.mp4` clips are produced only for the verify/refine loop and removed by
+  `cleanup_temp` — persistent storage is `video_path + start_t/end_t`, never clip files.
+
+### Retrieval agent (`src/video_ingestion_agent/retrieval/`)
+
+`RetrievalAgent` (in `retrieval_graph.py`) implements an EGAgent-style loop with two
+execution modes selected by `config.agent.parallel_tasks`:
+
+- **Parallel** (default): `task_decomposer → Send-per-task → task_search subgraph → vqa_synthesizer`.
+  Each sub-task runs its own compiled subgraph from `task_search_subgraph.py`.
+- **Sequential**: `task_decomposer → search_planner ⟷ executor ⟷ analyzer → vqa_synthesizer`,
+  driven by a `current_task_idx` counter.
+
+Inside each sub-task search there is a hierarchical relaxation loop (4 levels, exact →
+similar action/object). The agent has two tools (`tools/search_graph.py`,
+`tools/search_frames.py`) plus `extract_clip.py`. Visual hits carry a `segment_id` so
+`vector.db` matches resolve back to action segments in `graph.db`.
+
+### Storage
+
+Two SQLite files in `database.directory` (default `outputs/`), both in WAL mode for
+concurrent shard writes:
+
+- `graph.db` — `video_metadata`, `entities`, `relationships`, `action_segments`. Frame
+  embeddings in `vector.db` are tagged with `segment_id` to bridge the two.
+- `vector.db` — per-frame SigLIP-2 embeddings (default `google/siglip2-base-patch16-256`,
+  768-dim). Schema and writer in `ingestion/entity_graph/database_writer.py`.
+
+### Model backends (`src/video_ingestion_agent/models/`)
+
+`ModelManager` is the single entry point; all backends implement `generate_text()` and
+`generate_from_video()`. Pick via `models.vlm_backend` / `models.llm_backend` in YAML:
+
+- `vllm` — production. Requires `scripts/serve.py` running; supports `vllm_tp_size` for
+  tensor parallelism and `vllm_local_media: true` to pass `file://` URLs.
+- `local` — in-process HuggingFace (needs `[local]` extra and a GPU).
+- `api` — NVIDIA NIM / OpenAI-compatible (uses `NIM_API_KEY` or `models.api_key`).
+
+The frame embedding model (SigLIP-2) is always loaded locally regardless of VLM backend.
+
+### Webapp
+
+`webapp/app.py` builds the Gradio app from `tabs/` (ingestion, query, database, settings)
+on top of `services/` (database, ingestion, query) and `components/` (graph + pipeline
+visualizers). `scripts/run_webapp.py` is just a launcher.
+
+## Configuration
+
+All config is Pydantic, defined in `ingestion/config.py` (`PipelineConfig`) and
+`retrieval/config.py` (`RetrievalConfig`). YAML is loaded via `load_config()` /
+`load_retrieval_config()`. Three shipped configs:
+
+- `configs/ingestion.yaml` — single-video pipeline.
+- `configs/batch_ingestion.yaml` — many videos sharing one TP=8 vLLM server.
+- `configs/retrieval.yaml` — agent settings (steps, temperature, clips dir).
+- `configs/benchmark_epic_kitchens.yaml` — EPIC-KITCHENS evaluation.
+
+VLM/critic prompts live in `ingestion/segmentation/prompts.py` and
+`ingestion/entity_graph/prompts.py`; YAML overrides take precedence when set. Retrieval
+node prompts are in `retrieval/nodes/prompts.py`.
+
+## Conventions worth respecting
+
+- Add nodes by editing the relevant `*_graph.py` builder, not by sidestepping it.
+- Keep node functions pure: read from the typed state, return a partial-state dict.
+- Don't introduce a new persistent clip-file format — `ClipContext` is `video_path +
+  timestamps` by design (the verify/refine loop is the only place temp clips exist).
+- New SQLite columns must be added to `database_writer.py` and any reader that touches
+  the same table; both DBs assume WAL mode.
+- Ruff config lives in `pyproject.toml` (line length 100, target py310, selected rule
+  sets `E/W/F/I/B/C4/UP`). Pre-commit also enforces yaml/json validity, end-of-file
+  fixer, and a 1 MB max-added-file size.


### PR DESCRIPTION
Root-level dotfiles had accumulated rules that only applied to one subproject (mainly robotic_grounding). Move them into each package's own copies and add a CI workflow that prevents the drift from coming back.

Moves and content shifts:
- .pre-commit-config.yaml and .envrc -> robotic_grounding/. The robotic_grounding CI was already keying its cache on robotic_grounding/.pre-commit-config.yaml; this lines that up.
- Trim root .gitignore and .gitattributes to universal rules only; push package-anchored rules (robotic_grounding/checkpoints/, reconstruction/soma_data/, taco LFS paths, *.pkg, ...) into the matching subproject .gitignore / .gitattributes.
- Drop CLAUDE.md ignore rules from root and robotic_grounding gitignores so per-package agent guidance is committable; add video_ingestion_agent/CLAUDE.md which had been silently ignored.

New CI: .github/workflows/monorepo_hygiene.yml runs two jobs on changes to root config:
- check_root_files: fails if root .gitignore / .gitattributes contain patterns anchored to a subproject path, or if .pre-commit-config.yaml / .envrc exist at root.
- agent_context_check: fails if the root .gitignore ignores CLAUDE.md or AGENTS.md (per-package gitignores are out of scope by design).