### PR TITLE
[video_ingestion] webapp: surface 'reconstruction unavailable' toast …

### DIFF
--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/app.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/app.py
@@ -173,6 +173,27 @@ def create_app(config: AppConfig = None) -> gr.Blocks:
                 ],
             )
 
+        # When reconstruction isn't wired (no `reconstruction:` block in the
+        # webapp config, or the service raised during init), the button above
+        # would otherwise have no .click() handler and click silently. Attach
+        # a fallback that surfaces a toast so the user knows why.
+        elif "reconstruct_btn" in query_components:
+
+            def _reconstruct_unavailable():
+                gr.Warning(
+                    "Reconstruction is not configured. Launch the webapp with "
+                    "`--config configs/webapp.yaml` and install the sibling "
+                    "`reconstruction/` package "
+                    "(see reconstruction_interface/ego_e2e/README.md)."
+                )
+                return gr.update()  # tabs: no-op
+
+            query_components["reconstruct_btn"].click(
+                fn=_reconstruct_unavailable,
+                inputs=[],
+                outputs=[tabs],
+            )
+
     return app
 
 


### PR DESCRIPTION
  ## Summary
  - `app.py:87-91` gates the cross-tab `reconstruct_btn.click()` registration
    on `"reconstruction" in services`. That key is only set when
    `AppConfig.reconstruction` is a populated dict AND
    `ReconstructionService(...)` constructs without raising.
  - The default config path — `AppConfig.from_project_configs()`, taken when
    `scripts/run_webapp.py` is launched without `--config` — reads only
    `retrieval.yaml` and `ingestion.yaml`. Neither has a `reconstruction:`
    block. Result: the Reconstruct button appears on the page, gets enabled
    after a successful query, but has **no click handler** — clicking is a
    silent no-op (QA-reported behavior).
  - This patch adds an `elif` branch that wires a fallback handler firing a
    `gr.Warning(...)` toast explaining what to launch with. Happy path is
    unchanged.
