### PR TITLE
[release/0.1.0] cherry-pick ego e2e setup fixes from main (#84)

### DIFF
--- a/reconstruction/docs/ego_e2e_setup.md
+++ b/reconstruction/docs/ego_e2e_setup.md
@@ -11,25 +11,27 @@ All commands run from `reconstruction/`.
 
 ## 1. Install host packages
 
+Install just the packages this pipeline needs:
+
 ```bash
-pip install -e modules/v2d_pipelines
+./scripts/install_ego_e2e_packages.sh
+```
+
+Or install every host package in the repo:
+
+```bash
 ./scripts/install_packages.sh
 ```
 
 ## 2. Build Docker images
 
+Build just the containers this pipeline needs:
+
 ```bash
-# All containers used by the pipeline:
-python -m v2d.moge.docker.build
-python -m v2d.grounding_dino.docker.build
-python -m v2d.sam2.docker.build
-python -m v2d.sam3d.docker.build
-python -m v2d.foundation_pose.docker.build
-python modules/v2d_ego_hand_reconstruction/docker/build.py
-python modules/v2d_hand_alignment/docker/build.py
+./scripts/build_ego_e2e_containers.sh
 ```
 
-Or build everything at once:
+Or build every container in the repo:
 
 ```bash
 ./scripts/build_containers.sh
@@ -53,11 +55,13 @@ environment or log in with `huggingface-cli login` beforehand.
 Download `MANO_RIGHT.pkl` from https://mano.is.tue.mpg.de/ and generate BMC data
 following https://github.com/MengHao666/Hand-BMC-pytorch (run up to `python calculate_bmc.py`).
 
-Place both in the weights directory:
+Place both in the weights directory. The layout follows the manotorch
+convention so the same directory works for both DynHaMR and v2d_hamer:
 
 ```
 data/weights/hand/
-├── MANO_RIGHT.pkl
+├── models/
+│   └── MANO_RIGHT.pkl
 └── BMC/
     └── *.npy
 ```

--- a/reconstruction/modules/v2d_ego_hand_reconstruction/README.md
+++ b/reconstruction/modules/v2d_ego_hand_reconstruction/README.md
@@ -27,9 +27,16 @@ Build both Docker images (ViPE + Dyn-HaMR):
 python -m v2d_ego_hand_reconstruction.docker.build
 ```
 
-Place required data in your output directory before running (see `vendor/doc/quickstart.md`):
-- `MANO_RIGHT.pkl` from <https://mano.is.tue.mpg.de/>
-- `BMC/*.npy` from the Hand-BMC-pytorch repo
+Place required data in your weights directory before running (see `vendor/doc/quickstart.md`).
+The layout follows the manotorch convention so the same directory is shared with `v2d_hamer`:
+
+```
+<weights_dir>/
+├── models/
+│   └── MANO_RIGHT.pkl     # from https://mano.is.tue.mpg.de/
+└── BMC/
+    └── *.npy              # from the Hand-BMC-pytorch repo
+```
 
 ## Usage
 

--- a/reconstruction/modules/v2d_ego_hand_reconstruction/docker/run_reconstruction.py
+++ b/reconstruction/modules/v2d_ego_hand_reconstruction/docker/run_reconstruction.py
@@ -5,8 +5,8 @@ sync with upstream IsaacTeleop.
 
 Prerequisites:
     - Both Docker images must be built (``python -m v2d_ego_hand_reconstruction.docker.build``).
-    - MANO_RIGHT.pkl and BMC/*.npy must be placed in *output_dir*
-      (see ``vendor/doc/quickstart.md`` for download instructions).
+    - ``weights_dir`` must contain ``models/MANO_RIGHT.pkl`` and ``BMC/*.npy``
+      (manotorch layout; see ``vendor/doc/quickstart.md`` for download instructions).
 """
 
 import os
@@ -26,15 +26,17 @@ def run_reconstruction(
     Args:
         video_input: Local file path, or ``s3://`` / ``swift://`` URL.
         output_dir: Directory for all pipeline outputs.
-        weights_dir: Directory containing MANO_RIGHT.pkl and BMC/ folder.
+        weights_dir: Directory containing ``models/MANO_RIGHT.pkl`` and ``BMC/``
+            (manotorch layout — shared with v2d_hamer).
     """
     output_dir = os.path.abspath(output_dir)
     weights_dir = os.path.abspath(weights_dir)
     os.makedirs(output_dir, exist_ok=True)
 
-    # Copy weights into output_dir so the container can find them.
+    # The vendored Dyn-HaMR container reads MANO_RIGHT.pkl from the top of
+    # output_dir, so copy it out of the manotorch-style models/ subdir.
     # Symlinking doesn't work because the target is outside the container's mount.
-    mano_src = os.path.join(weights_dir, "MANO_RIGHT.pkl")
+    mano_src = os.path.join(weights_dir, "models", "MANO_RIGHT.pkl")
     mano_dst = os.path.join(output_dir, "MANO_RIGHT.pkl")
     if not os.path.exists(mano_dst):
         shutil.copy2(mano_src, mano_dst)
@@ -65,6 +67,6 @@ if __name__ == "__main__":
         help="Local path or s3:///swift:// URL",
     )
     parser.add_argument("--output_dir", required=True, help="Output directory")
-    parser.add_argument("--weights_dir", required=True, help="Directory with MANO_RIGHT.pkl and BMC/")
+    parser.add_argument("--weights_dir", required=True, help="Directory with models/MANO_RIGHT.pkl and BMC/")
     args = parser.parse_args()
     run_reconstruction(args.video_input, args.output_dir, args.weights_dir)

--- a/reconstruction/modules/v2d_pipelines/pyproject.toml
+++ b/reconstruction/modules/v2d_pipelines/pyproject.toml
@@ -8,7 +8,10 @@ version = "0.1.0"
 description = "Example pipelines composing v2d Docker modules"
 requires-python = ">=3.10"
 dependencies = [
+    "numpy",
     "opencv-python",
+    "trimesh",
+    "OpenEXR",
 ]
 # Other runtime dependencies are local packages installed via scripts/install_packages.sh
 

--- a/reconstruction/modules/v2d_pipelines/run_v2d_ego_e2e.py
+++ b/reconstruction/modules/v2d_pipelines/run_v2d_ego_e2e.py
@@ -135,8 +135,9 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--foundation_pose_weights", default="data/weights/foundation_pose",
                    help="FoundationPose weights directory. (default: data/weights/foundation_pose)")
     p.add_argument("--hand_reconstruction_weights", default="data/weights/hand",
-                   help="Ego hand reconstruction weights directory containing MANO_RIGHT.pkl "
-                        "and BMC/. (default: data/weights/hand)")
+                   help="Ego hand reconstruction weights directory containing "
+                        "models/MANO_RIGHT.pkl and BMC/ (manotorch layout; shared "
+                        "with v2d_hamer). (default: data/weights/hand)")
     p.add_argument("--mano_weights", default=None,
                    help="MANO model directory for hand alignment. "
                         "(default: --hand_reconstruction_weights)")

--- a/reconstruction/scripts/build_ego_e2e_containers.sh
+++ b/reconstruction/scripts/build_ego_e2e_containers.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Build only the Docker images required by the ego e2e pipeline
+# (modules/v2d_pipelines/run_v2d_ego_e2e.py).
+#
+# Use this when you don't need every container. For everything, run
+# ./scripts/build_containers.sh instead.
+#
+# Run from reconstruction/ or repo root. Requires Docker and (optionally)
+# NVIDIA Container Toolkit.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Modules under the v2d.<name>.docker namespace
+MODULES=(anycalib moge grounding_dino sam2 sam3d foundation_pose hamer)
+
+for module in "${MODULES[@]}"; do
+  echo "Building v2d_${module}..."
+  python -m "v2d.${module}.docker.build"
+done
+
+# Modules with their own build entry points
+echo "Building v2d_ego_hand_reconstruction..."
+python modules/v2d_ego_hand_reconstruction/docker/build.py
+echo "Building v2d_hand_alignment..."
+python modules/v2d_hand_alignment/docker/build.py
+
+echo "All ego-e2e containers built successfully."

--- a/reconstruction/scripts/install_ego_e2e_packages.sh
+++ b/reconstruction/scripts/install_ego_e2e_packages.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Install only the host-side packages required by the ego e2e pipeline
+# (modules/v2d_pipelines/run_v2d_ego_e2e.py).
+#
+# Use this when you don't need the full repo install. For everything, run
+# ./scripts/install_packages.sh instead.
+#
+# Run from reconstruction/ or repo root.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+echo "Installing host packages for the ego e2e pipeline..."
+pip install -e modules/v2d_common \
+  -e modules/v2d_docker \
+  -e modules/v2d_depth \
+  -e modules/v2d_anycalib/docker \
+  -e modules/v2d_ego_hand_reconstruction/docker \
+  -e modules/v2d_foundation_pose/docker \
+  -e modules/v2d_grounding_dino/docker \
+  -e modules/v2d_hamer/docker \
+  -e modules/v2d_hand_alignment/docker \
+  -e modules/v2d_moge/docker \
+  -e modules/v2d_sam2/docker \
+  -e modules/v2d_sam3d/docker \
+  -e modules/v2d_pipelines
+
+echo "Done. Next: build the matching containers with ./scripts/build_ego_e2e_containers.sh"

--- a/reconstruction/scripts/install_packages.sh
+++ b/reconstruction/scripts/install_packages.sh
@@ -7,24 +7,38 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
 echo "Installing v2d docker packages and v2d_pipelines..."
-pip install -e modules/v2d_sam2/docker \
-  -e modules/v2d_sam3d/docker \
-  -e modules/v2d_unidepth/docker \
-  -e modules/v2d_moge/docker \
+pip install -e modules/v2d_common \
+  -e modules/v2d_docker \
+  -e modules/v2d_mv \
+  -e modules/v2d_depth \
+  -e modules/v2d_viz \
   -e modules/v2d_anycalib/docker \
-  -e modules/v2d_nlf/docker \
+  -e modules/v2d_bundlesdf/docker \
+  -e modules/v2d_cusfm/docker \
+  -e modules/v2d_depth_anything/docker \
+  -e modules/v2d_detectron2/docker \
+  -e modules/v2d_droid_slam/docker \
+  -e modules/v2d_ego_hand_reconstruction/docker \
   -e modules/v2d_foundation_pose/docker \
   -e modules/v2d_foundation_stereo/docker \
   -e modules/v2d_grounding_dino/docker \
-  -e modules/v2d_mediapipe/docker \
-  -e modules/v2d_hamer/docker \
-  -e modules/v2d_wilor/docker \
-  -e modules/v2d_droid_slam/docker \
-  -e modules/v2d_cusfm/docker \
-  -e modules/v2d_bundlesdf/docker \
-  -e modules/v2d_hoi_object_reconstruction/docker \
-  -e modules/v2d_ego_hand_reconstruction/docker \
   -e modules/v2d_gsplat_refinement/docker \
+  -e modules/v2d_hamer/docker \
+  -e modules/v2d_hand_alignment/docker \
+  -e modules/v2d_hoi_object_reconstruction/docker \
+  -e modules/v2d_mediapipe/docker \
+  -e modules/v2d_mesh/docker \
+  -e modules/v2d_moge/docker \
+  -e modules/v2d_mv_calibration/docker \
+  -e modules/v2d_mv_postprocess/docker \
+  -e modules/v2d_mv_preprocess/docker \
+  -e modules/v2d_nlf/docker \
+  -e modules/v2d_rosbag/docker \
+  -e modules/v2d_sam2/docker \
+  -e modules/v2d_sam3d/docker \
+  -e modules/v2d_sam3d_body/docker \
+  -e modules/v2d_unidepth/docker \
+  -e modules/v2d_wilor/docker \
   -e modules/v2d_pipelines
 
 echo "Done. Run 'python -m v2d.pipelines.run_example_pipeline' or build containers with ./build_containers.sh"


### PR DESCRIPTION
Cherry-picks #84 onto the release branch (squash commit `4294ff2c`).

Addresses two QA EVT blockers and tightens the ego e2e setup path:

- **bug 6197910** — `scripts/install_packages.sh` had drifted out of sync with the modules tree; missing entries caused `ModuleNotFoundError` mid-pipeline. Script now installs every host-side package under `modules/`. `v2d_pipelines/pyproject.toml` also declares its direct host-side imports (`trimesh`, `OpenEXR`, `numpy`).
- **bug 6203170** — MANO assets now follow the manotorch convention (`data/weights/hand/models/MANO_RIGHT.pkl`); `v2d_ego_hand_reconstruction/docker/run_reconstruction.py` reads from the nested path and copies into the vendored container's flat location.
- **New focused scripts** — `scripts/install_ego_e2e_packages.sh` and `scripts/build_ego_e2e_containers.sh` install/build only what `run_v2d_ego_e2e.py` needs; `docs/ego_e2e_setup.md` links to both.

## Conflict resolution
Only `scripts/install_packages.sh` conflicted (release branch had an older module list). Resolved by taking the incoming #84 version — all 32 referenced module dirs exist on `release/0.1.0`, and the resulting file is byte-identical to `main`.