### PR TITLE
[release/0.1.0] cherry-pick webapp UX fixes from main (#85, #86, #87)

### DIFF
--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/app.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/app.py
@@ -173,6 +173,27 @@ def create_app(config: AppConfig = None) -> gr.Blocks:
                 ],
             )
 
+        # When reconstruction isn't wired (no `reconstruction:` block in the
+        # webapp config, or the service raised during init), the button above
+        # would otherwise have no .click() handler and click silently. Attach
+        # a fallback that surfaces a toast so the user knows why.
+        elif "reconstruct_btn" in query_components:
+
+            def _reconstruct_unavailable():
+                gr.Warning(
+                    "Reconstruction is not configured. Launch the webapp with "
+                    "`--config configs/webapp.yaml` and install the sibling "
+                    "`reconstruction/` package "
+                    "(see reconstruction_interface/ego_e2e/README.md)."
+                )
+                return gr.update()  # tabs: no-op
+
+            query_components["reconstruct_btn"].click(
+                fn=_reconstruct_unavailable,
+                inputs=[],
+                outputs=[tabs],
+            )
+
     return app
 
 

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/database_tab.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/database_tab.py
@@ -190,23 +190,28 @@ def create_database_tab(services: dict[str, Any], config: AppConfig) -> dict[str
     # Event handlers
     def load_database(db_dir: str):
         """Load database and return statistics and filter options."""
-        db_path = resolve_graph_db_path(db_dir)
-
-        if not db_path:
-            return (
-                gr.update(visible=True, value={"error": f"No graph.db found in {db_dir}"}),
-                gr.update(value=[], headers=["id", "video_path", "duration", "fps"]),
-                gr.update(choices=["(All)"]),
-                gr.update(choices=["(All)"]),
-                "*No data loaded.*",
-                gr.update(value=[]),
-                None,
-                None,
-                gr.update(),
-                gr.update(),
-            )
-
+        # Wrap everything — including resolve_graph_db_path — so any exception
+        # (Path() errors on weird input, OSError/PermissionError on unreadable
+        # parents, etc.) still resolves the Gradio outputs and exits the
+        # loading spinner. Toasts surface the failure to the user.
         try:
+            db_path = resolve_graph_db_path(db_dir)
+
+            if not db_path:
+                gr.Warning(f"No graph.db found in: {db_dir}")
+                return (
+                    gr.update(visible=True, value={"error": f"No graph.db found in {db_dir}"}),
+                    gr.update(value=[], headers=["id", "video_path", "duration", "fps"]),
+                    gr.update(choices=["(All)"]),
+                    gr.update(choices=["(All)"]),
+                    "*No data loaded.*",
+                    gr.update(value=[]),
+                    None,
+                    None,
+                    gr.update(),
+                    gr.update(),
+                )
+
             from ..services import DatabaseService
 
             service = DatabaseService(db_path)
@@ -253,7 +258,8 @@ def create_database_tab(services: dict[str, Any], config: AppConfig) -> dict[str
             )
 
         except Exception as e:
-            logger.error(f"Failed to load database: {e}")
+            logger.exception("Failed to load database")
+            gr.Warning(f"Failed to load database: {e}")
             return (
                 gr.update(visible=True, value={"error": str(e)}),
                 gr.update(value=[], headers=["id", "video_path", "duration", "fps"]),

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/ingestion_tab.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/ingestion_tab.py
@@ -354,8 +354,11 @@ def create_ingestion_tab(services: dict[str, Any], config: AppConfig) -> dict[st
             if now - last_poll > 2.0:
                 last_poll = now
 
-                # Read structured progress
-                done_videos, failed_videos, total_clips = _read_worker_progress()
+                # `_read_worker_progress()` returns deltas — accumulate, don't assign.
+                d_done, d_failed, d_clips = _read_worker_progress()
+                done_videos += d_done
+                failed_videos += d_failed
+                total_clips += d_clips
 
                 elapsed = now - t_start
                 desc = (
@@ -382,8 +385,11 @@ def create_ingestion_tab(services: dict[str, Any], config: AppConfig) -> dict[st
             if not line:
                 time.sleep(0.5)
 
-        # Final read of progress files
-        done_videos, failed_videos, total_clips = _read_worker_progress()
+        # Final delta read — accumulate the same way the poll loop does.
+        d_done, d_failed, d_clips = _read_worker_progress()
+        done_videos += d_done
+        failed_videos += d_failed
+        total_clips += d_clips
         elapsed = time.time() - t_start
 
         progress(1.0, desc="Batch ingestion complete")


### PR DESCRIPTION
  ## Summary
  Cherry-picks three webapp/UX bug fixes from `main` onto `release/0.1.0`:

  - **#85** — `[video_ingestion] webapp: surface 'reconstruction unavailable'
    toast on Retrieve→Reconstruct click`
    Reconstruct button on the Retrieve tab was a silent no-op when the
    webapp was launched without `--config configs/webapp.yaml`. Now fires a
    `gr.Warning(...)` toast explaining the missing config.

  - **#87** — `[video_ingestion] webapp: guarantee Database tab Load handler
    always returns + toast on failure`
    Typing a bad path into the Database tab and clicking Load Database
    could leave the Stats JSON spinner running forever. The load handler
    now wraps `resolve_graph_db_path` in `try/except`, returns the
    10-tuple on every code path, and surfaces a `gr.Warning(...)` toast.

  - **#86** — `[video_ingestion] webapp: accumulate batch-progress deltas
    instead of overwriting`
    Batch ingestion's "Batch Ingestion Complete!" panel and Statistics
    JSON reported 0/0/0 even on successful runs because
    `_read_worker_progress()` returns deltas and the callers assigned
    rather than accumulated.

  Each cherry-pick is conflict-free; the upstream commit SHAs are
  preserved in this branch (`bfedcec7`, `f61a1d87`, `58412f89`).
