### PR TITLE
[release/0.1.0] cherry-pick OSRB compliance changes from main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+<!--
+Thanks for opening a PR! A few things to check before you submit:
+-->
+
+## Summary
+
+<!-- 1-3 bullets describing what changed and why. -->
+
+## Test plan
+
+<!-- Bulleted checklist of how to verify the change. -->
+- [ ]
+
+## Checklist
+
+- [ ] All commits are signed off (`git commit -s`) per
+      [CONTRIBUTING.md](../video_ingestion_agent/CONTRIBUTING.md#sign-off-developer-certificate-of-origin)
+      ([Developer Certificate of Origin](https://developercertificate.org/)).
+- [ ] `pre-commit run --all-files` passes locally.
+- [ ] Tests added or updated, and `pytest` passes locally.
+- [ ] Docs updated (`docs/pages/...`) if the change is architectural or
+      user-facing.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Thanks for opening a PR! A few things to check before you submit:
 ## Checklist
 
 - [ ] All commits are signed off (`git commit -s`) per
-      [CONTRIBUTING.md](../video_ingestion_agent/CONTRIBUTING.md#sign-off-developer-certificate-of-origin)
+      [CONTRIBUTING.md](../video_ingestion_agent/CONTRIBUTING.md#signing-your-work)
       ([Developer Certificate of Origin](https://developercertificate.org/)).
 - [ ] `pre-commit run --all-files` passes locally.
 - [ ] Tests added or updated, and `pytest` passes locally.

--- a/video_ingestion_agent/.gitlab-ci.yml
+++ b/video_ingestion_agent/.gitlab-ci.yml
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 stages:
   - lint
   - docs

--- a/video_ingestion_agent/.pre-commit-config.yaml
+++ b/video_ingestion_agent/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/video_ingestion_agent/CONTRIBUTING.md
+++ b/video_ingestion_agent/CONTRIBUTING.md
@@ -59,6 +59,30 @@ Optional body explaining the *why*.
 
 Example: `[video_ingestion] retrieval: cap relaxation depth at 4 levels`.
 
+## Sign-off (Developer Certificate of Origin)
+
+This project follows the [Developer Certificate of Origin
+(DCO)](https://developercertificate.org/). Every commit you submit must
+include a `Signed-off-by:` trailer asserting that you have the right to
+contribute the change under this project's license terms.
+
+Add the trailer automatically with `git commit -s`:
+
+```bash
+git commit -s -m "[video_ingestion] my change"
+```
+
+This appends a line like the following to your commit message:
+
+```
+Signed-off-by: Your Name <you@example.com>
+```
+
+Use the name and email associated with your `git config user.name` /
+`git config user.email`. Commits without a `Signed-off-by:` trailer will
+not be accepted; if you forget, amend the commit (or use `git rebase
+--signoff`) and force-push to your branch before requesting review.
+
 ## Architecture conventions
 
 Documented in **`docs/pages/development.rst`** and **`CLAUDE.md`**.

--- a/video_ingestion_agent/CONTRIBUTING.md
+++ b/video_ingestion_agent/CONTRIBUTING.md
@@ -59,29 +59,59 @@ Optional body explaining the *why*.
 
 Example: `[video_ingestion] retrieval: cap relaxation depth at 4 levels`.
 
-## Sign-off (Developer Certificate of Origin)
+## Signing Your Work
 
-This project follows the [Developer Certificate of Origin
-(DCO)](https://developercertificate.org/). Every commit you submit must
-include a `Signed-off-by:` trailer asserting that you have the right to
-contribute the change under this project's license terms.
+* We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
 
-Add the trailer automatically with `git commit -s`:
+  * Any contribution which contains commits that are not Signed-Off will not be accepted.
 
-```bash
-git commit -s -m "[video_ingestion] my change"
-```
+* To sign off on a commit you simply use the `--signoff` (or `-s`) option when committing your changes:
+  ```bash
+  $ git commit -s -m "Add cool feature."
+  ```
+  This will append the following to your commit message:
+  ```
+  Signed-off-by: Your Name <your@email.com>
+  ```
 
-This appends a line like the following to your commit message:
+* Full text of the DCO (https://developercertificate.org/):
 
-```
-Signed-off-by: Your Name <you@example.com>
-```
+  ```
+    Developer Certificate of Origin
+    Version 1.1
 
-Use the name and email associated with your `git config user.name` /
-`git config user.email`. Commits without a `Signed-off-by:` trailer will
-not be accepted; if you forget, amend the commit (or use `git rebase
---signoff`) and force-push to your branch before requesting review.
+    Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+    Everyone is permitted to copy and distribute verbatim copies of this
+    license document, but changing it is not allowed.
+
+
+    Developer's Certificate of Origin 1.1
+
+    By making a contribution to this project, I certify that:
+
+    (a) The contribution was created in whole or in part by me and I
+        have the right to submit it under the open source license
+        indicated in the file; or
+
+    (b) The contribution is based upon previous work that, to the best
+        of my knowledge, is covered under an appropriate open source
+        license and I have the right under that license to submit that
+        work with modifications, whether created in whole or in part
+        by me, under the same open source license (unless I am
+        permitted to submit under a different license), as indicated
+        in the file; or
+
+    (c) The contribution was provided directly to me by some other
+        person who certified (a), (b) or (c) and I have not modified
+        it.
+
+    (d) I understand and agree that this project and the contribution
+        are public and that a record of the contribution (including all
+        personal information I submit with it, including my sign-off) is
+        maintained indefinitely and may be redistributed consistent with
+        this project or the open source license(s) involved.
+  ```
 
 ## Architecture conventions
 

--- a/video_ingestion_agent/Dockerfile
+++ b/video_ingestion_agent/Dockerfile
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/video_ingestion_agent/LICENSE
+++ b/video_ingestion_agent/LICENSE
@@ -1,15 +1,604 @@
-# Apache License 2.0
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+This code is dual-licensed with documentation/skills under the CC-BY-4.0 AND source code under Apache-2.0 license terms.
 
-Copyright 2025 NVIDIA CORPORATION
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Attribution 4.0 International
 
-    http://www.apache.org/licenses/LICENSE-2.0
+=======================================================================
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the "Licensor." The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+
+
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/video_ingestion_agent/NOTICE
+++ b/video_ingestion_agent/NOTICE
@@ -1,0 +1,259 @@
+# Third-Party Notices
+
+This file enumerates the direct dependencies of `video_ingestion_agent`
+and the license terms under which their upstream projects make them
+available. Transitive dependencies inherit their license terms from
+these direct parents.
+
+Versions reflect the resolved set in `uv.lock` at the time this file
+was generated; license identifiers and copyright attributions reflect
+each project's upstream LICENSE file. For the authoritative license
+terms of any individual package, consult the upstream project URL.
+
+---
+
+Copyright NumPy Developers - BSD-3-Clause License
+Attribution Statements: NVIDIA actively chooses the BSD-3-Clause license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/BSD-3-Clause.html)
+Package: numpy 2.2.6
+Project URL: https://numpy.org/
+
+Copyright OpenCV team and contributors - Apache-2.0 License
+Attribution Statements: NVIDIA actively chooses the Apache-2.0 license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/Apache-2.0.html)
+Package: opencv-python 4.13.0.92
+Project URL: https://github.com/opencv/opencv-python
+
+Copyright Jeffrey A. Clark and contributors - MIT-CMU License
+Attribution Statements: NVIDIA actively chooses the MIT-CMU license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT-CMU.html)
+Package: pillow 12.2.0
+Project URL: https://python-pillow.org/
+
+Copyright LangChain, Inc. - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: langgraph 1.1.10
+Project URL: https://github.com/langchain-ai/langgraph
+
+Copyright LangChain, Inc. - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: langchain-core 1.3.2
+Project URL: https://github.com/langchain-ai/langchain
+
+Copyright Kenneth Reitz and contributors - Apache-2.0 License
+Attribution Statements: NVIDIA actively chooses the Apache-2.0 license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/Apache-2.0.html)
+Package: requests 2.33.1
+Project URL: https://requests.readthedocs.io/
+
+Copyright OpenAI - Apache-2.0 License
+Attribution Statements: NVIDIA actively chooses the Apache-2.0 license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/Apache-2.0.html)
+Package: openai 2.34.0
+Project URL: https://github.com/openai/openai-python
+
+Copyright Mike Bayer and SQLAlchemy contributors - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: sqlalchemy 2.0.49
+Project URL: https://www.sqlalchemy.org/
+
+Copyright Samuel Colvin and other contributors - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: pydantic 2.13.3
+Project URL: https://docs.pydantic.dev/
+
+Copyright tqdm developers - MIT AND MPL-2.0 License
+Attribution Statements: NVIDIA actively chooses the MIT AND MPL-2.0 license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: tqdm 4.67.3
+Project URL: https://tqdm.github.io/
+
+Copyright Kirill Simonov and PyYAML contributors - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: pyyaml 6.0.3
+Project URL: https://pyyaml.org/
+
+Copyright Will McGugan - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: rich 15.0.0
+Project URL: https://github.com/Textualize/rich
+
+Copyright Meta Platforms, Inc. and PyTorch contributors - BSD-3-Clause License
+Attribution Statements: NVIDIA actively chooses the BSD-3-Clause license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/BSD-3-Clause.html)
+Package: torch 2.9.0
+Project URL: https://pytorch.org/
+
+Copyright The HuggingFace Team - Apache-2.0 License
+Attribution Statements: NVIDIA actively chooses the Apache-2.0 license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/Apache-2.0.html)
+Package: transformers 4.57.6
+Project URL: https://github.com/huggingface/transformers
+
+Copyright The HuggingFace Team - Apache-2.0 License
+Attribution Statements: NVIDIA actively chooses the Apache-2.0 license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/Apache-2.0.html)
+Package: accelerate 1.13.0
+Project URL: https://github.com/huggingface/accelerate
+
+Copyright Ross Wightman - Apache-2.0 License
+Attribution Statements: NVIDIA actively chooses the Apache-2.0 license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/Apache-2.0.html)
+Package: timm 1.0.26
+Project URL: https://github.com/huggingface/pytorch-image-models
+
+Copyright Tim Dettmers and contributors - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: bitsandbytes 0.49.2
+Project URL: https://github.com/bitsandbytes-foundation/bitsandbytes
+
+Copyright vLLM Team - Apache-2.0 License
+Attribution Statements: NVIDIA actively chooses the Apache-2.0 license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/Apache-2.0.html)
+Package: vllm 0.12.0
+Project URL: https://github.com/vllm-project/vllm
+
+Copyright Holger Krekel and pytest contributors - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: pytest 9.0.3
+Project URL: https://pytest.org/
+
+Copyright pytest-cov contributors - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: pytest-cov 7.1.0
+Project URL: https://github.com/pytest-dev/pytest-cov
+
+Copyright Astral Software, Inc. - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: ruff 0.15.12
+Project URL: https://github.com/astral-sh/ruff
+
+Copyright Jukka Lehtosalo and mypy contributors - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: mypy 1.20.2
+Project URL: https://www.mypy-lang.org/
+
+Copyright pre-commit contributors - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: pre-commit 4.6.0
+Project URL: https://pre-commit.com/
+
+Copyright Georg Brandl and the Sphinx team - BSD-2-Clause License
+Attribution Statements: NVIDIA actively chooses the BSD-2-Clause license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/BSD-2-Clause.html)
+Package: sphinx 8.2.3
+Project URL: https://www.sphinx-doc.org/
+
+Copyright NVIDIA Corporation - Apache-2.0 License
+Attribution Statements: NVIDIA actively chooses the Apache-2.0 license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/Apache-2.0.html)
+Package: nvidia-sphinx-theme 0.0.9.post1
+Project URL: https://github.com/nvidia/nvidia-sphinx-theme
+
+Copyright Holger Mauermann and contributors - BSD-2-Clause License
+Attribution Statements: NVIDIA actively chooses the BSD-2-Clause license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/BSD-2-Clause.html)
+Package: sphinx-multiversion 0.2.4
+Project URL: https://holzhaus.github.io/sphinx-multiversion/
+
+Copyright Sphinx-copybutton contributors - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: sphinx_copybutton 0.5.2
+Project URL: https://github.com/executablebooks/sphinx-copybutton
+
+Copyright Executable Books Project - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: sphinx_tabs 3.5.0
+Project URL: https://github.com/executablebooks/sphinx-tabs
+
+Copyright Executable Books Project - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: sphinx_design 0.7.0
+Project URL: https://github.com/executablebooks/sphinx-design
+
+Copyright Mark Hall and contributors - BSD-2-Clause License
+Attribution Statements: NVIDIA actively chooses the BSD-2-Clause license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/BSD-2-Clause.html)
+Package: sphinxcontrib-mermaid 2.0.1
+Project URL: https://github.com/mgaitan/sphinxcontrib-mermaid
+
+Copyright Jonathan Stoppani and contributors - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: sphinx-autobuild 2025.8.25
+Project URL: https://github.com/sphinx-doc/sphinx-autobuild
+
+Copyright John D. Hunter, Matplotlib Development Team - PSF-2.0 License
+Attribution Statements: NVIDIA actively chooses the PSF-2.0 license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/PSF-2.0.html)
+Package: matplotlib 3.10.9
+Project URL: https://matplotlib.org/
+
+Copyright Michael Waskom and the seaborn developers - BSD-3-Clause License
+Attribution Statements: NVIDIA actively chooses the BSD-3-Clause license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/BSD-3-Clause.html)
+Package: seaborn 0.13.2
+Project URL: https://seaborn.pydata.org/
+
+Copyright Plotly Technologies Inc. - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: plotly 6.7.0
+Project URL: https://plotly.com/python/
+
+Copyright NetworkX Developers - BSD-3-Clause License
+Attribution Statements: NVIDIA actively chooses the BSD-3-Clause license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/BSD-3-Clause.html)
+Package: networkx 3.6.1
+Project URL: https://networkx.org/
+
+Copyright The Gradio team - Apache-2.0 License
+Attribution Statements: NVIDIA actively chooses the Apache-2.0 license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/Apache-2.0.html)
+Package: gradio 6.14.0
+Project URL: https://www.gradio.app/
+
+Copyright Nils Reimers and contributors - Apache-2.0 License
+Attribution Statements: NVIDIA actively chooses the Apache-2.0 license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/Apache-2.0.html)
+Package: sentence-transformers 5.4.1
+Project URL: https://www.sbert.net/
+
+Copyright Tianyi Zhang and contributors - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: bert-score 0.3.13
+Project URL: https://github.com/Tiiiger/bert_score
+
+Copyright AQR Capital Management, LLC, Lambda Foundry, Inc. and PyData Development Team - BSD-3-Clause License
+Attribution Statements: NVIDIA actively chooses the BSD-3-Clause license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/BSD-3-Clause.html)
+Package: pandas 2.3.3
+Project URL: https://pandas.pydata.org/
+
+Copyright Gael Varoquaux and Joblib contributors - BSD-3-Clause License
+Attribution Statements: NVIDIA actively chooses the BSD-3-Clause license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/BSD-3-Clause.html)
+Package: joblib 1.5.3
+Project URL: https://joblib.readthedocs.io/
+
+Copyright Weights & Biases, Inc. - MIT License
+Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: wandb 0.26.1
+Project URL: https://wandb.ai/

--- a/video_ingestion_agent/README.md
+++ b/video_ingestion_agent/README.md
@@ -157,7 +157,7 @@ We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for the
 PR workflow and style guide. **Every commit must be signed off via
 `git commit -s`** under the
 [Developer Certificate of Origin](https://developercertificate.org/) —
-see the [Sign-off section](CONTRIBUTING.md#sign-off-developer-certificate-of-origin)
+see the [Signing Your Work section](CONTRIBUTING.md#signing-your-work)
 for details.
 
 ## Citation

--- a/video_ingestion_agent/README.md
+++ b/video_ingestion_agent/README.md
@@ -147,7 +147,18 @@ Full documentation builds from `docs/` with Sphinx — install
 
 ## License
 
-Apache 2.0 — see [LICENSE](LICENSE).
+Dual-licensed under [CC-BY-4.0 AND Apache-2.0](LICENSE): source code
+under Apache-2.0, documentation and mixed-content files under
+CC-BY-4.0. Third-party dependency notices are in [NOTICE](NOTICE).
+
+## Contributing
+
+We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+PR workflow and style guide. **Every commit must be signed off via
+`git commit -s`** under the
+[Developer Certificate of Origin](https://developercertificate.org/) —
+see the [Sign-off section](CONTRIBUTING.md#sign-off-developer-certificate-of-origin)
+for details.
 
 ## Citation
 

--- a/video_ingestion_agent/configs/batch_ingestion.yaml
+++ b/video_ingestion_agent/configs/batch_ingestion.yaml
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 # Batch Ingestion Pipeline Configuration
 # Optimised for processing 1000+ videos across multiple GPU shards on OSMO.
 # All shards share a single TP=8 vLLM server and write to the same graph.db / vector.db.

--- a/video_ingestion_agent/configs/benchmark_epic_kitchens.yaml
+++ b/video_ingestion_agent/configs/benchmark_epic_kitchens.yaml
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 # Benchmark Configuration for EPIC-KITCHENS-100
 # Based on ingestion.yaml, tuned for benchmarking segmentation accuracy.
 #

--- a/video_ingestion_agent/configs/benchmark_hot3d.yaml
+++ b/video_ingestion_agent/configs/benchmark_hot3d.yaml
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 # Benchmark Configuration for HOT3D (Aria) ground truth from per-object contact
 # segmentation.
 #

--- a/video_ingestion_agent/configs/ingestion.yaml
+++ b/video_ingestion_agent/configs/ingestion.yaml
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 # Unified Pipeline Configuration
 # Ingestion (segmentation + verification + refinement) + Entity Graph
 

--- a/video_ingestion_agent/configs/retrieval.yaml
+++ b/video_ingestion_agent/configs/retrieval.yaml
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 # Agent Configuration for Video Retrieval
 
 models:

--- a/video_ingestion_agent/configs/webapp.yaml
+++ b/video_ingestion_agent/configs/webapp.yaml
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 # Webapp configuration with the optional Reconstruct integration tab enabled.
 #
 # The `reconstruction:` block wires the Reconstruct tab at the sibling

--- a/video_ingestion_agent/docs/_ext/video_ingestion_agent_doc_tools.py
+++ b/video_ingestion_agent/docs/_ext/video_ingestion_agent_doc_tools.py
@@ -1,6 +1,5 @@
-# Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 
 import re
 from typing import Any

--- a/video_ingestion_agent/docs/conf.py
+++ b/video_ingestion_agent/docs/conf.py
@@ -1,6 +1,5 @@
-# Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 
 # Configuration file for the Sphinx documentation builder.
 # https://www.sphinx-doc.org/en/master/usage/configuration.html

--- a/video_ingestion_agent/osmo_workflows/batch_ingestion.yaml
+++ b/video_ingestion_agent/osmo_workflows/batch_ingestion.yaml
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/video_ingestion_agent/osmo_workflows/benchmark.yaml
+++ b/video_ingestion_agent/osmo_workflows/benchmark.yaml
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/video_ingestion_agent/osmo_workflows/dev_env.yaml
+++ b/video_ingestion_agent/osmo_workflows/dev_env.yaml
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/video_ingestion_agent/osmo_workflows/scripts/setup_ssh.sh
+++ b/video_ingestion_agent/osmo_workflows/scripts/setup_ssh.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 #
 # Shared SSH setup for osmo workflows.
 # Expects osmo credentials at /tmp/.ssh (set via `credentials: sshd-keys`).

--- a/video_ingestion_agent/osmo_workflows/scripts/start_vllm.sh
+++ b/video_ingestion_agent/osmo_workflows/scripts/start_vllm.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 #
 # Shared vLLM server launcher for osmo workflows.
 #

--- a/video_ingestion_agent/osmo_workflows/webapp.yaml
+++ b/video_ingestion_agent/osmo_workflows/webapp.yaml
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/video_ingestion_agent/pyproject.toml
+++ b/video_ingestion_agent/pyproject.toml
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 [project]
 name = "video_ingestion_agent"
 version = "0.1.0"

--- a/video_ingestion_agent/scripts/run_batch_ingestion.py
+++ b/video_ingestion_agent/scripts/run_batch_ingestion.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Batch video ingestion: discover videos, shard across GPUs, run full pipeline.
 

--- a/video_ingestion_agent/scripts/run_benchmark.py
+++ b/video_ingestion_agent/scripts/run_benchmark.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Run the video_ingestion_agent segmentation pipeline on EPIC-KITCHENS-100 videos.
 

--- a/video_ingestion_agent/scripts/run_benchmark_hot3d.py
+++ b/video_ingestion_agent/scripts/run_benchmark_hot3d.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 HOT3D benchmark runner: ingestion (via run_benchmark.py) + HOT3D evaluation.
 

--- a/video_ingestion_agent/scripts/run_ingestion.py
+++ b/video_ingestion_agent/scripts/run_ingestion.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Run the unified ingestion + entity graph pipeline.
 

--- a/video_ingestion_agent/scripts/run_osmo.py
+++ b/video_ingestion_agent/scripts/run_osmo.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 
 Script to submit OSMO workflows for the Video Ingestion Agent.
 

--- a/video_ingestion_agent/scripts/run_retrieval.py
+++ b/video_ingestion_agent/scripts/run_retrieval.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Query video using LangGraph-based agentic retrieval.
 

--- a/video_ingestion_agent/scripts/run_webapp.py
+++ b/video_ingestion_agent/scripts/run_webapp.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Launch the Video Ingestion Agent web application.
 
 This script is a launcher for the Gradio webapp defined in

--- a/video_ingestion_agent/scripts/serve.py
+++ b/video_ingestion_agent/scripts/serve.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 vLLM server manager for video_ingestion_agent.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Video Ingestion Agent
 

--- a/video_ingestion_agent/src/video_ingestion_agent/benchmark/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/benchmark/__init__.py
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Benchmark evaluation for EPIC-KITCHENS-100 and related datasets."""

--- a/video_ingestion_agent/src/video_ingestion_agent/benchmark/adapter.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/benchmark/adapter.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Prediction-to-submission adapter for EPIC-KITCHENS-100 benchmark.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/benchmark/evaluate.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/benchmark/evaluate.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Evaluation script for EPIC-KITCHENS-100 benchmark.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/benchmark/evaluate_hot3d.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/benchmark/evaluate_hot3d.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 HOT3D benchmark evaluator: temporal mAP@tIoU + object accuracy.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/benchmark/load_epic_kitchens.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/benchmark/load_epic_kitchens.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Ground truth loader for EPIC-KITCHENS-100 annotations.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/benchmark/load_hot3d.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/benchmark/load_hot3d.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Ground-truth loader for HOT3D contact-segmentation benchmark.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/benchmark/report.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/benchmark/report.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Benchmark report generator for EPIC-KITCHENS-100 evaluation.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/benchmark/wandb_logger.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/benchmark/wandb_logger.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Weights & Biases logging for benchmark results.
 
 Logs evaluation metrics, pipeline config, and result artifacts to W&B

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Unified video ingestion + entity graph pipeline.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/config.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/config.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Configuration models for the unified ingestion + entity graph pipeline.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph/__init__.py
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Entity graph building components (extractors, linker, DB writer)."""

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph/database_writer.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph/database_writer.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Database writer for entity graph with multi-video support."""
 
 import json

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph/entity_linker.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph/entity_linker.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Entity linking across chunks."""
 
 import logging

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph/extractors/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph/extractors/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Extractors package."""
 
 from video_ingestion_agent.ingestion.entity_graph.extractors.entity_extractor import EntityExtractor

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph/extractors/entity_extractor.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph/extractors/entity_extractor.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Entity extractor using LLM."""
 
 import json

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph/extractors/visual_extractor.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph/extractors/visual_extractor.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Visual feature extractor using VLM and SigLIP-2."""
 
 import logging

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph/prompts.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph/prompts.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Prompts for entity graph extraction.
 
 Based on EGAgent paper (arXiv:2601.18157) - "Agentic Very Long Video Understanding"

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph_nodes.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/entity_graph_nodes.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 LangGraph nodes for entity graph building and reporting.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/ingestion_graph.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/ingestion_graph.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 End-to-end LangGraph pipeline: ingestion + entity graph.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/io.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/io.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 I/O utilities for reading and writing JSONL files, with Pydantic model support.
 """

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/report.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/report.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 HTML report generator for pipeline results.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Video segmentation, verification, and refinement components."""
 
 from video_ingestion_agent.ingestion.segmentation.critic import Critic

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/critic.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/critic.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 COSMOS Reason Critic for segmentation verification.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/dedup.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/dedup.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Clip deduplication for overlapping segments.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/prompts.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/prompts.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Default prompts for video segmentation and verification.
 
 These constants are used as fallbacks when the YAML config does not provide

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/refiner.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/refiner.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 High-level refinement orchestration.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/segmenter.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/segmenter.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Hybrid video segmenter.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/strategies.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/strategies.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Base classes and strategies for clip refinement.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/video_utils.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/video_utils.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Video utilities for clip extraction.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation_nodes.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation_nodes.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 LangGraph nodes for the segmentation / verification / refinement loop.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/state.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/state.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Core data types for the unified ingestion + entity graph pipeline.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/models/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/models/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """LLM/VLM model management and inference backends."""
 
 from video_ingestion_agent.models.model_manager import (

--- a/video_ingestion_agent/src/video_ingestion_agent/models/api_model.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/models/api_model.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """API-based model wrapper.
 
 This module provides the API model wrapper for external LLM services

--- a/video_ingestion_agent/src/video_ingestion_agent/models/cosmos_model.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/models/cosmos_model.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Core Cosmos Reason 2 model wrapper.
 
 This module provides the base model wrapper for Cosmos Reason 2,

--- a/video_ingestion_agent/src/video_ingestion_agent/models/model_manager.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/models/model_manager.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Model Manager - Unified interface for local, API, and vLLM-based models.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/models/vllm_model.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/models/vllm_model.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """vLLM-based model wrapper.
 
 This module provides a model wrapper that connects to a vLLM server

--- a/video_ingestion_agent/src/video_ingestion_agent/reconstruction_interface/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/reconstruction_interface/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0

--- a/video_ingestion_agent/src/video_ingestion_agent/reconstruction_interface/_common/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/reconstruction_interface/_common/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0

--- a/video_ingestion_agent/src/video_ingestion_agent/reconstruction_interface/_common/ingestion_io.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/reconstruction_interface/_common/ingestion_io.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Read `video_ingestion_agent` output surfaces as a list of `IngestedSegment`s.
 
 Two equivalent sources:

--- a/video_ingestion_agent/src/video_ingestion_agent/reconstruction_interface/ego_e2e/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/reconstruction_interface/ego_e2e/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0

--- a/video_ingestion_agent/src/video_ingestion_agent/reconstruction_interface/ego_e2e/run_ego_e2e.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/reconstruction_interface/ego_e2e/run_ego_e2e.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Full ego hand + object reconstruction pipeline, fed by ingestion segments.
 
 For each segment in `runs/<run>/clips_final.jsonl` (or `outputs/graph.db`):

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Retrieval agents for video clip search and question answering.
 
 Available agents:

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/config.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/config.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Configuration models for the retrieval agent.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Agent node implementations.
 
 Each node represents a step in the LangGraph agent workflow.

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/analyzer.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/analyzer.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Analyzer node.
 
 Analyzes search results and reports findings. Does NOT make decisions about

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/base.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/base.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Base class for agent nodes.
 
 Provides common functionality for LLM calls, JSON parsing, and tool access.

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/executor.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/executor.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Executor node.
 
 Executes search operations for the current sub-task using available tools.

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/prompts.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/prompts.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Prompts for the LangGraph retrieval agent.
 
 Each prompt is split into:

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/search_planner.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/search_planner.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Search planner node.
 
 Central decision maker for all search strategy:

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/task_decomposer.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/task_decomposer.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Task decomposition node.
 
 Breaks down high-level user queries into concrete sub-tasks for retrieval.

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/vqa_synthesizer.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/nodes/vqa_synthesizer.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """VQA Synthesizer node.
 
 Synthesizes final answer and selects clips for robot policy training.

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/retrieval_graph.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/retrieval_graph.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """LangGraph-based agent for video clip retrieval.
 
 Enhanced with EGAgent paper (arXiv:2601.18157) patterns:

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/state.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/state.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Agent state definitions and data classes.
 
 This module defines the state that flows through the LangGraph agent,

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/task_search_subgraph.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/task_search_subgraph.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Per-task search subgraph for parallel execution.
 
 Encapsulates the search_planner -> executor -> analyzer loop for a single

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/tools/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/tools/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Tools for agentic video retrieval workflows.
 
 Available tools:

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/tools/base.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/tools/base.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Base tool interface for agentic workflows."""
 
 from abc import ABC, abstractmethod

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/tools/extract_clip.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/tools/extract_clip.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Tool for extracting video clips with multi-video support."""
 
 import logging

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/tools/search_frames.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/tools/search_frames.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Tool for semantic search over frame embeddings."""
 
 import logging

--- a/video_ingestion_agent/src/video_ingestion_agent/retrieval/tools/search_graph.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/retrieval/tools/search_graph.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Tool for searching the entity graph database."""
 
 import json

--- a/video_ingestion_agent/src/video_ingestion_agent/utils/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/utils/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Utilities package."""
 
 from video_ingestion_agent.utils.parsing import parse_llm_json, parse_timestamp

--- a/video_ingestion_agent/src/video_ingestion_agent/utils/parsing.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/utils/parsing.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Shared parsing utilities for LLM responses.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/utils/sharding.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/utils/sharding.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Shared video discovery, sharding, and parallel worker utilities.
 
 Used by both the benchmark runner and the batch ingestion script to

--- a/video_ingestion_agent/src/video_ingestion_agent/utils/types.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/utils/types.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Common data types and models."""
 
 from dataclasses import dataclass

--- a/video_ingestion_agent/src/video_ingestion_agent/utils/vector_database.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/utils/vector_database.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Vector database for storing and retrieving frame embeddings."""
 
 import json

--- a/video_ingestion_agent/src/video_ingestion_agent/utils/video_processor.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/utils/video_processor.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Video processing utilities for frame and audio extraction."""
 
 import logging

--- a/video_ingestion_agent/src/video_ingestion_agent/utils/video_utils.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/utils/video_utils.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Shared video utility functions.
 

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Video Ingestion Agent Web Application.
 
 A Gradio-based web interface for video ingestion, querying, and clip management.

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/app.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/app.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Main Gradio application for video_ingestion_agent."""
 
 import logging

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/components/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/components/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """UI components for the webapp."""
 
 from video_ingestion_agent.webapp.components.graph_visualizer import create_entity_graph_figure

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/components/graph_visualizer.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/components/graph_visualizer.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Entity graph visualization using a word cloud style Plotly plot."""
 
 import math

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/components/pipeline_visualizer.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/components/pipeline_visualizer.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """LangGraph pipeline visualization component."""
 
 from dataclasses import dataclass

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/config.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/config.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Application configuration for the Gradio webapp."""
 
 import logging

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/models/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/models/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Data models for the webapp."""
 
 from video_ingestion_agent.webapp.models.query_history import ClipResult, QueryRecord, SubTaskResult

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/models/query_history.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/models/query_history.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Query history data models."""
 
 import json

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/models/reconstruction.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/models/reconstruction.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Dataclasses shared between the reconstruction service and tab.
 
 The reconstruction chain is the 16-stage Full (ego_e2e) pipeline driven by

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/services/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/services/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Backend services for the webapp."""
 
 from video_ingestion_agent.webapp.services.database_service import DatabaseService

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/services/database_service.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/services/database_service.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Database browsing service wrapping SearchGraphTool."""
 
 import logging

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/services/ingestion_service.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/services/ingestion_service.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Video ingestion service wrapping the LangGraph ingestion pipeline."""
 
 import logging

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/services/query_service.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/services/query_service.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Query service wrapping RetrievalAgent."""
 
 import json

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/services/reconstruction_service.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/services/reconstruction_service.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Orchestrates the reconstruction chain via subprocess.
 
 One chain: invoke `reconstruction_interface/ego_e2e/run_ego_e2e.py` once per

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/__init__.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/__init__.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Tab implementations for the webapp."""
 
 from video_ingestion_agent.webapp.tabs.database_tab import create_database_tab

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/database_tab.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/database_tab.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Database browser tab for exploring entity graphs."""
 
 import logging

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/ingestion_tab.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/ingestion_tab.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Video ingestion tab for uploading and processing videos."""
 
 import json

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/query_tab.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/query_tab.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Video query tab — dark card-based layout with horizontal pipeline."""
 
 import logging

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/reconstruction_tab.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/reconstruction_tab.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Reconstruction tab — runs the 16-stage hand + object reconstruction chain.
 
 User picks a segment from a `clips_final.jsonl` (or types a segment_id), clicks

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/settings_tab.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/settings_tab.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Settings tab for configuring pipeline and model parameters."""
 
 import logging

--- a/video_ingestion_agent/tests/test_adapter.py
+++ b/video_ingestion_agent/tests/test_adapter.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Tests for the EPIC-KITCHENS adapter verb-mapping logic.
 
 Covers the pure-function helpers that don't need a sentence-transformer model:

--- a/video_ingestion_agent/tests/test_common_utils.py
+++ b/video_ingestion_agent/tests/test_common_utils.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Tests for the refactored shared utilities in common/.
 

--- a/video_ingestion_agent/tests/test_dedup.py
+++ b/video_ingestion_agent/tests/test_dedup.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Tests for :class:`ClipDeduplicator`.
 
 Covers both heuristic (no model) and LLM-based (with model) dedup strategies.

--- a/video_ingestion_agent/tests/test_executor_visual.py
+++ b/video_ingestion_agent/tests/test_executor_visual.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Tests for visual-search segment resolution in ExecutorNode."""
 
 from dataclasses import dataclass

--- a/video_ingestion_agent/tests/test_extract_clip.py
+++ b/video_ingestion_agent/tests/test_extract_clip.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Unit tests for the extract_clip tool's path-resolution fallback.
 
 Specifically covers the LLM-mutation case where the analyzer rewrites

--- a/video_ingestion_agent/tests/test_ingestion.py
+++ b/video_ingestion_agent/tests/test_ingestion.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """
 Tests for the ingestion subpackage.
 

--- a/video_ingestion_agent/tests/test_reconstruction_service.py
+++ b/video_ingestion_agent/tests/test_reconstruction_service.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Unit tests for the webapp's reconstruction orchestrator.
 
 The heavy work (Docker containers, weights, GPU) is mocked out — these tests

--- a/video_ingestion_agent/tests/test_retrieval_config.py
+++ b/video_ingestion_agent/tests/test_retrieval_config.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Tests for retrieval agent configuration."""
 
 from pathlib import Path

--- a/video_ingestion_agent/tests/test_retrieval_parallel.py
+++ b/video_ingestion_agent/tests/test_retrieval_parallel.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Tests for parallel sub-task execution in the retrieval agent.
 
 Covers:

--- a/video_ingestion_agent/tests/test_visual_extractor.py
+++ b/video_ingestion_agent/tests/test_visual_extractor.py
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Test visual extractor on sample video.
 
 This is a manual integration test -- run it directly via:


### PR DESCRIPTION
  ## Summary
  Cherry-picks the in-flight OSRB compliance PR (branch
  `liuw/osrb_compliance` on `main`) onto `release/0.1.0`:

  - **`976176cb`** — `[video_ingestion] OSRB compliance: dual-license
    LICENSE, NOTICE, SPDX headers, DCO sign-off` (128 files)
  - **`b02681d9`** — `[video_ingestion] CONTRIBUTING: use full DCO text +
    standard "Signing Your Work" wording` (3 files)
