### PR TITLE
[video_ingestion] webapp: guarantee Database tab Load handler always …

### DIFF
--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/database_tab.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/database_tab.py
@@ -190,23 +190,28 @@ def create_database_tab(services: dict[str, Any], config: AppConfig) -> dict[str
     # Event handlers
     def load_database(db_dir: str):
         """Load database and return statistics and filter options."""
-        db_path = resolve_graph_db_path(db_dir)
-
-        if not db_path:
-            return (
-                gr.update(visible=True, value={"error": f"No graph.db found in {db_dir}"}),
-                gr.update(value=[], headers=["id", "video_path", "duration", "fps"]),
-                gr.update(choices=["(All)"]),
-                gr.update(choices=["(All)"]),
-                "*No data loaded.*",
-                gr.update(value=[]),
-                None,
-                None,
-                gr.update(),
-                gr.update(),
-            )
-
+        # Wrap everything — including resolve_graph_db_path — so any exception
+        # (Path() errors on weird input, OSError/PermissionError on unreadable
+        # parents, etc.) still resolves the Gradio outputs and exits the
+        # loading spinner. Toasts surface the failure to the user.
         try:
+            db_path = resolve_graph_db_path(db_dir)
+
+            if not db_path:
+                gr.Warning(f"No graph.db found in: {db_dir}")
+                return (
+                    gr.update(visible=True, value={"error": f"No graph.db found in {db_dir}"}),
+                    gr.update(value=[], headers=["id", "video_path", "duration", "fps"]),
+                    gr.update(choices=["(All)"]),
+                    gr.update(choices=["(All)"]),
+                    "*No data loaded.*",
+                    gr.update(value=[]),
+                    None,
+                    None,
+                    gr.update(),
+                    gr.update(),
+                )
+
             from ..services import DatabaseService
 
             service = DatabaseService(db_path)
@@ -253,7 +258,8 @@ def create_database_tab(services: dict[str, Any], config: AppConfig) -> dict[str
             )
 
         except Exception as e:
-            logger.error(f"Failed to load database: {e}")
+            logger.exception("Failed to load database")
+            gr.Warning(f"Failed to load database: {e}")
             return (
                 gr.update(visible=True, value={"error": str(e)}),
                 gr.update(value=[], headers=["id", "video_path", "duration", "fps"]),


### PR DESCRIPTION
  ## Summary
  - `database_tab.load_database()` called `resolve_graph_db_path(db_dir)`
    **outside** its `try/except`. If that call raised — `Path(...)` on
    adversarial input, `OSError` / `PermissionError` on an unreadable
    parent, etc. — the function exited without producing the 10-tuple the
    Gradio `.click()` binding expects, and the frontend sat in a loading
    spinner forever with no error surfaced. This violates the F.1 Error
    paths spec contract ("no silent hangs in any case") and is the
    symptom QA reported when typing a bad path into the Database
    directory input.
  - Fix: hoist the `try/except` to wrap the resolve call, and add
    `gr.Warning(...)` toasts on both failure paths so the user gets a
    visible signal regardless of which output widget is animating.
  - Also switched the exception logger to `logger.exception(...)` so the
    stack trace lands in stderr for future audits.
