### PR TITLE
[release/0.1.0] cherry-pick airplane.mp4 demo video from main (#97)

### DIFF
--- a/reconstruction/.gitattributes
+++ b/reconstruction/.gitattributes
@@ -1,0 +1,5 @@
+# Package-specific LFS rules for the reconstruction subproject.
+# (Universal rules live in the repo-root .gitattributes.)
+
+# Demo / test media
+assets/airplane.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/reconstruction/assets/airplane.mp4
+++ b/reconstruction/assets/airplane.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25e202b3659a0913231b3f6e969f8c9713f150404e25319311d4521665e90311
+size 26132424

--- a/reconstruction/docs/ego_e2e_setup.md
+++ b/reconstruction/docs/ego_e2e_setup.md
@@ -66,15 +66,34 @@ data/weights/hand/
     └── *.npy
 ```
 
-## 5. Run the pipeline
+## 5. Get the sample video
+
+A ready-to-run sample, `assets/airplane.mp4` (~25 MB), ships with the repo via
+[Git LFS](https://git-lfs.com/). If you cloned with Git LFS installed it is already
+present. Otherwise install LFS and pull it:
+
+```bash
+git lfs install                                              # one-time, enables LFS filters
+git lfs pull --include reconstruction/assets/airplane.mp4    # paths are repo-root relative
+```
+
+Confirm it materialized — it should be ~25 MB, not a ~130-byte pointer file:
+
+```bash
+ls -lh assets/airplane.mp4
+```
+
+## 6. Run the pipeline
 
 ```bash
 python modules/v2d_pipelines/run_v2d_ego_e2e.py \
-    --video_path  data/my_video.mp4 \
-    --prompt      "blue cup" \
-    --output_dir  data/outputs/my_video \
+    --video_path  assets/airplane.mp4 \
+    --prompt      "airplane" \
+    --output_dir  data/outputs/airplane \
     --depth_source moge
 ```
+
+Substitute your own `--video_path` / `--prompt` to run on a different clip.
 
 All weight paths default to `data/weights/<model>` relative to cwd so no extra flags are needed
 if you followed the layout above.


### PR DESCRIPTION
Cherry-picks #97 (`43bbc099`) from `main` onto the release branch.

Brings the ego e2e demo video to `release/0.1.0`:
- `reconstruction/assets/airplane.mp4` (~25 MB) via **Git LFS** (pointer cherry-picked; LFS object already in the remote store from #97 — no re-upload).
- `reconstruction/.gitattributes` — scoped LFS rule (`assets/airplane.mp4` only).
- `reconstruction/docs/ego_e2e_setup.md` — "Get the sample video" step + run example pointed at the bundled sample.

Clean cherry-pick (no conflicts); `airplane.mp4` verified to remain a 133-byte LFS pointer in the tree.