### PR TITLE
[video_ingestion] webapp: keep stats_display visible from start to fi…

### DIFF
--- a/video_ingestion_agent/README.md
+++ b/video_ingestion_agent/README.md
@@ -128,7 +128,7 @@ For batch ingestion across many videos and GPUs:
 
 ```bash
 python scripts/run_batch_ingestion.py --input-dir <videos> \
-    -c configs/ingestion.yaml --output-dir runs/batch --num-shards 8 --resume
+    -c configs/batch_ingestion.yaml --output-dir runs/batch --num-shards 8 --resume
 ```
 
 ## Documentation

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/database_tab.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/database_tab.py
@@ -52,7 +52,15 @@ def create_database_tab(services: dict[str, Any], config: AppConfig) -> dict[str
             refresh_db_btn = gr.Button("↻", size="sm", scale=0, min_width=40)
             load_db_btn = gr.Button("Load Database", variant="primary", scale=1)
 
-        stats_display = gr.JSON(label="Database Statistics", visible=False)
+        # Rendered from the start (visible=True) on purpose. A gr.JSON created
+        # hidden and flipped visible *inside* the load_database event mounts
+        # only after Gradio has already dispatched that event's terminal
+        # loading status for it, so its queue progress overlay
+        # ("processing | …s") never clears — the spinner spins forever on both
+        # the success and the no-graph.db paths even though the value is written.
+        # Keeping the component always-mounted lets the value update and the
+        # spinner reset apply normally.
+        stats_display = gr.JSON(label="Database Statistics", value=None, visible=True)
 
         # ── Filters group ──
         with gr.Group():


### PR DESCRIPTION
PR #87 / cherry-pick #92 wrapped `load_database` in try/except so the handler always returns the 10-tuple Gradio's binding expects. That closed one failure mode (exceptions leaking out of the handler) but the user-reported spinner hang on `gr.JSON` persisted: a JSON component created with `visible=False` and flipped to `visible=True` inside a click handler mounts only AFTER Gradio has dispatched the event's terminal loading status for it, so the queue progress overlay ("processing | …s") never clears. The spinner sits forever on BOTH the happy and the no-graph.db paths even though the value is written.

Fix: create `stats_display` with `visible=True, value=None` from the start. The component is always mounted, so value updates flow through normally and the spinner-clear signal lands. Inline comment captures the dispatch-timing rationale so future edits don't undo it.

Also folded in a documentation nit: README.md's batch-ingestion example referenced `configs/ingestion.yaml`, but batch runs should use the dedicated `configs/batch_ingestion.yaml` (TP=8 vLLM defaults, shared graph.db / vector.db settings tuned for sharded multi-GPU execution). One-line fix to the code-block in §Quickstart.