### PR TITLE
[video_ingestion] webapp: accumulate batch-progress deltas instead of…

### DIFF
--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/ingestion_tab.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/ingestion_tab.py
@@ -354,8 +354,11 @@ def create_ingestion_tab(services: dict[str, Any], config: AppConfig) -> dict[st
             if now - last_poll > 2.0:
                 last_poll = now
 
-                # Read structured progress
-                done_videos, failed_videos, total_clips = _read_worker_progress()
+                # `_read_worker_progress()` returns deltas — accumulate, don't assign.
+                d_done, d_failed, d_clips = _read_worker_progress()
+                done_videos += d_done
+                failed_videos += d_failed
+                total_clips += d_clips
 
                 elapsed = now - t_start
                 desc = (
@@ -382,8 +385,11 @@ def create_ingestion_tab(services: dict[str, Any], config: AppConfig) -> dict[st
             if not line:
                 time.sleep(0.5)
 
-        # Final read of progress files
-        done_videos, failed_videos, total_clips = _read_worker_progress()
+        # Final delta read — accumulate the same way the poll loop does.
+        d_done, d_failed, d_clips = _read_worker_progress()
+        done_videos += d_done
+        failed_videos += d_failed
+        total_clips += d_clips
         elapsed = time.time() - t_start
 
         progress(1.0, desc="Batch ingestion complete")


### PR DESCRIPTION
## Summary
  - `_read_worker_progress()` returns **deltas** since its previous call (it
    tracks consumed JSONL lines per worker via `progress_lines_read`). Both
    call sites — the 2 s poll loop and the final read — were *assigning* the
    tuple back into the outer totals, so once the JSONL was fully drained,
    the next call returned (0, 0, 0) and clobbered the prior counts.
  - Result before this patch: a successful 2/2-video, 6-clip batch run shows
    `Videos processed: 0/0, Failed: 0, Total clips: 0` in the webapp, while
    `summary_worker_*.json` on disk records the real successful counts.
    ("Workers" and "Total time" were correct because they weren't routed
    through the buggy helper — exactly what QA flagged.)
  - Fix: accumulate (`+=`) the delta tuple at both call sites; no change to
    `_read_worker_progress()` itself.