### PR TITLE
[video_ingestion] batch: truncate progress_worker_*.jsonl on non-resu…

### DIFF
--- a/video_ingestion_agent/scripts/run_batch_ingestion.py
+++ b/video_ingestion_agent/scripts/run_batch_ingestion.py
@@ -272,6 +272,7 @@ def main():
         graph_db_path=graph_db_path,
         vector_db_path=vector_db_path,
         worker_id=worker_id,
+        resume=args.resume,
     )
 
     # ---- Summary ----

--- a/video_ingestion_agent/scripts/run_benchmark.py
+++ b/video_ingestion_agent/scripts/run_benchmark.py
@@ -503,6 +503,7 @@ def main():
                 config=config,
                 per_video_subdir="",
                 worker_id=args.worker_id,
+                resume=args.resume,
             )
 
             # Save results summary

--- a/video_ingestion_agent/src/video_ingestion_agent/utils/sharding.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/utils/sharding.py
@@ -221,6 +221,7 @@ def process_videos(
     vector_db_path: Path | None = None,
     worker_id: int = 0,
     per_video_subdir: str = "per_video",
+    resume: bool = False,
 ) -> list[dict[str, Any]]:
     """Process a list of videos sequentially through the ingestion pipeline.
 
@@ -237,6 +238,12 @@ def process_videos(
         per_video_subdir: Subdirectory under *output_dir* for per-video
             run dirs.  Use ``""`` to place run dirs directly under
             *output_dir* (as the benchmark does).
+        resume: If False (default), truncate the per-worker progress
+            JSONL at run start. Without this, re-running into a non-empty
+            output_dir leaves stale entries that downstream readers (the
+            webapp Ingest tab) sum into the current run's totals. If
+            True, the file is preserved and new entries append, matching
+            ``summary_worker_*.json``'s per-session contract.
 
     Returns:
         List of per-video result dicts with keys ``video``, ``status``,
@@ -244,6 +251,13 @@ def process_videos(
     """
     # Lazy import to keep this module light at import time
     from video_ingestion_agent.ingestion import run_pipeline
+
+    # Truncate progress file at start of a non-resume run so that re-running
+    # into a populated output_dir doesn't cause readers to sum stale entries
+    # from the prior run into the current run's totals.
+    progress_path = output_dir / f"progress_worker_{worker_id}.jsonl"
+    if not resume:
+        progress_path.unlink(missing_ok=True)
 
     results: list[dict[str, Any]] = []
     total = len(videos)
@@ -296,8 +310,7 @@ def process_videos(
         }
         results.append(result)
 
-        # Append progress incrementally
-        progress_path = output_dir / f"progress_worker_{worker_id}.jsonl"
+        # Append progress incrementally (file already prepared at run start).
         with open(progress_path, "a") as f:
             f.write(json.dumps(result) + "\n")
 


### PR DESCRIPTION
…me run start

`process_videos()` opened `progress_worker_<id>.jsonl` in append mode without ever truncating it. Re-running batch ingestion into a non-empty output directory without `--resume` therefore concatenated the new per-video progress records onto whatever the prior run had left behind. `summary_worker_<id>.json` and `graph.db` rows are rewritten or replaced in-place per run (per-run semantics), but the JSONL kept accumulating (audit-log semantics).

Downstream reader mismatch: the webapp Ingest tab's `_read_worker_progress` sums every line of the JSONL and reports it as the current run's totals. A 2-video re-run into a 2-video dir displayed `Videos processed: 4 / 2` (numerator from the stale-plus-new JSONL, denominator from the current invocation's input count) — mathematically impossible and inconsistent with the rest of the same panel (`Total time` is per-run, not cumulative).

Fix: add `resume: bool = False` kwarg to `process_videos()`; when False, unlink the per-worker progress file at function entry so the loop writes a fresh stream of records. Matches the per-run contract that `summary_worker_<id>.json` already follows. Both callers (`scripts/run_batch_ingestion.py`, `scripts/run_benchmark.py`) pass `resume=args.resume`, so a `--resume` invocation preserves the prior file as before.