### PR TITLE
[release/0.1.0] OSRB comment #7: SPDX Apache-2.0 + NOTICE dep clarification (bug 6165912)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Each new reconstruction module must expose a Docker image, a `run_download_weigh
 
 ## License
 
-This project is dual-licensed: source code under **Apache-2.0** and documentation/skill files under **CC-BY-4.0**, per the top-level [`LICENSE`](LICENSE). NVIDIA-authored files carry SPDX headers (`SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0`).
+This project is dual-licensed: source code under **Apache-2.0** and documentation/skill files under **CC-BY-4.0**, per the top-level [`LICENSE`](LICENSE). NVIDIA-authored code files carry an `SPDX-License-Identifier: Apache-2.0` header; mixed documentation/skill content is covered by the CC-BY-4.0 AND Apache-2.0 dual terms from the top-level `LICENSE` and does not carry a per-file header.
 
 Some bundled third-party components are covered by their own licenses, **not** this project's terms, and retain their own `LICENSE` files in-tree:
 

--- a/reconstruction/NOTICE
+++ b/reconstruction/NOTICE
@@ -277,82 +277,103 @@ License Text(http://spdx.org/licenses/Apache-2.0.html)
 Package: wis3d (version per module pyproject.toml)
 Project URL: https://github.com/zju3dv/Wis3D
 
-## Vendored / bundled upstream model code
+## Bundled upstream code redistributed in this source tree
+
+The following upstream code is committed in this repository and is therefore
+redistributed as part of the source release. Each retains its own upstream
+copyright headers and (where present) its own LICENSE file in-tree, and is NOT
+relicensed under this project's Apache-2.0 / CC-BY-4.0 terms.
 
 Copyright NVIDIA Corporation & affiliates - NVIDIA Source Code License (Non-Commercial)
-Attribution Statements: This component IS redistributed in source form under modules/v2d_foundation_pose/lib/FoundationPose/, which retains its own LICENSE file. It is NOT covered by this project's Apache-2.0 / CC-BY-4.0 terms: the NVIDIA Source Code License restricts use to non-commercial (research or evaluation) purposes only, except that NVIDIA and its affiliates may use it commercially. Downstream users must comply with that LICENSE for this subtree.
+Attribution Statements: NVIDIA-authored. Redistributed in source form under modules/v2d_foundation_pose/lib/FoundationPose/, which retains its own LICENSE file. The NVIDIA Source Code License limits use to non-commercial (research/evaluation) purposes, except that NVIDIA and its affiliates may use it commercially. As NVIDIA's own IP, NVIDIA elects to redistribute it under this license; it is not covered by, and not relicensed under, this project's Apache-2.0/CC-BY-4.0 terms.
 License Text(https://github.com/NVlabs/FoundationPose/blob/main/LICENSE.txt)
-Package: FoundationPose (vendored source — separately licensed, see subtree LICENSE)
+Package: FoundationPose (redistributed in-tree — separately licensed, see subtree LICENSE)
 Project URL: https://github.com/NVlabs/FoundationPose
 
-Copyright Meta Platforms, Inc. and affiliates - Apache-2.0 License
-Attribution Statements: NVIDIA actively chooses the Apache-2.0 license to apply to files with this copyright and license.
-License Text(http://spdx.org/licenses/Apache-2.0.html)
-Package: SAM 2 / Segment Anything 2 (vendored source)
-Project URL: https://github.com/facebookresearch/sam2
-
 Copyright Meta Platforms, Inc. and affiliates - SAM License
-Attribution Statements: Redistributed in source form under modules/v2d_sam3d_body/lib/sam_3d_body/, retaining its Meta copyright headers. The SAM License is a permissive license (commercial use permitted) with acceptable-use restrictions; it is not an SPDX-listed identifier. The upstream SAM License text should be bundled alongside this subtree.
+Attribution Statements: Redistributed in source form under modules/v2d_sam3d_body/lib/sam_3d_body/, retaining its Meta copyright headers, with the upstream SAM License text bundled in that subtree (modules/v2d_sam3d_body/lib/sam_3d_body/LICENSE). The SAM License permits commercial use, subject to acceptable-use restrictions; it is a Meta custom license, not an SPDX identifier. Not covered by this project's Apache-2.0/CC-BY-4.0 terms.
 License Text(https://github.com/facebookresearch/sam-3d-body/blob/main/LICENSE)
-Package: SAM3D-Body / sam_3d_body (vendored source — separately licensed under the SAM License)
+Package: SAM3D-Body / sam_3d_body (redistributed in-tree — separately licensed under the SAM License)
 Project URL: https://github.com/facebookresearch/sam-3d-body
 
-Copyright Microsoft Corporation - MIT License
-Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
-License Text(http://spdx.org/licenses/MIT.html)
-Package: MoGe (vendored source)
-Project URL: https://github.com/microsoft/MoGe
-
-Copyright Luigi Piccinelli (ETH Zurich) - CC-BY-NC-4.0 License
-Attribution Statements: NVIDIA actively chooses the CC-BY-NC-4.0 license to apply to files with this copyright and license.
-License Text(http://spdx.org/licenses/CC-BY-NC-4.0.html)
-Package: UniDepth (vendored source)
-Project URL: https://github.com/lpiccinelli-eth/UniDepth
-
-Copyright Georgios Pavlakos and contributors - MIT License
-Attribution Statements: NVIDIA actively chooses the MIT license to apply to files with this copyright and license.
-License Text(http://spdx.org/licenses/MIT.html)
-Package: HaMeR (vendored source)
-Project URL: https://github.com/geopavlakos/hamer
-
-Copyright Rolandos Alexandros Potamias and contributors - CC-BY-NC-ND-4.0 License
-Attribution Statements: NVIDIA actively chooses the CC-BY-NC-ND-4.0 license to apply to files with this copyright and license.
-License Text(http://spdx.org/licenses/CC-BY-NC-ND-4.0.html)
-Package: WiLoR (vendored source)
-Project URL: https://github.com/rolpotamias/WiLoR
-
-Copyright Princeton Vision & Learning Lab - BSD-3-Clause License
-Attribution Statements: NVIDIA actively chooses the BSD-3-Clause license to apply to files with this copyright and license.
-License Text(http://spdx.org/licenses/BSD-3-Clause.html)
-Package: DROID-SLAM (vendored source)
-Project URL: https://github.com/princeton-vl/DROID-SLAM
-
 Copyright Meta Platforms, Inc. and affiliates - Apache-2.0 License
-Attribution Statements: NVIDIA actively chooses the Apache-2.0 license to apply to files with this copyright and license.
+Attribution Statements: A small number of permissively-licensed upstream support files are also committed in-tree under their original Apache-2.0 license, retaining their headers: Detectron2 model-config files (modules/v2d_detectron2/lib/cascade_mask_rcnn_vitdet_*.py, build_detector.py) and a SAM2 utility (modules/v2d_sam2/lib/sam2_utils.py).
 License Text(http://spdx.org/licenses/Apache-2.0.html)
-Package: Detectron2 / ViTDet (vendored source)
+Package: Detectron2 / SAM2 support files (redistributed in-tree, permissive Apache-2.0)
 Project URL: https://github.com/facebookresearch/detectron2
 
-Copyright IDEA Research - Apache-2.0 License
-Attribution Statements: NVIDIA actively chooses the Apache-2.0 license to apply to files with this copyright and license.
-License Text(http://spdx.org/licenses/Apache-2.0.html)
-Package: GroundingDINO (vendored source)
-Project URL: https://github.com/IDEA-Research/GroundingDINO
+## Upstream models fetched at build/download time (NOT redistributed in this tree)
 
-Copyright LiheYoung (Lihe Yang) and contributors - Apache-2.0 License
-Attribution Statements: NVIDIA actively chooses the Apache-2.0 license to apply to files with this copyright and license.
-License Text(http://spdx.org/licenses/Apache-2.0.html)
-Package: Depth-Anything (vendored source)
-Project URL: https://github.com/LiheYoung/Depth-Anything
+The following models are NOT redistributed in this repository. Only thin
+NVIDIA-authored wrapper modules are committed under each module's lib/; the
+upstream model code and/or weights are obtained directly from the project URL
+at container-build time (pip / git) or via each module's weight-download step.
+Their license terms govern what the user obtains from upstream, not this source
+distribution. They are listed for completeness, including non-commercial terms
+that downstream users should be aware of.
+
+Copyright Luigi Piccinelli (ETH Zurich) - CC-BY-NC-4.0 License
+Attribution Statements: Fetched from the project URL; not redistributed in this source tree. Non-commercial license — applies to the upstream model the user obtains.
+License Text(http://spdx.org/licenses/CC-BY-NC-4.0.html)
+Package: UniDepth (fetched at build)
+Project URL: https://github.com/lpiccinelli-eth/UniDepth
+
+Copyright Rolandos Alexandros Potamias and contributors - CC-BY-NC-ND-4.0 License
+Attribution Statements: Fetched from the project URL; not redistributed in this source tree. Non-commercial, no-derivatives license — applies to the upstream model the user obtains.
+License Text(http://spdx.org/licenses/CC-BY-NC-ND-4.0.html)
+Package: WiLoR (fetched at build)
+Project URL: https://github.com/rolpotamias/WiLoR
 
 Copyright NVIDIA Corporation & affiliates - NVIDIA Source Code License (Non-Commercial)
-Attribution Statements: The upstream model code is obtained at container-build time (not redistributed in this source tree); listed here for completeness as a non-commercial dependency.
+Attribution Statements: NVIDIA-authored. Fetched from the project URL; not redistributed in this source tree. Non-commercial license (NVIDIA and affiliates may use commercially).
 License Text(https://github.com/NVlabs/BundleSDF/blob/master/LICENSE)
 Package: BundleSDF (fetched at build)
 Project URL: https://github.com/NVlabs/BundleSDF
 
 Copyright NVIDIA Corporation & affiliates - NVIDIA Source Code License (Non-Commercial)
-Attribution Statements: The upstream model code is obtained at container-build time (not redistributed in this source tree); listed here for completeness as a non-commercial dependency.
+Attribution Statements: NVIDIA-authored. Fetched from the project URL; not redistributed in this source tree. Non-commercial license (NVIDIA and affiliates may use commercially).
 License Text(https://github.com/NVlabs/FoundationStereo/blob/master/LICENSE)
 Package: FoundationStereo (fetched at build)
 Project URL: https://github.com/NVlabs/FoundationStereo
+
+Copyright Microsoft Corporation - MIT License
+Attribution Statements: Fetched from the project URL; not redistributed in this source tree.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: MoGe (fetched at build)
+Project URL: https://github.com/microsoft/MoGe
+
+Copyright Meta Platforms, Inc. and affiliates - Apache-2.0 License
+Attribution Statements: Fetched from the project URL; not redistributed in this source tree.
+License Text(http://spdx.org/licenses/Apache-2.0.html)
+Package: SAM 2 / Segment Anything 2 (fetched at build)
+Project URL: https://github.com/facebookresearch/sam2
+
+Copyright IDEA Research - Apache-2.0 License
+Attribution Statements: Fetched from the project URL; not redistributed in this source tree.
+License Text(http://spdx.org/licenses/Apache-2.0.html)
+Package: GroundingDINO (fetched at build)
+Project URL: https://github.com/IDEA-Research/GroundingDINO
+
+Copyright Princeton Vision & Learning Lab - BSD-3-Clause License
+Attribution Statements: Fetched from the project URL; not redistributed in this source tree.
+License Text(http://spdx.org/licenses/BSD-3-Clause.html)
+Package: DROID-SLAM (fetched at build)
+Project URL: https://github.com/princeton-vl/DROID-SLAM
+
+Copyright Meta Platforms, Inc. and affiliates - Apache-2.0 License
+Attribution Statements: Fetched from the project URL; not redistributed in this source tree. (A few model-config support files are committed in-tree — see the redistributed section above.)
+License Text(http://spdx.org/licenses/Apache-2.0.html)
+Package: Detectron2 / ViTDet (fetched at build)
+Project URL: https://github.com/facebookresearch/detectron2
+
+Copyright LiheYoung (Lihe Yang) and contributors - Apache-2.0 License
+Attribution Statements: Fetched from the project URL; not redistributed in this source tree.
+License Text(http://spdx.org/licenses/Apache-2.0.html)
+Package: Depth-Anything (fetched at build)
+Project URL: https://github.com/LiheYoung/Depth-Anything
+
+Copyright Georgios Pavlakos and contributors - MIT License
+Attribution Statements: Fetched from the project URL; not redistributed in this source tree.
+License Text(http://spdx.org/licenses/MIT.html)
+Package: HaMeR (fetched at build)
+Project URL: https://github.com/geopavlakos/hamer

--- a/reconstruction/modules/v2d_anycalib/docker/__init__.py
+++ b/reconstruction/modules/v2d_anycalib/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_anycalib/docker/_config.py
+++ b/reconstruction/modules/v2d_anycalib/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_anycalib"

--- a/reconstruction/modules/v2d_anycalib/docker/build.py
+++ b/reconstruction/modules/v2d_anycalib/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 

--- a/reconstruction/modules/v2d_anycalib/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_anycalib/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_anycalib/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_anycalib/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import os
 import subprocess

--- a/reconstruction/modules/v2d_anycalib/docker/run_image_folder_to_calibration.py
+++ b/reconstruction/modules/v2d_anycalib/docker/run_image_folder_to_calibration.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.anycalib.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_anycalib/docker/run_image_to_calibration.py
+++ b/reconstruction/modules/v2d_anycalib/docker/run_image_to_calibration.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.anycalib.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_anycalib/docker/run_shell.py
+++ b/reconstruction/modules/v2d_anycalib/docker/run_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 

--- a/reconstruction/modules/v2d_anycalib/docker/run_video_to_calibration.py
+++ b/reconstruction/modules/v2d_anycalib/docker/run_video_to_calibration.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.anycalib.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_anycalib/lib/__init__.py
+++ b/reconstruction/modules/v2d_anycalib/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_anycalib/lib/_anycalib.py
+++ b/reconstruction/modules/v2d_anycalib/lib/_anycalib.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """AnyCalib model loader + thin inference helper.
 
 AnyCalib (Tirado-Garín & Civera, 2024) is a learned single-view camera

--- a/reconstruction/modules/v2d_anycalib/lib/_undistort.py
+++ b/reconstruction/modules/v2d_anycalib/lib/_undistort.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """OpenCV-based undistortion for the camera models AnyCalib emits.
 
 We support the two most common output models:

--- a/reconstruction/modules/v2d_anycalib/lib/download_weights.py
+++ b/reconstruction/modules/v2d_anycalib/lib/download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Pre-download AnyCalib weights into a torch hub cache directory.
 
 AnyCalib auto-fetches its checkpoint from GitHub Releases on first instantiation

--- a/reconstruction/modules/v2d_anycalib/lib/image_folder_to_calibration.py
+++ b/reconstruction/modules/v2d_anycalib/lib/image_folder_to_calibration.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """AnyCalib: estimate intrinsics + distortion from a folder of images, then
 optionally write undistorted copies of every image to an output folder.
 

--- a/reconstruction/modules/v2d_anycalib/lib/image_to_calibration.py
+++ b/reconstruction/modules/v2d_anycalib/lib/image_to_calibration.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """AnyCalib: estimate intrinsics + distortion from a single image, optionally
 write an undistorted copy of the input.
 

--- a/reconstruction/modules/v2d_anycalib/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_anycalib/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_anycalib/lib/video_to_calibration.py
+++ b/reconstruction/modules/v2d_anycalib/lib/video_to_calibration.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """AnyCalib: estimate intrinsics + distortion from a video, optionally write an
 undistorted copy of the video.
 

--- a/reconstruction/modules/v2d_bundlesdf/__init__.py
+++ b/reconstruction/modules/v2d_bundlesdf/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_bundlesdf/docker/__init__.py
+++ b/reconstruction/modules/v2d_bundlesdf/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_bundlesdf/docker/build.py
+++ b/reconstruction/modules/v2d_bundlesdf/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 from pathlib import Path
 

--- a/reconstruction/modules/v2d_bundlesdf/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_bundlesdf/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_bundlesdf/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_bundlesdf/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import os
 import subprocess

--- a/reconstruction/modules/v2d_bundlesdf/docker/run_reconstruct.py
+++ b/reconstruction/modules/v2d_bundlesdf/docker/run_reconstruct.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Run BundleSDF SDF training and texture baking with pre-computed depth and masks.
 

--- a/reconstruction/modules/v2d_bundlesdf/lib/__init__.py
+++ b/reconstruction/modules/v2d_bundlesdf/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_bundlesdf/lib/data/configs/hoi_pipeline.yaml
+++ b/reconstruction/modules/v2d_bundlesdf/lib/data/configs/hoi_pipeline.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # HOI Object Reconstruction — Pipeline Configuration
 #
 # Controls the orchestration-level behaviour of each pipeline step.

--- a/reconstruction/modules/v2d_bundlesdf/lib/data/configs/theseus_optimizer_hawk.yaml
+++ b/reconstruction/modules/v2d_bundlesdf/lib/data/configs/theseus_optimizer_hawk.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # Configuration for NVIDIA Hawk stereo camera
 # Resolution: 1920x1200, fx=fy=852.41, cx=946.45, cy=556.80, baseline=0.1496m
 #

--- a/reconstruction/modules/v2d_bundlesdf/lib/download_weights.py
+++ b/reconstruction/modules/v2d_bundlesdf/lib/download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Download BundleSDF weights (RoMA feature matcher).
 

--- a/reconstruction/modules/v2d_bundlesdf/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_bundlesdf/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_bundlesdf/lib/reconstruct.py
+++ b/reconstruction/modules/v2d_bundlesdf/lib/reconstruct.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Run BundleSDF reconstruction with pre-computed camera poses.
 

--- a/reconstruction/modules/v2d_bundlesdf/tools/fuse_depth_to_pointcloud.py
+++ b/reconstruction/modules/v2d_bundlesdf/tools/fuse_depth_to_pointcloud.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Fuse depth maps into a single world-frame point cloud using camera poses.
 

--- a/reconstruction/modules/v2d_bundlesdf/tools/visualize_reconstruction_standalone.py
+++ b/reconstruction/modules/v2d_bundlesdf/tools/visualize_reconstruction_standalone.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Standalone visualization of camera poses and point cloud from keyframes.yml.
 

--- a/reconstruction/modules/v2d_common/__init__.py
+++ b/reconstruction/modules/v2d_common/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # v2d.common package
 from v2d.common.broadcast import (
     apply_output_pattern,

--- a/reconstruction/modules/v2d_common/broadcast.py
+++ b/reconstruction/modules/v2d_common/broadcast.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import glob
 from pathlib import Path
 

--- a/reconstruction/modules/v2d_common/datatypes.py
+++ b/reconstruction/modules/v2d_common/datatypes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from dataclasses import dataclass
 import json
 import numpy as np

--- a/reconstruction/modules/v2d_common/pyproject.toml
+++ b/reconstruction/modules/v2d_common/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_common/utils.py
+++ b/reconstruction/modules/v2d_common/utils.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Video utility functions: frame extraction, video encoding, and stitching."""
 import glob
 import os

--- a/reconstruction/modules/v2d_common/video.py
+++ b/reconstruction/modules/v2d_common/video.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Frame I/O utilities: FrameSource (read), FrameWriter (write), and video helpers.
 
 Moved here from ``v2d.mv.io.video`` so that all modules can use frame I/O

--- a/reconstruction/modules/v2d_cusfm/__init__.py
+++ b/reconstruction/modules/v2d_cusfm/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_cusfm/configs/backpack/cuvslam_config/default.yaml
+++ b/reconstruction/modules/v2d_cusfm/configs/backpack/cuvslam_config/default.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 cuvslam:
   # Core SLAM settings
   cfg_enable_slam: true # override: true

--- a/reconstruction/modules/v2d_cusfm/configs/cuvslam_config/default.yaml
+++ b/reconstruction/modules/v2d_cusfm/configs/cuvslam_config/default.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 cuvslam:
   # Core SLAM settings
   cfg_enable_slam: true # override: true

--- a/reconstruction/modules/v2d_cusfm/docker/__init__.py
+++ b/reconstruction/modules/v2d_cusfm/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_cusfm/docker/build.py
+++ b/reconstruction/modules/v2d_cusfm/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 from pathlib import Path
 

--- a/reconstruction/modules/v2d_cusfm/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_cusfm/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_cusfm/docker/run_image_list_to_sfm.py
+++ b/reconstruction/modules/v2d_cusfm/docker/run_image_list_to_sfm.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Run CuSFM structure-from-motion on a directory of stereo images.
 

--- a/reconstruction/modules/v2d_cusfm/lib/__init__.py
+++ b/reconstruction/modules/v2d_cusfm/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_cusfm/lib/image_list_to_sfm.py
+++ b/reconstruction/modules/v2d_cusfm/lib/image_list_to_sfm.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Run pyCuSFM on a directory of images to produce camera poses.
 

--- a/reconstruction/modules/v2d_cusfm/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_cusfm/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_depth/lib/__init__.py
+++ b/reconstruction/modules/v2d_depth/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_depth/lib/align_depth_sequence.py
+++ b/reconstruction/modules/v2d_depth/lib/align_depth_sequence.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Temporal scale alignment for monocular depth sequences.
 

--- a/reconstruction/modules/v2d_depth/lib/stabilize_intrinsics.py
+++ b/reconstruction/modules/v2d_depth/lib/stabilize_intrinsics.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Stabilise per-frame camera intrinsics produced by monocular depth models.
 

--- a/reconstruction/modules/v2d_depth/pyproject.toml
+++ b/reconstruction/modules/v2d_depth/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_depth_anything/docker/__init__.py
+++ b/reconstruction/modules/v2d_depth_anything/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_depth_anything/docker/_config.py
+++ b/reconstruction/modules/v2d_depth_anything/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_depth_anything"

--- a/reconstruction/modules/v2d_depth_anything/docker/build.py
+++ b/reconstruction/modules/v2d_depth_anything/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_depth_anything/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_depth_anything/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_depth_anything/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_depth_anything/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.depth_anything.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_depth_anything/docker/run_image_to_depth.py
+++ b/reconstruction/modules/v2d_depth_anything/docker/run_image_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.depth_anything.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_depth_anything/docker/run_shell.py
+++ b/reconstruction/modules/v2d_depth_anything/docker/run_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.depth_anything.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_depth_anything/docker/run_video_to_depth.py
+++ b/reconstruction/modules/v2d_depth_anything/docker/run_video_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.depth_anything.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_depth_anything/lib/__init__.py
+++ b/reconstruction/modules/v2d_depth_anything/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_depth_anything/lib/download_weights.py
+++ b/reconstruction/modules/v2d_depth_anything/lib/download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 from huggingface_hub import snapshot_download
 

--- a/reconstruction/modules/v2d_depth_anything/lib/image_to_depth.py
+++ b/reconstruction/modules/v2d_depth_anything/lib/image_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Depth Anything 3 single image to depth processing function.
 Can be called directly from command line or imported as a function.

--- a/reconstruction/modules/v2d_depth_anything/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_depth_anything/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_depth_anything/lib/video_to_depth.py
+++ b/reconstruction/modules/v2d_depth_anything/lib/video_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Depth Anything 3 video to depth processing function.
 Can be called directly from command line or imported as a function.

--- a/reconstruction/modules/v2d_detectron2/docker/__init__.py
+++ b/reconstruction/modules/v2d_detectron2/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_detectron2/docker/_config.py
+++ b/reconstruction/modules/v2d_detectron2/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_detectron2"

--- a/reconstruction/modules/v2d_detectron2/docker/build.py
+++ b/reconstruction/modules/v2d_detectron2/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_detectron2/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_detectron2/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_detectron2/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_detectron2/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 from v2d.detectron2.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_detectron2/docker/run_mv_track_bboxes.py
+++ b/reconstruction/modules/v2d_detectron2/docker/run_mv_track_bboxes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_detectron2/docker/run_shell.py
+++ b/reconstruction/modules/v2d_detectron2/docker/run_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.detectron2.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_detectron2/docker/run_track_bboxes.py
+++ b/reconstruction/modules/v2d_detectron2/docker/run_track_bboxes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.detectron2.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_detectron2/lib/__init__.py
+++ b/reconstruction/modules/v2d_detectron2/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_detectron2/lib/bytetracker.py
+++ b/reconstruction/modules/v2d_detectron2/lib/bytetracker.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """ByteTrack multi-object tracker.
 
 Implements the two-stage association strategy from:

--- a/reconstruction/modules/v2d_detectron2/lib/download_weights.py
+++ b/reconstruction/modules/v2d_detectron2/lib/download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import urllib.request
 from pathlib import Path

--- a/reconstruction/modules/v2d_detectron2/lib/mv_track_bboxes.py
+++ b/reconstruction/modules/v2d_detectron2/lib/mv_track_bboxes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 import torch

--- a/reconstruction/modules/v2d_detectron2/lib/mv_track_bboxes.yaml
+++ b/reconstruction/modules/v2d_detectron2/lib/mv_track_bboxes.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 rgb_dir: ???
 output_dir: ???
 

--- a/reconstruction/modules/v2d_detectron2/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_detectron2/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_detectron2/lib/track_bboxes.py
+++ b/reconstruction/modules/v2d_detectron2/lib/track_bboxes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import argparse

--- a/reconstruction/modules/v2d_detectron2/lib/tracker.py
+++ b/reconstruction/modules/v2d_detectron2/lib/tracker.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/reconstruction/modules/v2d_docker/__init__.py
+++ b/reconstruction/modules/v2d_docker/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 
 __all__ = ["run_in_container"]

--- a/reconstruction/modules/v2d_docker/container.py
+++ b/reconstruction/modules/v2d_docker/container.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 from pathlib import Path

--- a/reconstruction/modules/v2d_docker/pyproject.toml
+++ b/reconstruction/modules/v2d_docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_droid_slam/docker/__init__.py
+++ b/reconstruction/modules/v2d_droid_slam/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_droid_slam/docker/_config.py
+++ b/reconstruction/modules/v2d_droid_slam/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_droid_slam"

--- a/reconstruction/modules/v2d_droid_slam/docker/build.py
+++ b/reconstruction/modules/v2d_droid_slam/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 

--- a/reconstruction/modules/v2d_droid_slam/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_droid_slam/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_droid_slam/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_droid_slam/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 

--- a/reconstruction/modules/v2d_droid_slam/docker/run_image_list_to_slam.py
+++ b/reconstruction/modules/v2d_droid_slam/docker/run_image_list_to_slam.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.droid_slam.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_droid_slam/docker/run_video_to_slam.py
+++ b/reconstruction/modules/v2d_droid_slam/docker/run_video_to_slam.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.droid_slam.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_droid_slam/lib/__init__.py
+++ b/reconstruction/modules/v2d_droid_slam/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_droid_slam/lib/_slam.py
+++ b/reconstruction/modules/v2d_droid_slam/lib/_slam.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Internal DROID-SLAM driver shared by video_to_slam and image_list_to_slam.
 

--- a/reconstruction/modules/v2d_droid_slam/lib/download_weights.py
+++ b/reconstruction/modules/v2d_droid_slam/lib/download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Download the DROID-SLAM checkpoint (droid.pth) into a local weights folder.
 

--- a/reconstruction/modules/v2d_droid_slam/lib/image_list_to_slam.py
+++ b/reconstruction/modules/v2d_droid_slam/lib/image_list_to_slam.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Run DROID-SLAM on a folder of frame images → per-frame camera poses
 (+ optional depth, PLY). Sibling of video_to_slam with the same options.

--- a/reconstruction/modules/v2d_droid_slam/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_droid_slam/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_droid_slam/lib/video_to_slam.py
+++ b/reconstruction/modules/v2d_droid_slam/lib/video_to_slam.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Run DROID-SLAM on a video file → per-frame camera poses (+ optional depth, PLY).
 

--- a/reconstruction/modules/v2d_droid_slam/tools/poses_to_frustums.py
+++ b/reconstruction/modules/v2d_droid_slam/tools/poses_to_frustums.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Convert a folder of Transform3d (camera-to-world) JSONs into a PLY of camera
 frustum wireframes. Open this PLY alongside the point cloud in MeshLab (or

--- a/reconstruction/modules/v2d_ego_hand_reconstruction/__init__.py
+++ b/reconstruction/modules/v2d_ego_hand_reconstruction/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_ego_hand_reconstruction/diff.sh
+++ b/reconstruction/modules/v2d_ego_hand_reconstruction/diff.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # Show local modifications to vendored content vs upstream IsaacTeleop.
 # Usage: ./diff.sh            (summary of changed files)
 #        ./diff.sh --full     (full unified diff)

--- a/reconstruction/modules/v2d_ego_hand_reconstruction/docker/__init__.py
+++ b/reconstruction/modules/v2d_ego_hand_reconstruction/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_ego_hand_reconstruction/docker/_config.py
+++ b/reconstruction/modules/v2d_ego_hand_reconstruction/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 MODULE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))

--- a/reconstruction/modules/v2d_ego_hand_reconstruction/docker/build.py
+++ b/reconstruction/modules/v2d_ego_hand_reconstruction/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Build Docker images for ego hand reconstruction (ViPE + Dyn-HaMR).
 
 Delegates to the vendored shell scripts so build flags stay in sync with

--- a/reconstruction/modules/v2d_ego_hand_reconstruction/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_ego_hand_reconstruction/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_ego_hand_reconstruction/docker/run_mesh_generation.py
+++ b/reconstruction/modules/v2d_ego_hand_reconstruction/docker/run_mesh_generation.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Export per-track MANO hand meshes and joint trajectories from Dyn-HaMR results.
 
 Delegates to the vendored ``run_mesh_generation.sh`` so mesh export logic stays

--- a/reconstruction/modules/v2d_ego_hand_reconstruction/docker/run_reconstruction.py
+++ b/reconstruction/modules/v2d_ego_hand_reconstruction/docker/run_reconstruction.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Run ego hand reconstruction pipeline (ViPE camera estimation + Dyn-HaMR).
 
 Delegates to the vendored ``run_reconstruction.sh`` so pipeline logic stays in

--- a/reconstruction/modules/v2d_ego_hand_reconstruction/sync.sh
+++ b/reconstruction/modules/v2d_ego_hand_reconstruction/sync.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/reconstruction/modules/v2d_foundation_pose/docker/__init__.py
+++ b/reconstruction/modules/v2d_foundation_pose/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_foundation_pose/docker/_config.py
+++ b/reconstruction/modules/v2d_foundation_pose/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_foundation_pose"

--- a/reconstruction/modules/v2d_foundation_pose/docker/build.py
+++ b/reconstruction/modules/v2d_foundation_pose/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_foundation_pose/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_foundation_pose/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_foundation_pose/docker/run_align_depth_to_object.py
+++ b/reconstruction/modules/v2d_foundation_pose/docker/run_align_depth_to_object.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 from v2d.docker.container import run_in_container
 from v2d.foundation_pose.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_foundation_pose/docker/run_align_depth_to_reference_depth.py
+++ b/reconstruction/modules/v2d_foundation_pose/docker/run_align_depth_to_reference_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 from v2d.docker.container import run_in_container
 from v2d.foundation_pose.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_foundation_pose/docker/run_correct_depth_scale.py
+++ b/reconstruction/modules/v2d_foundation_pose/docker/run_correct_depth_scale.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 from v2d.docker.container import run_in_container
 from v2d.foundation_pose.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_foundation_pose/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_foundation_pose/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.foundation_pose.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_foundation_pose/docker/run_ekf_smoothing.py
+++ b/reconstruction/modules/v2d_foundation_pose/docker/run_ekf_smoothing.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 from v2d.docker.container import run_in_container
 from v2d.foundation_pose.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_foundation_pose/docker/run_estimate_mesh_scale.py
+++ b/reconstruction/modules/v2d_foundation_pose/docker/run_estimate_mesh_scale.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 from v2d.docker.container import run_in_container
 from v2d.foundation_pose.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_foundation_pose/docker/run_mv_videos_to_poses.py
+++ b/reconstruction/modules/v2d_foundation_pose/docker/run_mv_videos_to_poses.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_foundation_pose/docker/run_render_poses.py
+++ b/reconstruction/modules/v2d_foundation_pose/docker/run_render_poses.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 from v2d.docker.container import run_in_container
 from v2d.foundation_pose.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_foundation_pose/docker/run_shell.py
+++ b/reconstruction/modules/v2d_foundation_pose/docker/run_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.foundation_pose.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_foundation_pose/docker/run_video_to_poses.py
+++ b/reconstruction/modules/v2d_foundation_pose/docker/run_video_to_poses.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 from v2d.docker.container import run_in_container
 from v2d.foundation_pose.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_foundation_pose/lib/__init__.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_foundation_pose/lib/depth_alignment.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/depth_alignment.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Temporal depth alignment via ICP on scene point clouds.
 
 Aligns raw monocular depth for each frame to a metric reference depth by

--- a/reconstruction/modules/v2d_foundation_pose/lib/download_weights.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Download FoundationPose weights from Google Drive.
 

--- a/reconstruction/modules/v2d_foundation_pose/lib/foundation_pose_tracker.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/foundation_pose_tracker.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Stateful FoundationPose tracker.
 
 Lifecycle:

--- a/reconstruction/modules/v2d_foundation_pose/lib/fp_utils.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/fp_utils.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Re-export commonly used FoundationPose utility functions.
 

--- a/reconstruction/modules/v2d_foundation_pose/lib/multiview_tracker.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/multiview_tracker.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Multi-view 6-DoF object tracker using FoundationPose.
 
 Creates N FoundationPose estimators with shared weights (scorer, refiner,

--- a/reconstruction/modules/v2d_foundation_pose/lib/mv_videos_to_poses.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/mv_videos_to_poses.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Multi-view 6-DoF object tracking with FoundationPose."""
 
 import argparse

--- a/reconstruction/modules/v2d_foundation_pose/lib/mv_videos_to_poses.yaml
+++ b/reconstruction/modules/v2d_foundation_pose/lib/mv_videos_to_poses.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 rig_config: stereo-4
 cameras: [0, 2, 4, 6]
 mask_obj_id: 0

--- a/reconstruction/modules/v2d_foundation_pose/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_foundation_pose/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_foundation_pose/lib/render_overlay.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/render_overlay.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Render mesh overlay on video frames using per-frame object-to-camera poses.
 

--- a/reconstruction/modules/v2d_foundation_pose/lib/run_align_depth_to_object.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/run_align_depth_to_object.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Align raw monocular depth to an object mesh via FP-guided affine grid search.
 
 Searches over (scale, shift) in D_aligned = scale * D_raw + shift and returns

--- a/reconstruction/modules/v2d_foundation_pose/lib/run_align_depth_to_reference_depth.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/run_align_depth_to_reference_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Align a folder of raw depth images to a metric reference depth via ICP + affine solve.
 
 For each frame in depth_folder, finds (scale, shift) such that

--- a/reconstruction/modules/v2d_foundation_pose/lib/run_correct_depth_scale.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/run_correct_depth_scale.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 FP-guided per-frame depth scale correction.
 

--- a/reconstruction/modules/v2d_foundation_pose/lib/run_ekf_smoothing.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/run_ekf_smoothing.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 EKF + RTS smoother for FoundationPose output pose sequences.
 

--- a/reconstruction/modules/v2d_foundation_pose/lib/run_estimate_mesh_scale.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/run_estimate_mesh_scale.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Estimate the scale factor between a mesh and a scene's metric depth.
 

--- a/reconstruction/modules/v2d_foundation_pose/lib/run_render_poses.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/run_render_poses.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 GPU-batched mesh overlay renderer using nvdiffrast.
 

--- a/reconstruction/modules/v2d_foundation_pose/lib/run_video_to_poses.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/run_video_to_poses.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 FoundationPose video-to-poses processing function.
 Can be called directly from command line or imported as a function.

--- a/reconstruction/modules/v2d_foundation_pose/lib/symmetry.py
+++ b/reconstruction/modules/v2d_foundation_pose/lib/symmetry.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Symmetry-aware pose canonicalization for multi-view FoundationPose.
 
 Loads BOP-style symmetry annotations produced by hoi-tools' compute_symmetry

--- a/reconstruction/modules/v2d_foundation_stereo/docker/__init__.py
+++ b/reconstruction/modules/v2d_foundation_stereo/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_foundation_stereo/docker/_config.py
+++ b/reconstruction/modules/v2d_foundation_stereo/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_foundation_stereo"

--- a/reconstruction/modules/v2d_foundation_stereo/docker/build.py
+++ b/reconstruction/modules/v2d_foundation_stereo/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_foundation_stereo/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_foundation_stereo/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_foundation_stereo/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_foundation_stereo/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.foundation_stereo.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_foundation_stereo/docker/run_export_engine.py
+++ b/reconstruction/modules/v2d_foundation_stereo/docker/run_export_engine.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.foundation_stereo.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_foundation_stereo/docker/run_image_list_to_depth.py
+++ b/reconstruction/modules/v2d_foundation_stereo/docker/run_image_list_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.foundation_stereo.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_foundation_stereo/docker/run_image_to_depth.py
+++ b/reconstruction/modules/v2d_foundation_stereo/docker/run_image_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.foundation_stereo.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_foundation_stereo/docker/run_mv_image_list_to_depth.py
+++ b/reconstruction/modules/v2d_foundation_stereo/docker/run_mv_image_list_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_foundation_stereo/docker/run_shell.py
+++ b/reconstruction/modules/v2d_foundation_stereo/docker/run_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.foundation_stereo.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_foundation_stereo/lib/__init__.py
+++ b/reconstruction/modules/v2d_foundation_stereo/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_foundation_stereo/lib/download_weights.py
+++ b/reconstruction/modules/v2d_foundation_stereo/lib/download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Download Foundation Stereo ONNX model from NVIDIA NGC.
 
 The TensorRT engine is compiled at runtime (GPU-architecture-specific).

--- a/reconstruction/modules/v2d_foundation_stereo/lib/export_engine.py
+++ b/reconstruction/modules/v2d_foundation_stereo/lib/export_engine.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Export Foundation Stereo ONNX model to a TensorRT engine.
 
 The engine filename is versioned by TensorRT version + GPU SM to allow caching

--- a/reconstruction/modules/v2d_foundation_stereo/lib/image_list_to_depth.py
+++ b/reconstruction/modules/v2d_foundation_stereo/lib/image_list_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Foundation Stereo: process a synchronized stereo image directory pair to depth maps.
 
 Takes two directories of images with matching filenames (left_dir and right_dir),

--- a/reconstruction/modules/v2d_foundation_stereo/lib/image_to_depth.py
+++ b/reconstruction/modules/v2d_foundation_stereo/lib/image_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Foundation Stereo: process a single stereo image pair to a depth map.
 
 Usage:

--- a/reconstruction/modules/v2d_foundation_stereo/lib/mv_image_list_to_depth.py
+++ b/reconstruction/modules/v2d_foundation_stereo/lib/mv_image_list_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Multi-view stereo depth estimation using Foundation Stereo TRT.
 
 Iterates over stereo pairs from a rig config, reads calibration from EDEX,

--- a/reconstruction/modules/v2d_foundation_stereo/lib/mv_image_list_to_depth.yaml
+++ b/reconstruction/modules/v2d_foundation_stereo/lib/mv_image_list_to_depth.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 camera_params_path: ???
 rgb_dir: ???
 output_dir: ???

--- a/reconstruction/modules/v2d_foundation_stereo/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_foundation_stereo/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_foundation_stereo/lib/trt_inference.py
+++ b/reconstruction/modules/v2d_foundation_stereo/lib/trt_inference.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """TensorRT-based Foundation Stereo inference for stereo depth estimation.
 
 Adapted from real2sim's tensorrt_inference_base.py, stereo_inference_base.py,

--- a/reconstruction/modules/v2d_grounding_dino/docker/__init__.py
+++ b/reconstruction/modules/v2d_grounding_dino/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_grounding_dino/docker/_config.py
+++ b/reconstruction/modules/v2d_grounding_dino/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_grounding_dino"

--- a/reconstruction/modules/v2d_grounding_dino/docker/build.py
+++ b/reconstruction/modules/v2d_grounding_dino/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_grounding_dino/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_grounding_dino/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_grounding_dino/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_grounding_dino/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.grounding_dino.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_grounding_dino/docker/run_image_list_to_object_bboxes.py
+++ b/reconstruction/modules/v2d_grounding_dino/docker/run_image_list_to_object_bboxes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.grounding_dino.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_grounding_dino/docker/run_image_to_object_bboxes.py
+++ b/reconstruction/modules/v2d_grounding_dino/docker/run_image_to_object_bboxes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.grounding_dino.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_grounding_dino/docker/run_mv_image_list_to_object_bboxes.py
+++ b/reconstruction/modules/v2d_grounding_dino/docker/run_mv_image_list_to_object_bboxes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_grounding_dino/docker/run_shell.py
+++ b/reconstruction/modules/v2d_grounding_dino/docker/run_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.grounding_dino.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_grounding_dino/docker/run_video_to_object_bboxes.py
+++ b/reconstruction/modules/v2d_grounding_dino/docker/run_video_to_object_bboxes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.grounding_dino.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_grounding_dino/lib/__init__.py
+++ b/reconstruction/modules/v2d_grounding_dino/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_grounding_dino/lib/download_weights.py
+++ b/reconstruction/modules/v2d_grounding_dino/lib/download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Download GroundingDINO SwinT-OGC checkpoint."""
 import argparse
 import os

--- a/reconstruction/modules/v2d_grounding_dino/lib/image_list_to_object_bboxes.py
+++ b/reconstruction/modules/v2d_grounding_dino/lib/image_list_to_object_bboxes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Grounding DINO: detect objects in a directory of images using a text prompt.
 
 Usage:

--- a/reconstruction/modules/v2d_grounding_dino/lib/image_to_object_bboxes.py
+++ b/reconstruction/modules/v2d_grounding_dino/lib/image_to_object_bboxes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Grounding DINO: detect objects in a single image using a text prompt.
 
 Usage:

--- a/reconstruction/modules/v2d_grounding_dino/lib/mv_image_list_to_object_bboxes.py
+++ b/reconstruction/modules/v2d_grounding_dino/lib/mv_image_list_to_object_bboxes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Multi-view Grounding DINO: detect objects across cameras using a text prompt.
 
 Reads the object prompt from a plain-text file and runs detection on a subset

--- a/reconstruction/modules/v2d_grounding_dino/lib/mv_image_list_to_object_bboxes.yaml
+++ b/reconstruction/modules/v2d_grounding_dino/lib/mv_image_list_to_object_bboxes.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 rig_config: stereo-4
 cameras: [0, 2, 4, 6]
 

--- a/reconstruction/modules/v2d_grounding_dino/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_grounding_dino/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_grounding_dino/lib/video_to_object_bboxes.py
+++ b/reconstruction/modules/v2d_grounding_dino/lib/video_to_object_bboxes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Grounding DINO: detect objects in every frame of a video using a text prompt.
 
 Usage:

--- a/reconstruction/modules/v2d_grounding_dino/lib/vis.py
+++ b/reconstruction/modules/v2d_grounding_dino/lib/vis.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Visualization utilities for Grounding DINO bounding box outputs.
 
 Draws detected bounding boxes on images/video frames and saves debug images.

--- a/reconstruction/modules/v2d_gsplat_refinement/docker/__init__.py
+++ b/reconstruction/modules/v2d_gsplat_refinement/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_gsplat_refinement/docker/_config.py
+++ b/reconstruction/modules/v2d_gsplat_refinement/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_gsplat_refinement"

--- a/reconstruction/modules/v2d_gsplat_refinement/docker/build.py
+++ b/reconstruction/modules/v2d_gsplat_refinement/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 

--- a/reconstruction/modules/v2d_gsplat_refinement/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_gsplat_refinement/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_gsplat_refinement/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_gsplat_refinement/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """No-op weights downloader.
 
 This module has no model weights of its own — gsplat ships its CUDA kernels

--- a/reconstruction/modules/v2d_gsplat_refinement/docker/run_refine.py
+++ b/reconstruction/modules/v2d_gsplat_refinement/docker/run_refine.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.gsplat_refinement.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_gsplat_refinement/docker/run_visualize.py
+++ b/reconstruction/modules/v2d_gsplat_refinement/docker/run_visualize.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Interactive viewer for a trained gsplat checkpoint.
 
 Docker orchestration around ``v2d.gsplat_refinement.lib.visualize``. Runs the

--- a/reconstruction/modules/v2d_gsplat_refinement/lib/__init__.py
+++ b/reconstruction/modules/v2d_gsplat_refinement/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_gsplat_refinement/lib/background.py
+++ b/reconstruction/modules/v2d_gsplat_refinement/lib/background.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Background Gaussian set + per-frame rigid background→camera pose.
 
 Models the static scene behind the foreground hand+object so the

--- a/reconstruction/modules/v2d_gsplat_refinement/lib/gaussians.py
+++ b/reconstruction/modules/v2d_gsplat_refinement/lib/gaussians.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Gaussian primitive sets for joint hand+object refinement.
 
 Two sets, both following the standard 3DGS parameterization (means / quats /

--- a/reconstruction/modules/v2d_gsplat_refinement/lib/io.py
+++ b/reconstruction/modules/v2d_gsplat_refinement/lib/io.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """I/O for the gsplat-refinement optimizer.
 
 All loaders return torch tensors on a target device so the optimizer can

--- a/reconstruction/modules/v2d_gsplat_refinement/lib/losses.py
+++ b/reconstruction/modules/v2d_gsplat_refinement/lib/losses.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Losses for joint hand+object Gaussian refinement.
 
 Photometric:    L1 between rendered RGB and image RGB, masked to the union

--- a/reconstruction/modules/v2d_gsplat_refinement/lib/pose_fields.py
+++ b/reconstruction/modules/v2d_gsplat_refinement/lib/pose_fields.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Per-frame learnable pose state.
 
 Two modules:

--- a/reconstruction/modules/v2d_gsplat_refinement/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_gsplat_refinement/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_gsplat_refinement/lib/refine.py
+++ b/reconstruction/modules/v2d_gsplat_refinement/lib/refine.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Joint hand+object Gaussian-splatting refinement.
 
 Optimizes:

--- a/reconstruction/modules/v2d_gsplat_refinement/lib/render.py
+++ b/reconstruction/modules/v2d_gsplat_refinement/lib/render.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """gsplat render wrapper for the refinement loop.
 
 Renders Gaussian sets into the camera frame. We build everything already in

--- a/reconstruction/modules/v2d_gsplat_refinement/lib/visualize.py
+++ b/reconstruction/modules/v2d_gsplat_refinement/lib/visualize.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Interactive OpenCV viewer for a v2d_gsplat_refinement checkpoint.
 
 Reconstructs the trained Gaussian sets + pose fields from a checkpoint and

--- a/reconstruction/modules/v2d_hamer/docker/__init__.py
+++ b/reconstruction/modules/v2d_hamer/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_hamer/docker/_config.py
+++ b/reconstruction/modules/v2d_hamer/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_hamer"

--- a/reconstruction/modules/v2d_hamer/docker/build.py
+++ b/reconstruction/modules/v2d_hamer/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 

--- a/reconstruction/modules/v2d_hamer/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_hamer/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_hamer/docker/run_align_hands.py
+++ b/reconstruction/modules/v2d_hamer/docker/run_align_hands.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.hamer.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_hamer/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_hamer/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.hamer.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_hamer/docker/run_masks_to_hands.py
+++ b/reconstruction/modules/v2d_hamer/docker/run_masks_to_hands.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.hamer.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_hamer/docker/run_render_hands_aligned_video.py
+++ b/reconstruction/modules/v2d_hamer/docker/run_render_hands_aligned_video.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.hamer.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_hamer/docker/run_render_hands_video.py
+++ b/reconstruction/modules/v2d_hamer/docker/run_render_hands_video.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.hamer.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_hamer/docker/run_shell.py
+++ b/reconstruction/modules/v2d_hamer/docker/run_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 

--- a/reconstruction/modules/v2d_hamer/lib/__init__.py
+++ b/reconstruction/modules/v2d_hamer/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_hamer/lib/_hamer.py
+++ b/reconstruction/modules/v2d_hamer/lib/_hamer.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Singleton HaMeR loader and per-crop forward helper.
 
 Wraps the upstream API:

--- a/reconstruction/modules/v2d_hamer/lib/align_hands.py
+++ b/reconstruction/modules/v2d_hamer/lib/align_hands.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Per-frame depth alignment of HaMeR predictions.
 
 Takes raw HaMeR JSONs (virtual-pinhole, scaled_focal_length ≈ 25000) plus a

--- a/reconstruction/modules/v2d_hamer/lib/download_weights.py
+++ b/reconstruction/modules/v2d_hamer/lib/download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Download HaMeR demo data + checkpoint.
 
 Downloads ``hamer_demo_data.tar.gz`` from the original HaMeR project page

--- a/reconstruction/modules/v2d_hamer/lib/masks_to_hands.py
+++ b/reconstruction/modules/v2d_hamer/lib/masks_to_hands.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Per-track per-frame HaMeR regression driven by SAM2 hand masks.
 
 For each (track, frame) pair, this module:

--- a/reconstruction/modules/v2d_hamer/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_hamer/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_hamer/lib/render_hands_aligned_video.py
+++ b/reconstruction/modules/v2d_hamer/lib/render_hands_aligned_video.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Render aligned MANO meshes (+ optional object) onto the source video.
 
 Consumes the JSONs written by ``align_hands.py`` (real intrinsics,

--- a/reconstruction/modules/v2d_hamer/lib/render_hands_video.py
+++ b/reconstruction/modules/v2d_hamer/lib/render_hands_video.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Verification: render projected MANO meshes onto the source video.
 
 Takes the per-frame per-track JSONs written by ``masks_to_hands`` and

--- a/reconstruction/modules/v2d_hand_alignment/docker/__init__.py
+++ b/reconstruction/modules/v2d_hand_alignment/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_hand_alignment/docker/_config.py
+++ b/reconstruction/modules/v2d_hand_alignment/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_hand_alignment"

--- a/reconstruction/modules/v2d_hand_alignment/docker/build.py
+++ b/reconstruction/modules/v2d_hand_alignment/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_hand_alignment/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_hand_alignment/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_hand_alignment/docker/run_align_hand_depth.py
+++ b/reconstruction/modules/v2d_hand_alignment/docker/run_align_hand_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.hand_alignment.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_hand_alignment/docker/run_dynhamr_to_hamer_tracks.py
+++ b/reconstruction/modules/v2d_hand_alignment/docker/run_dynhamr_to_hamer_tracks.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.hand_alignment.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_hand_alignment/docker/run_recover_mano_params.py
+++ b/reconstruction/modules/v2d_hand_alignment/docker/run_recover_mano_params.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.hand_alignment.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_hand_alignment/docker/run_render_mano_params_video.py
+++ b/reconstruction/modules/v2d_hand_alignment/docker/run_render_mano_params_video.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.hand_alignment.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_hand_alignment/docker/run_render_multiview_video.py
+++ b/reconstruction/modules/v2d_hand_alignment/docker/run_render_multiview_video.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.hand_alignment.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_hand_alignment/docker/run_reproject_hand_mesh.py
+++ b/reconstruction/modules/v2d_hand_alignment/docker/run_reproject_hand_mesh.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.hand_alignment.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_hand_alignment/docker/run_smooth_hand_mesh.py
+++ b/reconstruction/modules/v2d_hand_alignment/docker/run_smooth_hand_mesh.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.hand_alignment.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_hand_alignment/lib/__init__.py
+++ b/reconstruction/modules/v2d_hand_alignment/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_hand_alignment/lib/align_hand_depth.py
+++ b/reconstruction/modules/v2d_hand_alignment/lib/align_hand_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Align hand mesh depth to MoGe depth by estimating a z-scale factor.
 

--- a/reconstruction/modules/v2d_hand_alignment/lib/dynhamr_to_hamer_tracks.py
+++ b/reconstruction/modules/v2d_hand_alignment/lib/dynhamr_to_hamer_tracks.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Convert a DynHaMR ``world_results.npz`` to per-frame v2d_hamer-style tracks.
 
 Each frame's hand state is re-expressed in DynHaMR's *per-frame camera*

--- a/reconstruction/modules/v2d_hand_alignment/lib/hand_object_alignment.py
+++ b/reconstruction/modules/v2d_hand_alignment/lib/hand_object_alignment.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 HandObjectAlignment — align DynHaMR hand parameters to monocular depth via pyrender.
 

--- a/reconstruction/modules/v2d_hand_alignment/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_hand_alignment/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_hand_alignment/lib/recover_mano_params.py
+++ b/reconstruction/modules/v2d_hand_alignment/lib/recover_mano_params.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Recover MANO parameters in aligned camera space from the alignment pipeline outputs.
 

--- a/reconstruction/modules/v2d_hand_alignment/lib/render_mano_params_video.py
+++ b/reconstruction/modules/v2d_hand_alignment/lib/render_mano_params_video.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Render a video with MANO FK hands projected onto the camera view.
 

--- a/reconstruction/modules/v2d_hand_alignment/lib/render_multiview_video.py
+++ b/reconstruction/modules/v2d_hand_alignment/lib/render_multiview_video.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Render a 4-panel video of object mesh + hand meshes:
   top-left:     original camera perspective

--- a/reconstruction/modules/v2d_hand_alignment/lib/reproject_hand_mesh.py
+++ b/reconstruction/modules/v2d_hand_alignment/lib/reproject_hand_mesh.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Reproject hand mesh vertices from world frame + hand intrinsics to per-frame
 camera space using target intrinsics.

--- a/reconstruction/modules/v2d_hand_alignment/lib/smooth_hand_mesh.py
+++ b/reconstruction/modules/v2d_hand_alignment/lib/smooth_hand_mesh.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Smooth hand mesh center position temporally.
 

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/__init__.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/docker/__init__.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/docker/_pipeline_utils.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/docker/_pipeline_utils.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Shared utilities for HOI pipeline orchestration scripts."""
 
 import subprocess

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/docker/build.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 from pathlib import Path
 

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/docker/run_reconstruction.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/docker/run_reconstruction.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 End-to-end object reconstruction pipeline (HOST-SIDE orchestrator).
 

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/__init__.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/center_mesh.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/center_mesh.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Center a mesh at the origin by subtracting its bounding box center.
 

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/compute_object_world_poses.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/compute_object_world_poses.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Compute object-to-world transforms by composing:
   T_world_from_obj = T_world_from_cam  @  T_cam_from_obj

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/data/configs/hoi_pipeline.yaml
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/data/configs/hoi_pipeline.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # HOI Object Reconstruction — Pipeline Configuration
 #
 # Controls the orchestration-level behaviour of each pipeline step.

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/detect_stage1_end.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/detect_stage1_end.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Auto-detect the end of Stage 1 (first scanning loop) from CuSFM camera trajectory.
 

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/prepare_FP_folder.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/prepare_FP_folder.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Prepare a FoundationPose job directory from stereo image data.
 

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/recon_utils.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/recon_utils.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Shared pose-math and image-conversion utilities for reconstruction scripts."""
 
 import json

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/scale_mesh_srt.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/scale_mesh_srt.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Scale + Rotation + Translation (SRT) estimation for SAM3D meshes.
 
 Multi-view silhouette alignment: optimises scale, orientation, and translation

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/select_sam3d_frames.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/select_sam3d_frames.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Select representative frames for SAM3D reconstruction.
 
 Uses CuSFM camera trajectory to pick one frame per azimuthal angle bin,

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/setup_reconstruction_for_stage1.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/setup_reconstruction_for_stage1.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Set up Stage-1 reconstruction directory from CuSFM keyframes.
 

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/lib/setup_reconstruction_from_fp_poses.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/lib/setup_reconstruction_from_fp_poses.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Set up 3D reconstruction directory from CuSFM keyframes filtered to scanning stages.
 

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/tools/depth_npy_to_ply.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/tools/depth_npy_to_ply.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Convert a depth .npy file to a .ply point cloud viewable in CloudCompare.
 

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/tools/spin_mesh_video.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/tools/spin_mesh_video.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Generate a spinning turntable video of a GLB/OBJ mesh using trimesh + pyrender (EGL offscreen).
 

--- a/reconstruction/modules/v2d_hoi_object_reconstruction/tools/view_glb.py
+++ b/reconstruction/modules/v2d_hoi_object_reconstruction/tools/view_glb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Simple GLB/Mesh Viewer using trimesh
 

--- a/reconstruction/modules/v2d_mediapipe/docker/__init__.py
+++ b/reconstruction/modules/v2d_mediapipe/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_mediapipe/docker/_config.py
+++ b/reconstruction/modules/v2d_mediapipe/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_mediapipe"

--- a/reconstruction/modules/v2d_mediapipe/docker/build.py
+++ b/reconstruction/modules/v2d_mediapipe/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 

--- a/reconstruction/modules/v2d_mediapipe/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_mediapipe/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_mediapipe/docker/run_image_to_hand_bboxes.py
+++ b/reconstruction/modules/v2d_mediapipe/docker/run_image_to_hand_bboxes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.mediapipe.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_mediapipe/docker/run_shell.py
+++ b/reconstruction/modules/v2d_mediapipe/docker/run_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 

--- a/reconstruction/modules/v2d_mediapipe/lib/__init__.py
+++ b/reconstruction/modules/v2d_mediapipe/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_mediapipe/lib/image_to_hand_bboxes.py
+++ b/reconstruction/modules/v2d_mediapipe/lib/image_to_hand_bboxes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """MediaPipe HandLandmarker (Tasks API): bbox + handedness from a single image.
 
 Uses the newer ``mediapipe.tasks.vision.HandLandmarker`` model, which is more

--- a/reconstruction/modules/v2d_mediapipe/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_mediapipe/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_mesh/docker/__init__.py
+++ b/reconstruction/modules/v2d_mesh/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_mesh/docker/_config.py
+++ b/reconstruction/modules/v2d_mesh/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_mesh"

--- a/reconstruction/modules/v2d_mesh/docker/build.py
+++ b/reconstruction/modules/v2d_mesh/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_mesh/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_mesh/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_mesh/docker/run_mesh_align_depth.py
+++ b/reconstruction/modules/v2d_mesh/docker/run_mesh_align_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.mesh.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_mesh/docker/run_mesh_get_bounding_box.py
+++ b/reconstruction/modules/v2d_mesh/docker/run_mesh_get_bounding_box.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.mesh.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_mesh/docker/run_mesh_render_depth.py
+++ b/reconstruction/modules/v2d_mesh/docker/run_mesh_render_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.mesh.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_mesh/docker/run_mesh_render_image.py
+++ b/reconstruction/modules/v2d_mesh/docker/run_mesh_render_image.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.mesh.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_mesh/docker/run_mesh_render_mask.py
+++ b/reconstruction/modules/v2d_mesh/docker/run_mesh_render_mask.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.mesh.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_mesh/docker/run_mesh_simplify.py
+++ b/reconstruction/modules/v2d_mesh/docker/run_mesh_simplify.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.mesh.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_mesh/docker/run_mesh_transform.py
+++ b/reconstruction/modules/v2d_mesh/docker/run_mesh_transform.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.mesh.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_mesh/docker/run_tests.py
+++ b/reconstruction/modules/v2d_mesh/docker/run_tests.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.mesh.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_mesh/docker/tests/__init__.py
+++ b/reconstruction/modules/v2d_mesh/docker/tests/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_mesh/docker/tests/conftest.py
+++ b/reconstruction/modules/v2d_mesh/docker/tests/conftest.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 import pytest

--- a/reconstruction/modules/v2d_mesh/docker/tests/test_mesh_get_bounding_box.py
+++ b/reconstruction/modules/v2d_mesh/docker/tests/test_mesh_get_bounding_box.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import json
 import shutil
 

--- a/reconstruction/modules/v2d_mesh/docker/tests/test_mesh_render.py
+++ b/reconstruction/modules/v2d_mesh/docker/tests/test_mesh_render.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.mesh.docker.run_mesh_render_depth import run_mesh_render_depth
 from v2d.mesh.docker.run_mesh_render_image import run_mesh_render_image
 from v2d.mesh.docker.run_mesh_render_mask import run_mesh_render_mask

--- a/reconstruction/modules/v2d_mesh/docker/tests/test_mesh_simplify.py
+++ b/reconstruction/modules/v2d_mesh/docker/tests/test_mesh_simplify.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import shutil
 
 from v2d.mesh.docker.run_mesh_simplify import run_mesh_simplify

--- a/reconstruction/modules/v2d_mesh/docker/tests/test_mesh_transform.py
+++ b/reconstruction/modules/v2d_mesh/docker/tests/test_mesh_transform.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import shutil
 
 from v2d.mesh.docker.run_mesh_transform import run_mesh_transform

--- a/reconstruction/modules/v2d_mesh/lib/__init__.py
+++ b/reconstruction/modules/v2d_mesh/lib/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.common.datatypes import BoundingBox3d, Image
 from v2d.common.broadcast import broadcast_pairs, broadcast_zip, resolve_glob, resolve_output, apply_output_pattern
 from v2d.mesh.lib.mesh import Mesh

--- a/reconstruction/modules/v2d_mesh/lib/mesh.py
+++ b/reconstruction/modules/v2d_mesh/lib/mesh.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from dataclasses import dataclass, field
 import numpy as np
 import trimesh

--- a/reconstruction/modules/v2d_mesh/lib/mesh_align_depth.py
+++ b/reconstruction/modules/v2d_mesh/lib/mesh_align_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import numpy as np
 
 from v2d.common.datatypes import CameraIntrinsics, DepthImage, Transform3d

--- a/reconstruction/modules/v2d_mesh/lib/mesh_get_bounding_box.py
+++ b/reconstruction/modules/v2d_mesh/lib/mesh_get_bounding_box.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.common.datatypes import BoundingBox3d
 from v2d.mesh.lib.mesh import Mesh
 

--- a/reconstruction/modules/v2d_mesh/lib/mesh_render_depth.py
+++ b/reconstruction/modules/v2d_mesh/lib/mesh_render_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 os.environ.setdefault('PYOPENGL_PLATFORM', 'egl')
 

--- a/reconstruction/modules/v2d_mesh/lib/mesh_render_image.py
+++ b/reconstruction/modules/v2d_mesh/lib/mesh_render_image.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 os.environ.setdefault('PYOPENGL_PLATFORM', 'egl')
 

--- a/reconstruction/modules/v2d_mesh/lib/mesh_render_mask.py
+++ b/reconstruction/modules/v2d_mesh/lib/mesh_render_mask.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 os.environ.setdefault('PYOPENGL_PLATFORM', 'egl')
 

--- a/reconstruction/modules/v2d_mesh/lib/mesh_simplify.py
+++ b/reconstruction/modules/v2d_mesh/lib/mesh_simplify.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import trimesh
 import numpy as np
 from v2d.mesh.lib.mesh import Mesh

--- a/reconstruction/modules/v2d_mesh/lib/mesh_transform.py
+++ b/reconstruction/modules/v2d_mesh/lib/mesh_transform.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import numpy as np
 from v2d.common.datatypes import Transform3d
 from v2d.mesh.lib.mesh import Mesh

--- a/reconstruction/modules/v2d_mesh/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_mesh/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_mesh/lib/run_mesh_align_depth.py
+++ b/reconstruction/modules/v2d_mesh/lib/run_mesh_align_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import os
 

--- a/reconstruction/modules/v2d_mesh/lib/run_mesh_get_bounding_box.py
+++ b/reconstruction/modules/v2d_mesh/lib/run_mesh_get_bounding_box.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import os
 from pathlib import Path

--- a/reconstruction/modules/v2d_mesh/lib/run_mesh_render_depth.py
+++ b/reconstruction/modules/v2d_mesh/lib/run_mesh_render_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import os
 

--- a/reconstruction/modules/v2d_mesh/lib/run_mesh_render_image.py
+++ b/reconstruction/modules/v2d_mesh/lib/run_mesh_render_image.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import os
 

--- a/reconstruction/modules/v2d_mesh/lib/run_mesh_render_mask.py
+++ b/reconstruction/modules/v2d_mesh/lib/run_mesh_render_mask.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import os
 

--- a/reconstruction/modules/v2d_mesh/lib/run_mesh_simplify.py
+++ b/reconstruction/modules/v2d_mesh/lib/run_mesh_simplify.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import os
 from pathlib import Path

--- a/reconstruction/modules/v2d_mesh/lib/run_mesh_transform.py
+++ b/reconstruction/modules/v2d_mesh/lib/run_mesh_transform.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import os
 

--- a/reconstruction/modules/v2d_mesh/lib/tests/__init__.py
+++ b/reconstruction/modules/v2d_mesh/lib/tests/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_mesh/lib/tests/conftest.py
+++ b/reconstruction/modules/v2d_mesh/lib/tests/conftest.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # Must be set before any pyrender/OpenGL/pyglet import.
 import os
 os.environ.setdefault('PYOPENGL_PLATFORM', 'egl')

--- a/reconstruction/modules/v2d_mesh/lib/tests/test_mesh.py
+++ b/reconstruction/modules/v2d_mesh/lib/tests/test_mesh.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import tempfile
 import os
 import numpy as np

--- a/reconstruction/modules/v2d_mesh/lib/tests/test_mesh_get_bounding_box.py
+++ b/reconstruction/modules/v2d_mesh/lib/tests/test_mesh_get_bounding_box.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import numpy as np
 import pytest
 

--- a/reconstruction/modules/v2d_mesh/lib/tests/test_mesh_render_depth.py
+++ b/reconstruction/modules/v2d_mesh/lib/tests/test_mesh_render_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import numpy as np
 import pytest
 

--- a/reconstruction/modules/v2d_mesh/lib/tests/test_mesh_render_image.py
+++ b/reconstruction/modules/v2d_mesh/lib/tests/test_mesh_render_image.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import numpy as np
 import pytest
 

--- a/reconstruction/modules/v2d_mesh/lib/tests/test_mesh_render_mask.py
+++ b/reconstruction/modules/v2d_mesh/lib/tests/test_mesh_render_mask.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import numpy as np
 import pytest
 

--- a/reconstruction/modules/v2d_mesh/lib/tests/test_mesh_simplify.py
+++ b/reconstruction/modules/v2d_mesh/lib/tests/test_mesh_simplify.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import numpy as np
 import pytest
 import trimesh

--- a/reconstruction/modules/v2d_mesh/lib/tests/test_mesh_transform.py
+++ b/reconstruction/modules/v2d_mesh/lib/tests/test_mesh_transform.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import numpy as np
 import pytest
 

--- a/reconstruction/modules/v2d_mesh/lib/tests/test_run_mesh_transform.py
+++ b/reconstruction/modules/v2d_mesh/lib/tests/test_run_mesh_transform.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 import numpy as np

--- a/reconstruction/modules/v2d_moge/docker/__init__.py
+++ b/reconstruction/modules/v2d_moge/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_moge/docker/_config.py
+++ b/reconstruction/modules/v2d_moge/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_moge"

--- a/reconstruction/modules/v2d_moge/docker/build.py
+++ b/reconstruction/modules/v2d_moge/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_moge/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_moge/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_moge/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_moge/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.moge.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_moge/docker/run_image_to_depth.py
+++ b/reconstruction/modules/v2d_moge/docker/run_image_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.moge.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_moge/docker/run_shell.py
+++ b/reconstruction/modules/v2d_moge/docker/run_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.moge.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_moge/docker/run_video_to_depth.py
+++ b/reconstruction/modules/v2d_moge/docker/run_video_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.moge.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_moge/lib/__init__.py
+++ b/reconstruction/modules/v2d_moge/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_moge/lib/download_weights.py
+++ b/reconstruction/modules/v2d_moge/lib/download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_moge/lib/image_to_depth.py
+++ b/reconstruction/modules/v2d_moge/lib/image_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 MoGe image to depth processing function.
 Can be called directly from command line or imported as a function.

--- a/reconstruction/modules/v2d_moge/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_moge/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_moge/lib/video_to_depth.py
+++ b/reconstruction/modules/v2d_moge/lib/video_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 MoGe video to depth processing function.
 Can be called directly from command line or imported as a function.

--- a/reconstruction/modules/v2d_mv/__init__.py
+++ b/reconstruction/modules/v2d_mv/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_mv/cli/__init__.py
+++ b/reconstruction/modules/v2d_mv/cli/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_mv/cli/tile_videos.py
+++ b/reconstruction/modules/v2d_mv/cli/tile_videos.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 from pathlib import Path
 

--- a/reconstruction/modules/v2d_mv/io/__init__.py
+++ b/reconstruction/modules/v2d_mv/io/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_mv/math/__init__.py
+++ b/reconstruction/modules/v2d_mv/math/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_mv/math/numpy_fn.py
+++ b/reconstruction/modules/v2d_mv/math/numpy_fn.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from typing import Callable
 
 import numpy as np

--- a/reconstruction/modules/v2d_mv/math/torch_fn.py
+++ b/reconstruction/modules/v2d_mv/math/torch_fn.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from typing import Callable
 
 import numpy as np

--- a/reconstruction/modules/v2d_mv/pyproject.toml
+++ b/reconstruction/modules/v2d_mv/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_mv/rig/__init__.py
+++ b/reconstruction/modules/v2d_mv/rig/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from .params import CameraParam, edex_camera_to_param, param_overwrite_in_edex
 from .rig import CameraEntry, RigConfig, StereoPair
 

--- a/reconstruction/modules/v2d_mv/rig/edex.py
+++ b/reconstruction/modules/v2d_mv/rig/edex.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from enum import Enum
 from functools import partial
 import json

--- a/reconstruction/modules/v2d_mv/rig/params.py
+++ b/reconstruction/modules/v2d_mv/rig/params.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path

--- a/reconstruction/modules/v2d_mv/rig/rig.py
+++ b/reconstruction/modules/v2d_mv/rig/rig.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/reconstruction/modules/v2d_mv/rig/rigs/stereo-4.yaml
+++ b/reconstruction/modules/v2d_mv/rig/rigs/stereo-4.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 cameras:
   - name: front_stereo_camera_left
     cam_id: 0

--- a/reconstruction/modules/v2d_mv/vis/__init__.py
+++ b/reconstruction/modules/v2d_mv/vis/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 def __getattr__(name):
     if name == "Renderer":
         from .renderer import Renderer

--- a/reconstruction/modules/v2d_mv/vis/renderer.py
+++ b/reconstruction/modules/v2d_mv/vis/renderer.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import os

--- a/reconstruction/modules/v2d_mv/vis/wis3d_helper.py
+++ b/reconstruction/modules/v2d_mv/vis/wis3d_helper.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 from pathlib import Path

--- a/reconstruction/modules/v2d_mv_calibration/docker/__init__.py
+++ b/reconstruction/modules/v2d_mv_calibration/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_mv_calibration/docker/_config.py
+++ b/reconstruction/modules/v2d_mv_calibration/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_mv_calibration"

--- a/reconstruction/modules/v2d_mv_calibration/docker/build.py
+++ b/reconstruction/modules/v2d_mv_calibration/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_mv_calibration/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_mv_calibration/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_mv_calibration/docker/run_calibrate_extrinsics.py
+++ b/reconstruction/modules/v2d_mv_calibration/docker/run_calibrate_extrinsics.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_mv_calibration/lib/__init__.py
+++ b/reconstruction/modules/v2d_mv_calibration/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_mv_calibration/lib/calibrate_extrinsics.py
+++ b/reconstruction/modules/v2d_mv_calibration/lib/calibrate_extrinsics.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Extrinsic calibration: chessboard detection -> PnP initialization -> Ceres BA."""
 
 import json

--- a/reconstruction/modules/v2d_mv_calibration/lib/calibrate_extrinsics.yaml
+++ b/reconstruction/modules/v2d_mv_calibration/lib/calibrate_extrinsics.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 rig_name: stereo-4
 
 camera_params_path: ???

--- a/reconstruction/modules/v2d_mv_calibration/lib/chessboard.py
+++ b/reconstruction/modules/v2d_mv_calibration/lib/chessboard.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Chessboard corner detection for multi-camera calibration."""
 
 import logging

--- a/reconstruction/modules/v2d_mv_calibration/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_mv_calibration/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_mv_calibration/lib/solve.py
+++ b/reconstruction/modules/v2d_mv_calibration/lib/solve.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Extrinsic calibration solvers: PnP initialization and Ceres bundle adjustment."""
 
 import copy

--- a/reconstruction/modules/v2d_mv_calibration/lib/vis.py
+++ b/reconstruction/modules/v2d_mv_calibration/lib/vis.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Calibration visualization utilities using Rerun."""
 
 import logging

--- a/reconstruction/modules/v2d_mv_postprocess/docker/__init__.py
+++ b/reconstruction/modules/v2d_mv_postprocess/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_mv_postprocess/docker/_config.py
+++ b/reconstruction/modules/v2d_mv_postprocess/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_mv_postprocess"

--- a/reconstruction/modules/v2d_mv_postprocess/docker/build.py
+++ b/reconstruction/modules/v2d_mv_postprocess/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_mv_postprocess/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_mv_postprocess/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_mv_postprocess/docker/run_export_demo.py
+++ b/reconstruction/modules/v2d_mv_postprocess/docker/run_export_demo.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Docker wrapper for export_demo.
 
 Load exported training data and render HOI overlay as a sanity check:

--- a/reconstruction/modules/v2d_mv_postprocess/docker/run_export_sequence.py
+++ b/reconstruction/modules/v2d_mv_postprocess/docker/run_export_sequence.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Docker wrapper for export_sequence.
 
 Export from CSS (remote):

--- a/reconstruction/modules/v2d_mv_postprocess/docker/run_mv_estimate_ground_plane.py
+++ b/reconstruction/modules/v2d_mv_postprocess/docker/run_mv_estimate_ground_plane.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_mv_postprocess/docker/run_mv_eval_chamfer_human.py
+++ b/reconstruction/modules/v2d_mv_postprocess/docker/run_mv_eval_chamfer_human.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_mv_postprocess/docker/run_mv_eval_chamfer_object.py
+++ b/reconstruction/modules/v2d_mv_postprocess/docker/run_mv_eval_chamfer_object.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_mv_postprocess/docker/run_mv_export_fused_pointcloud.py
+++ b/reconstruction/modules/v2d_mv_postprocess/docker/run_mv_export_fused_pointcloud.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_mv_postprocess/docker/run_mv_render_hoi_overlay.py
+++ b/reconstruction/modules/v2d_mv_postprocess/docker/run_mv_render_hoi_overlay.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_mv_postprocess/docker/run_mv_visualize_wis3d.py
+++ b/reconstruction/modules/v2d_mv_postprocess/docker/run_mv_visualize_wis3d.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_mv_postprocess/lib/__init__.py
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_mv_postprocess/lib/check_accuracy.py
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/check_accuracy.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Aggregate accuracy checks.
 
 Reads chamfer-distance metrics from ``eval_chamfer_object`` and

--- a/reconstruction/modules/v2d_mv_postprocess/lib/check_object_mask.py
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/check_object_mask.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Check that SAM2 object masks are contained within labeled bboxes.
 
 For each camera, derives the tight bounding box of the SAM2 mask (object 0,

--- a/reconstruction/modules/v2d_mv_postprocess/lib/export_demo.py
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/export_demo.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Demonstrate loading and visualizing the exported flat training data.
 
 Loads calibration, meshes, poses, params, depth, masks from the flat layout

--- a/reconstruction/modules/v2d_mv_postprocess/lib/export_sequence.py
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/export_sequence.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Export a reconstructed sequence into a flat training-ready layout.
 
 Supports two modes:

--- a/reconstruction/modules/v2d_mv_postprocess/lib/fuse_depth_pointcloud.py
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/fuse_depth_pointcloud.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Shared utilities for multiview depth fusion: backproject, merge, downsample, clean."""
 from __future__ import annotations
 

--- a/reconstruction/modules/v2d_mv_postprocess/lib/mv_estimate_ground_plane.py
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/mv_estimate_ground_plane.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Estimate the ground plane from multiview depth + MHR foot keypoints."""
 from __future__ import annotations
 

--- a/reconstruction/modules/v2d_mv_postprocess/lib/mv_estimate_ground_plane.yaml
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/mv_estimate_ground_plane.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 camera_params_path: ???
 depth_dir: ???
 human_pose_dir: ???

--- a/reconstruction/modules/v2d_mv_postprocess/lib/mv_eval_chamfer.py
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/mv_eval_chamfer.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import json

--- a/reconstruction/modules/v2d_mv_postprocess/lib/mv_eval_chamfer_human.py
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/mv_eval_chamfer_human.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import argparse

--- a/reconstruction/modules/v2d_mv_postprocess/lib/mv_eval_chamfer_human.yaml
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/mv_eval_chamfer_human.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 camera_params_path: ???
 human_pose_dir: ???
 output_dir: ???

--- a/reconstruction/modules/v2d_mv_postprocess/lib/mv_eval_chamfer_object.py
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/mv_eval_chamfer_object.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import argparse

--- a/reconstruction/modules/v2d_mv_postprocess/lib/mv_eval_chamfer_object.yaml
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/mv_eval_chamfer_object.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 camera_params_path: ???
 object_mesh_path: ???
 object_pose_dir: ???

--- a/reconstruction/modules/v2d_mv_postprocess/lib/mv_export_fused_pointcloud.py
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/mv_export_fused_pointcloud.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Export per-frame multiview fused point clouds as colored PLY files."""
 from __future__ import annotations
 

--- a/reconstruction/modules/v2d_mv_postprocess/lib/mv_export_fused_pointcloud.yaml
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/mv_export_fused_pointcloud.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 camera_params_path: ???
 depth_dir: ???
 rgb_dir: ???

--- a/reconstruction/modules/v2d_mv_postprocess/lib/mv_render_hoi_overlay.py
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/mv_render_hoi_overlay.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import argparse

--- a/reconstruction/modules/v2d_mv_postprocess/lib/mv_render_hoi_overlay.yaml
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/mv_render_hoi_overlay.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 rig_config: stereo-4
 cameras: [0, 2, 4, 6]
 

--- a/reconstruction/modules/v2d_mv_postprocess/lib/mv_visualize_wis3d.py
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/mv_visualize_wis3d.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import argparse

--- a/reconstruction/modules/v2d_mv_postprocess/lib/mv_visualize_wis3d.yaml
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/mv_visualize_wis3d.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 rig_config: stereo-4
 cameras: [0, 2, 4, 6]
 

--- a/reconstruction/modules/v2d_mv_postprocess/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_mv_postprocess/lib/upload_hitl.py
+++ b/reconstruction/modules/v2d_mv_postprocess/lib/upload_hitl.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Stage HITL intake files (tiled overlay video + SuperAnnotate JSON).
 
 Runs after ``check_accuracy`` passes — task dependencies in the workflow

--- a/reconstruction/modules/v2d_mv_preprocess/docker/__init__.py
+++ b/reconstruction/modules/v2d_mv_preprocess/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_mv_preprocess/docker/_config.py
+++ b/reconstruction/modules/v2d_mv_preprocess/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_mv_preprocess"

--- a/reconstruction/modules/v2d_mv_preprocess/docker/build.py
+++ b/reconstruction/modules/v2d_mv_preprocess/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_mv_preprocess/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_mv_preprocess/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_mv_preprocess/docker/run_mv_preprocess.py
+++ b/reconstruction/modules/v2d_mv_preprocess/docker/run_mv_preprocess.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_mv_preprocess/docker/run_preprocess_stereo.py
+++ b/reconstruction/modules/v2d_mv_preprocess/docker/run_preprocess_stereo.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Docker wrapper for single stereo pair preprocessing."""
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_mv_preprocess/lib/__init__.py
+++ b/reconstruction/modules/v2d_mv_preprocess/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_mv_preprocess/lib/image_proc/__init__.py
+++ b/reconstruction/modules/v2d_mv_preprocess/lib/image_proc/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from .base import ImageProcessorBase, ImagePipeline
 from .proc_cv2 import (
     RectifyProcessor,

--- a/reconstruction/modules/v2d_mv_preprocess/lib/image_proc/base.py
+++ b/reconstruction/modules/v2d_mv_preprocess/lib/image_proc/base.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from abc import ABC, abstractmethod
 
 import numpy as np

--- a/reconstruction/modules/v2d_mv_preprocess/lib/image_proc/proc_cv2.py
+++ b/reconstruction/modules/v2d_mv_preprocess/lib/image_proc/proc_cv2.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import copy
 import logging
 

--- a/reconstruction/modules/v2d_mv_preprocess/lib/mv_preprocess.py
+++ b/reconstruction/modules/v2d_mv_preprocess/lib/mv_preprocess.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Multi-view preprocessing: stereo rectification and HOI metadata remapping."""
 
 import copy

--- a/reconstruction/modules/v2d_mv_preprocess/lib/mv_preprocess.yaml
+++ b/reconstruction/modules/v2d_mv_preprocess/lib/mv_preprocess.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 rig_name: stereo-4
 
 rgb_dir: ???

--- a/reconstruction/modules/v2d_mv_preprocess/lib/preprocess_stereo.py
+++ b/reconstruction/modules/v2d_mv_preprocess/lib/preprocess_stereo.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Stereo image preprocessing: rectification, rescaling, and cropping.
 
 Processes a single stereo image pair and returns updated camera parameters.

--- a/reconstruction/modules/v2d_mv_preprocess/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_mv_preprocess/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_pipelines/extract_images.py
+++ b/reconstruction/modules/v2d_pipelines/extract_images.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Extract video frames to numbered PNG images."""
 import os
 import cv2

--- a/reconstruction/modules/v2d_pipelines/mv_configs/mv_videos_to_object_masks.yaml
+++ b/reconstruction/modules/v2d_pipelines/mv_configs/mv_videos_to_object_masks.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 bbox_dir: ???
 rgb_dir: null
 video_dir: null

--- a/reconstruction/modules/v2d_pipelines/pyproject.toml
+++ b/reconstruction/modules/v2d_pipelines/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_pipelines/run_ego_wilor.py
+++ b/reconstruction/modules/v2d_pipelines/run_ego_wilor.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """WiLoR-driven hand pipeline: detect per frame → SAM2 → IoU match → per-track JSONs.
 
 Differs from ``run_hand_masks.py`` in two ways:

--- a/reconstruction/modules/v2d_pipelines/run_example_pipeline.py
+++ b/reconstruction/modules/v2d_pipelines/run_example_pipeline.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Example pipeline composing v2d Docker modules.
 Run from reconstruction/ or repo root: python -m v2d.pipelines.run_example_pipeline

--- a/reconstruction/modules/v2d_pipelines/run_hand_masks.py
+++ b/reconstruction/modules/v2d_pipelines/run_hand_masks.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Hand pipeline: detection → SAM2 tracking → HaMeR → depth alignment.
 
 Steps:

--- a/reconstruction/modules/v2d_pipelines/run_mv_calibration.py
+++ b/reconstruction/modules/v2d_pipelines/run_mv_calibration.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Pipeline: extract calibration images from rosbag, run extrinsic calibration.
 
 This pipeline is for calibration datasets (containing chessboard images).

--- a/reconstruction/modules/v2d_pipelines/run_mv_hoi_reconstruction.py
+++ b/reconstruction/modules/v2d_pipelines/run_mv_hoi_reconstruction.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Pipeline: rosbag -> preprocessing -> depth -> detection -> segmentation -> body reconstruction.
 
 Usage:

--- a/reconstruction/modules/v2d_pipelines/run_sam3d_mesh_render.py
+++ b/reconstruction/modules/v2d_pipelines/run_sam3d_mesh_render.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Pipeline: SAM3D image-to-mesh, then render depth, mask, and image.
 Run from reconstruction/: python -m v2d.pipelines.run_sam3d_mesh_render

--- a/reconstruction/modules/v2d_pipelines/run_v2d_ego_e2e.py
+++ b/reconstruction/modules/v2d_pipelines/run_v2d_ego_e2e.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 End-to-end ego hand + object reconstruction pipeline from a single video.
 

--- a/reconstruction/modules/v2d_pipelines/run_video_object_tracking.py
+++ b/reconstruction/modules/v2d_pipelines/run_video_object_tracking.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Pipeline: Video → Segment → Depth → 3D Mesh → Scale Align → Track → Render
 

--- a/reconstruction/modules/v2d_rosbag/docker/__init__.py
+++ b/reconstruction/modules/v2d_rosbag/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_rosbag/docker/_config.py
+++ b/reconstruction/modules/v2d_rosbag/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_rosbag"

--- a/reconstruction/modules/v2d_rosbag/docker/build.py
+++ b/reconstruction/modules/v2d_rosbag/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_rosbag/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_rosbag/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_rosbag/docker/run_rosbag_to_edex.py
+++ b/reconstruction/modules/v2d_rosbag/docker/run_rosbag_to_edex.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_rosbag/lib/__init__.py
+++ b/reconstruction/modules/v2d_rosbag/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_rosbag/lib/config.py
+++ b/reconstruction/modules/v2d_rosbag/lib/config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Configuration for rosbag-to-EDEX extraction."""
 
 import pathlib

--- a/reconstruction/modules/v2d_rosbag/lib/configs/nova_hawk.yaml
+++ b/reconstruction/modules/v2d_rosbag/lib/configs/nova_hawk.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # Topic names:
 camera_info_topics:
   - /front_stereo_camera/left/camera_info

--- a/reconstruction/modules/v2d_rosbag/lib/configs/oak6.yaml
+++ b/reconstruction/modules/v2d_rosbag/lib/configs/oak6.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # Topic names:
 camera_info_topics:
   - /oak_cam6/left/camera_info

--- a/reconstruction/modules/v2d_rosbag/lib/configs/realsense.yaml
+++ b/reconstruction/modules/v2d_rosbag/lib/configs/realsense.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # Topic names:
 camera_info_topics:
   - /camera0/color/camera_info

--- a/reconstruction/modules/v2d_rosbag/lib/edex_extraction.py
+++ b/reconstruction/modules/v2d_rosbag/lib/edex_extraction.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Full EDEX extraction including camera extrinsics from TF tree and optional IMU."""
 
 import json

--- a/reconstruction/modules/v2d_rosbag/lib/image_extraction.py
+++ b/reconstruction/modules/v2d_rosbag/lib/image_extraction.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Extract and synchronize images from a ROS bag.
 
 Handles both raw (sensor_msgs/msg/Image) and compressed

--- a/reconstruction/modules/v2d_rosbag/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_rosbag/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_rosbag/lib/rosbag_to_edex.py
+++ b/reconstruction/modules/v2d_rosbag/lib/rosbag_to_edex.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """CLI entry point for rosbag-to-EDEX extraction."""
 
 import argparse

--- a/reconstruction/modules/v2d_rosbag/lib/tf_extraction.py
+++ b/reconstruction/modules/v2d_rosbag/lib/tf_extraction.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Extract static and temporal transforms from a ROS bag's /tf and /tf_static topics."""
 
 import collections

--- a/reconstruction/modules/v2d_sam2/docker/__init__.py
+++ b/reconstruction/modules/v2d_sam2/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_sam2/docker/_config.py
+++ b/reconstruction/modules/v2d_sam2/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_sam2"

--- a/reconstruction/modules/v2d_sam2/docker/build.py
+++ b/reconstruction/modules/v2d_sam2/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_sam2/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_sam2/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_sam2/docker/run_annotate.py
+++ b/reconstruction/modules/v2d_sam2/docker/run_annotate.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.sam2.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_sam2/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_sam2/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.sam2.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_sam2/docker/run_mv_videos_to_masks.py
+++ b/reconstruction/modules/v2d_sam2/docker/run_mv_videos_to_masks.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_sam2/docker/run_shell.py
+++ b/reconstruction/modules/v2d_sam2/docker/run_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.sam2.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_sam2/docker/run_video_to_masks.py
+++ b/reconstruction/modules/v2d_sam2/docker/run_video_to_masks.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.sam2.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_sam2/lib/__init__.py
+++ b/reconstruction/modules/v2d_sam2/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_sam2/lib/annotate.py
+++ b/reconstruction/modules/v2d_sam2/lib/annotate.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Web-based annotation tool for SAM2 prompts.
 Allows interactive annotation of objects using points and boxes.

--- a/reconstruction/modules/v2d_sam2/lib/datatypes.py
+++ b/reconstruction/modules/v2d_sam2/lib/datatypes.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.common.datatypes import Sam2Prompt, Sam2Prompts
 
 __all__ = ["Sam2Prompt", "Sam2Prompts"]

--- a/reconstruction/modules/v2d_sam2/lib/download_weights.py
+++ b/reconstruction/modules/v2d_sam2/lib/download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import subprocess
 

--- a/reconstruction/modules/v2d_sam2/lib/image_to_mask.py
+++ b/reconstruction/modules/v2d_sam2/lib/image_to_mask.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 HOI object reconstruction: generate mask for the reference frame only.
 

--- a/reconstruction/modules/v2d_sam2/lib/mv_videos_to_masks.py
+++ b/reconstruction/modules/v2d_sam2/lib/mv_videos_to_masks.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import argparse

--- a/reconstruction/modules/v2d_sam2/lib/mv_videos_to_masks.yaml
+++ b/reconstruction/modules/v2d_sam2/lib/mv_videos_to_masks.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 bbox_dir: ???
 rgb_dir: ???
 output_dir: ???

--- a/reconstruction/modules/v2d_sam2/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_sam2/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_sam2/lib/video_to_masks.py
+++ b/reconstruction/modules/v2d_sam2/lib/video_to_masks.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 SAM2 video to masks processing function.
 Can be called directly from command line or imported as a function.

--- a/reconstruction/modules/v2d_sam3d/docker/__init__.py
+++ b/reconstruction/modules/v2d_sam3d/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_sam3d/docker/_config.py
+++ b/reconstruction/modules/v2d_sam3d/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_sam3d"

--- a/reconstruction/modules/v2d_sam3d/docker/build.py
+++ b/reconstruction/modules/v2d_sam3d/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_sam3d/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_sam3d/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_sam3d/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_sam3d/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.sam3d.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_sam3d/docker/run_image_to_mesh.py
+++ b/reconstruction/modules/v2d_sam3d/docker/run_image_to_mesh.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 from v2d.docker.container import run_in_container
 from v2d.sam3d.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_sam3d/docker/run_render_debug_image.py
+++ b/reconstruction/modules/v2d_sam3d/docker/run_render_debug_image.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.sam3d.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_sam3d/docker/run_shell.py
+++ b/reconstruction/modules/v2d_sam3d/docker/run_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.sam3d.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_sam3d/lib/__init__.py
+++ b/reconstruction/modules/v2d_sam3d/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_sam3d/lib/download_weights.py
+++ b/reconstruction/modules/v2d_sam3d/lib/download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 Downloads all SAM3D weights into a single directory:
   weights_dir/

--- a/reconstruction/modules/v2d_sam3d/lib/image_to_mesh.py
+++ b/reconstruction/modules/v2d_sam3d/lib/image_to_mesh.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 SAM3D image to mesh processing function.
 Can be called directly from command line or imported as a function.

--- a/reconstruction/modules/v2d_sam3d/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_sam3d/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_sam3d/lib/render_debug_image.py
+++ b/reconstruction/modules/v2d_sam3d/lib/render_debug_image.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import cv2
 import trimesh

--- a/reconstruction/modules/v2d_sam3d/lib/render_textured_video.py
+++ b/reconstruction/modules/v2d_sam3d/lib/render_textured_video.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Render a Stage-1 overlay video: textured SRT mesh projected via open3d.
 
 Runs inside the v2d_sam3d container (has open3d with Filament/EGL backend).

--- a/reconstruction/modules/v2d_sam3d_body/docker/__init__.py
+++ b/reconstruction/modules/v2d_sam3d_body/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_sam3d_body/docker/_config.py
+++ b/reconstruction/modules/v2d_sam3d_body/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_sam3d_body"

--- a/reconstruction/modules/v2d_sam3d_body/docker/build.py
+++ b/reconstruction/modules/v2d_sam3d_body/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_sam3d_body/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_sam3d_body/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_sam3d_body/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_sam3d_body/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.sam3d_body.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_sam3d_body/docker/run_estimate_mhr_params.py
+++ b/reconstruction/modules/v2d_sam3d_body/docker/run_estimate_mhr_params.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_sam3d_body/docker/run_export_soma.py
+++ b/reconstruction/modules/v2d_sam3d_body/docker/run_export_soma.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_sam3d_body/docker/run_mv_optimize_mhr_params.py
+++ b/reconstruction/modules/v2d_sam3d_body/docker/run_mv_optimize_mhr_params.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 
 from v2d.docker.container import run_in_container

--- a/reconstruction/modules/v2d_sam3d_body/docker/run_shell.py
+++ b/reconstruction/modules/v2d_sam3d_body/docker/run_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.sam3d_body.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_sam3d_body/lib/__init__.py
+++ b/reconstruction/modules/v2d_sam3d_body/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_sam3d_body/lib/download_weights.py
+++ b/reconstruction/modules/v2d_sam3d_body/lib/download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import getpass
 import os

--- a/reconstruction/modules/v2d_sam3d_body/lib/estimate_mhr_params.py
+++ b/reconstruction/modules/v2d_sam3d_body/lib/estimate_mhr_params.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import argparse

--- a/reconstruction/modules/v2d_sam3d_body/lib/export_soma.py
+++ b/reconstruction/modules/v2d_sam3d_body/lib/export_soma.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Export MHR parameters from v2d sam3d_body to SOMA format.
 
 Reads the multi-view MHR output (.pt files) and uses SOMA-X's PoseInversion

--- a/reconstruction/modules/v2d_sam3d_body/lib/mv_optimize_mhr_params.py
+++ b/reconstruction/modules/v2d_sam3d_body/lib/mv_optimize_mhr_params.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import math

--- a/reconstruction/modules/v2d_sam3d_body/lib/mv_optimize_mhr_params.yaml
+++ b/reconstruction/modules/v2d_sam3d_body/lib/mv_optimize_mhr_params.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 camera_params_path: ???
 weights_dir: ???
 rgb_dir: ???

--- a/reconstruction/modules/v2d_sam3d_body/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_sam3d_body/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_sam3d_body/lib/renderer_gpu.py
+++ b/reconstruction/modules/v2d_sam3d_body/lib/renderer_gpu.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import torch

--- a/reconstruction/modules/v2d_sam3d_body/lib/tests/test_estimate_mhr_mask_prompts.py
+++ b/reconstruction/modules/v2d_sam3d_body/lib/tests/test_estimate_mhr_mask_prompts.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import numpy as np
 import pytest
 

--- a/reconstruction/modules/v2d_sam3d_body/lib/visibility.py
+++ b/reconstruction/modules/v2d_sam3d_body/lib/visibility.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import numpy as np

--- a/reconstruction/modules/v2d_unidepth/docker/__init__.py
+++ b/reconstruction/modules/v2d_unidepth/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_unidepth/docker/_config.py
+++ b/reconstruction/modules/v2d_unidepth/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_unidepth"

--- a/reconstruction/modules/v2d_unidepth/docker/build.py
+++ b/reconstruction/modules/v2d_unidepth/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_unidepth/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_unidepth/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_unidepth/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_unidepth/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.unidepth.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_unidepth/docker/run_image_to_depth.py
+++ b/reconstruction/modules/v2d_unidepth/docker/run_image_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.unidepth.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_unidepth/docker/run_shell.py
+++ b/reconstruction/modules/v2d_unidepth/docker/run_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 from v2d.unidepth.docker._config import IMAGE_NAME, MODULES_DIR

--- a/reconstruction/modules/v2d_unidepth/docker/run_video_to_depth.py
+++ b/reconstruction/modules/v2d_unidepth/docker/run_video_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.unidepth.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_unidepth/lib/__init__.py
+++ b/reconstruction/modules/v2d_unidepth/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_unidepth/lib/download_weights.py
+++ b/reconstruction/modules/v2d_unidepth/lib/download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import subprocess
 import os
 

--- a/reconstruction/modules/v2d_unidepth/lib/image_to_depth.py
+++ b/reconstruction/modules/v2d_unidepth/lib/image_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 UniDepth image to depth processing function.
 Can be called directly from command line or imported as a function.

--- a/reconstruction/modules/v2d_unidepth/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_unidepth/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_unidepth/lib/video_to_depth.py
+++ b/reconstruction/modules/v2d_unidepth/lib/video_to_depth.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 UniDepth video to depth processing function.
 Can be called directly from command line or imported as a function.

--- a/reconstruction/modules/v2d_viz/pyproject.toml
+++ b/reconstruction/modules/v2d_viz/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_viz/run_3d_viewer.py
+++ b/reconstruction/modules/v2d_viz/run_3d_viewer.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """
 3D depth viewer — Flask backend
 

--- a/reconstruction/modules/v2d_wilor/docker/__init__.py
+++ b/reconstruction/modules/v2d_wilor/docker/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_wilor/docker/_config.py
+++ b/reconstruction/modules/v2d_wilor/docker/_config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 IMAGE_NAME = "v2d_wilor"

--- a/reconstruction/modules/v2d_wilor/docker/build.py
+++ b/reconstruction/modules/v2d_wilor/docker/build.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 

--- a/reconstruction/modules/v2d_wilor/docker/pyproject.toml
+++ b/reconstruction/modules/v2d_wilor/docker/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_wilor/docker/run_download_weights.py
+++ b/reconstruction/modules/v2d_wilor/docker/run_download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.wilor.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_wilor/docker/run_image_list_to_hands.py
+++ b/reconstruction/modules/v2d_wilor/docker/run_image_list_to_hands.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.wilor.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_wilor/docker/run_image_to_hands.py
+++ b/reconstruction/modules/v2d_wilor/docker/run_image_to_hands.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.wilor.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_wilor/docker/run_masks_intersect_silhouette.py
+++ b/reconstruction/modules/v2d_wilor/docker/run_masks_intersect_silhouette.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.wilor.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_wilor/docker/run_masks_to_hands.py
+++ b/reconstruction/modules/v2d_wilor/docker/run_masks_to_hands.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.wilor.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_wilor/docker/run_render_hands_video.py
+++ b/reconstruction/modules/v2d_wilor/docker/run_render_hands_video.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.wilor.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_wilor/docker/run_shell.py
+++ b/reconstruction/modules/v2d_wilor/docker/run_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
 

--- a/reconstruction/modules/v2d_wilor/docker/run_tracks_from_wilor_masks.py
+++ b/reconstruction/modules/v2d_wilor/docker/run_tracks_from_wilor_masks.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.wilor.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_wilor/docker/run_tracks_interpolate.py
+++ b/reconstruction/modules/v2d_wilor/docker/run_tracks_interpolate.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.wilor.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_wilor/docker/run_video_to_hands.py
+++ b/reconstruction/modules/v2d_wilor/docker/run_video_to_hands.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.wilor.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_wilor/docker/run_wilor_tracks_interpolate.py
+++ b/reconstruction/modules/v2d_wilor/docker/run_wilor_tracks_interpolate.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 from v2d.docker.container import run_in_container
 from v2d.wilor.docker._config import IMAGE_NAME, MODULES_DIR
 

--- a/reconstruction/modules/v2d_wilor/lib/__init__.py
+++ b/reconstruction/modules/v2d_wilor/lib/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0

--- a/reconstruction/modules/v2d_wilor/lib/_wilor.py
+++ b/reconstruction/modules/v2d_wilor/lib/_wilor.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Singleton WiLoR loader + inference helpers.
 
 Wraps the upstream pipeline:

--- a/reconstruction/modules/v2d_wilor/lib/download_weights.py
+++ b/reconstruction/modules/v2d_wilor/lib/download_weights.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Pre-fetch WiLoR weights into ``<weights_dir>/pretrained_models/``.
 
 The pipeline auto-downloads its four files (mano_mean_params.npz,

--- a/reconstruction/modules/v2d_wilor/lib/image_list_to_hands.py
+++ b/reconstruction/modules/v2d_wilor/lib/image_list_to_hands.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """WiLoR over a folder of images: per-image JSON list in <output_dir>/<stem>.json.
 
 If ``--bboxes_dir`` is supplied, each image's corresponding ``<stem>.json``

--- a/reconstruction/modules/v2d_wilor/lib/image_to_hands.py
+++ b/reconstruction/modules/v2d_wilor/lib/image_to_hands.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Single-image WiLoR: write a JSON list of {bbox, mano, camera} detections.
 
 Detector mode:

--- a/reconstruction/modules/v2d_wilor/lib/masks_intersect_silhouette.py
+++ b/reconstruction/modules/v2d_wilor/lib/masks_intersect_silhouette.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Refine SAM2 hand masks by intersecting with a dilated MANO silhouette.
 
 For each (hand track, frame) where we have both a wilor pose record and a

--- a/reconstruction/modules/v2d_wilor/lib/masks_to_hands.py
+++ b/reconstruction/modules/v2d_wilor/lib/masks_to_hands.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Per-track per-frame WiLoR reconstruction driven by SAM2 hand masks.
 
 Mirrors ``v2d.hamer.lib.masks_to_hands`` so the two backends are A/B-swappable

--- a/reconstruction/modules/v2d_wilor/lib/pyproject.toml
+++ b/reconstruction/modules/v2d_wilor/lib/pyproject.toml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/reconstruction/modules/v2d_wilor/lib/render_hands_video.py
+++ b/reconstruction/modules/v2d_wilor/lib/render_hands_video.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Verification: render projected MANO meshes onto the source video.
 
 Accepts either the per-frame layout produced by ``video_to_hands`` /

--- a/reconstruction/modules/v2d_wilor/lib/tracks_from_wilor_masks.py
+++ b/reconstruction/modules/v2d_wilor/lib/tracks_from_wilor_masks.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Assign WiLoR per-frame detections to SAM2 tracks via silhouette IoU.
 
 WiLoR's detector runs independently per frame and produces an unordered list

--- a/reconstruction/modules/v2d_wilor/lib/tracks_interpolate.py
+++ b/reconstruction/modules/v2d_wilor/lib/tracks_interpolate.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Gap-fill per-track aligned hand records by interpolating between real frames.
 
 Consumes the output of hamer's ``align_hands`` (real-only, post-alignment):

--- a/reconstruction/modules/v2d_wilor/lib/video_to_hands.py
+++ b/reconstruction/modules/v2d_wilor/lib/video_to_hands.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """WiLoR over a video: per-frame JSON list in <output_dir>/<frame:06d>.json.
 
 The video is decoded with ffmpeg (cheaper + more robust than imageio across

--- a/reconstruction/modules/v2d_wilor/lib/wilor_tracks_interpolate.py
+++ b/reconstruction/modules/v2d_wilor/lib/wilor_tracks_interpolate.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Gap-fill per-track *pre-align* wilor records by interpolating between real frames.
 
 Consumes the camera-frame wilor schema written by ``tracks_from_wilor_masks``:

--- a/reconstruction/scripts/build_containers.sh
+++ b/reconstruction/scripts/build_containers.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # Build all v2d Docker images.
 # Run from reconstruction/ or repo root. Requires Docker and (optionally) NVIDIA Container Toolkit.
 set -e

--- a/reconstruction/scripts/build_ego_e2e_containers.sh
+++ b/reconstruction/scripts/build_ego_e2e_containers.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # Build only the Docker images required by the ego e2e pipeline
 # (modules/v2d_pipelines/run_v2d_ego_e2e.py).
 #

--- a/reconstruction/scripts/install_ego_e2e_packages.sh
+++ b/reconstruction/scripts/install_ego_e2e_packages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # Install only the host-side packages required by the ego e2e pipeline
 # (modules/v2d_pipelines/run_v2d_ego_e2e.py).
 #

--- a/reconstruction/scripts/install_packages.sh
+++ b/reconstruction/scripts/install_packages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # Install all lightweight packages: docker orchestration + v2d_pipelines.
 # Run from reconstruction/ or repo root.
 set -e

--- a/reconstruction/scripts/setup_css_env.sh
+++ b/reconstruction/scripts/setup_css_env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # Source this file to set CSS (PDX) credentials for sync_css.py.
 #
 # Usage:

--- a/reconstruction/scripts/sync_css.py
+++ b/reconstruction/scripts/sync_css.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Download or upload files/folders to CSS (NVIDIA PDX storage).
 
 Operates on swift:// URLs or bucket-relative paths used by the reconstruction

--- a/reconstruction/workflows/hello_world.yaml
+++ b/reconstruction/workflows/hello_world.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # Hello world OSMO workflow: download a file from Swift and print it.
 #
 # Usage:

--- a/reconstruction/workflows/mv_hoi/blacklist.py
+++ b/reconstruction/workflows/mv_hoi/blacklist.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Manage dataset-scoped MV HOI sequence blacklist entries.
 
 Examples:

--- a/reconstruction/workflows/mv_hoi/build_images.sh
+++ b/reconstruction/workflows/mv_hoi/build_images.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # Build all Docker images needed by the MV HOI pipelines (calibration + reconstruction).
 #
 # Usage:

--- a/reconstruction/workflows/mv_hoi/config.yaml
+++ b/reconstruction/workflows/mv_hoi/config.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 datasets:
   sc_office_4exo_1:
     swift_base: swift://pdx.s8k.io/AUTH_team-isaac/recordings/v2d/multiview/sc_office_4exo_1

--- a/reconstruction/workflows/mv_hoi/db.py
+++ b/reconstruction/workflows/mv_hoi/db.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """SQLite database for tracking pipeline versions and workflow status.
 
 Tables:

--- a/reconstruction/workflows/mv_hoi/mark_ready.py
+++ b/reconstruction/workflows/mv_hoi/mark_ready.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Create a ready_for_processing marker in the HITL S3 batch folder.
 
 Usage:

--- a/reconstruction/workflows/mv_hoi/osmo/mv_calibration.yaml
+++ b/reconstruction/workflows/mv_hoi/osmo/mv_calibration.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # MV Calibration OSMO Workflow: extract images from rosbag, calibrate extrinsics.
 #
 # Usage:

--- a/reconstruction/workflows/mv_hoi/osmo/mv_hoi_reconstruction.yaml
+++ b/reconstruction/workflows/mv_hoi/osmo/mv_hoi_reconstruction.yaml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # MV HOI Reconstruction OSMO Workflow.
 #
 # Usage:

--- a/reconstruction/workflows/mv_hoi/push_images.sh
+++ b/reconstruction/workflows/mv_hoi/push_images.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # Tag and push all MV HOI Docker images to the registry.
 #
 # Usage:

--- a/reconstruction/workflows/mv_hoi/query.py
+++ b/reconstruction/workflows/mv_hoi/query.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Query workflow status, metrics, and aggregate summaries.
 
 Single sequence:

--- a/reconstruction/workflows/mv_hoi/submit.py
+++ b/reconstruction/workflows/mv_hoi/submit.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 """Submit OSMO workflows for MV calibration and HOI reconstruction.
 
 Auto mode — scan Swift for new sequences and submit up to max_concurrent:

--- a/reconstruction/workflows/mv_hoi/submit_cron.sh
+++ b/reconstruction/workflows/mv_hoi/submit_cron.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
 export HOME=/home/dzou

--- a/reconstruction/workflows/mv_hoi/tests/test_blacklist.py
+++ b/reconstruction/workflows/mv_hoi/tests/test_blacklist.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 import sys
 import types
 from pathlib import Path


### PR DESCRIPTION
Addresses **both items** of OSRB comment #7 (Michael Hasper).

## Item 1 — SPDX headers on code-only files
- Flips the SPDX identifier on **534** NVIDIA-authored code/config files under `reconstruction/` from `CC-BY-4.0 AND Apache-2.0` → **`Apache-2.0`**.
- Updates the top-level README License section. The dual license **text** (top-level + per-package `LICENSE`) is unchanged.
- The flagged representative file now shows `SPDX-License-Identifier: Apache-2.0`.

## Item 2 — NOTICE dependency clarification
The NOTICE previously labelled ~13 components "(vendored source)" under one heading, implying far more was redistributed than actually is. Now split into two explicit groups:
- **Redistributed in this source tree:** only **FoundationPose** (NVIDIA Source Code License — NVIDIA-authored) and **SAM3D-Body/sam_3d_body** (Meta SAM License — commercial use permitted), plus a few permissive Apache-2.0 Detectron2/SAM2 support files.
- **Fetched at build/download (NOT redistributed):** UniDepth, WiLoR, BundleSDF, FoundationStereo, MoGe, SAM2, GroundingDINO, DROID-SLAM, Detectron2, Depth-Anything, HaMeR — only thin NVIDIA wrappers committed; upstream obtained from the project URL at build/download time.

Mirrors the same corrections on `main` (PR #100).