### PR TITLE
[video_ingestion] webapp: count distinct videos in batch progress, no…

### DIFF
--- a/video_ingestion_agent/src/video_ingestion_agent/utils/sharding.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/utils/sharding.py
@@ -326,6 +326,52 @@ def process_videos(
     return results
 
 
+def aggregate_worker_progress(output_dir: Path) -> dict[str, dict[str, Any]]:
+    """Aggregate per-worker progress JSONL into one record per video.
+
+    Reads every ``progress_worker_*.jsonl`` under *output_dir* and returns a
+    mapping ``video_id -> latest record`` (the last line written for a given
+    video wins). The ``worker_id`` parsed from each filename is added to the
+    record.
+
+    Deduping by ``video_id`` makes the result robust to three things a naive
+    line-summing reader gets wrong:
+
+    * stale records left in the file by a prior run into the same dir,
+    * the file being truncated and recreated mid-run on a non-resume launch
+      (a concurrent poller, e.g. the webapp Ingest tab, otherwise double-counts
+      records across the rewrite and reports more videos than were processed),
+    * orphan ``progress_worker_N.jsonl`` files from a prior run that used more
+      shards than the current one.
+
+    Callers should count distinct videos from this mapping rather than summing
+    raw JSONL lines.
+    """
+    counted: dict[str, dict[str, Any]] = {}
+    for pf in sorted(output_dir.glob("progress_worker_*.jsonl")):
+        try:
+            wid = int(pf.stem.split("_")[-1])
+        except ValueError:
+            continue
+        try:
+            lines = pf.read_text().splitlines()
+        except OSError:
+            continue
+        for jline in lines:
+            jline = jline.strip()
+            if not jline:
+                continue
+            try:
+                rec = json.loads(jline)
+            except json.JSONDecodeError:
+                continue
+            vid = rec.get("video_id") or Path(rec.get("video", "")).stem
+            if not vid:
+                continue
+            counted[vid] = {**rec, "worker_id": wid}
+    return counted
+
+
 # ---------------------------------------------------------------------------
 # Parallel Worker Orchestration
 # ---------------------------------------------------------------------------

--- a/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/ingestion_tab.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/webapp/tabs/ingestion_tab.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
 """Video ingestion tab for uploading and processing videos."""
 
-import json
 import logging
 import subprocess
 import sys
@@ -12,6 +11,7 @@ from typing import Any
 
 import gradio as gr
 
+from video_ingestion_agent.utils.sharding import aggregate_worker_progress
 from video_ingestion_agent.webapp.config import AppConfig
 
 logger = logging.getLogger(__name__)
@@ -289,48 +289,45 @@ def create_ingestion_tab(services: dict[str, Any], config: AppConfig) -> dict[st
         # Poll subprocess stdout and worker progress JSONL files.
         # Detailed per-worker logs are viewed separately via the Worker Logs
         # accordion (dropdown + refresh).
-        progress_lines_read: dict[int, int] = {}  # worker_id -> jsonl lines consumed
+        # video_ids already emitted to the log panel, so each video is logged
+        # once even though counts are recomputed from scratch every poll.
+        logged_video_ids: set[str] = set()
         t_start = time.time()
 
         def _read_worker_progress() -> tuple[int, int, int]:
-            """Read all progress_worker_*.jsonl files and aggregate counts."""
+            """Recompute absolute aggregate counts from all progress files.
+
+            Returns ``(success, failed, total_clips)`` deduped by ``video_id``,
+            recomputed from the full files each call. This is idempotent and
+            robust to the backend truncating/recreating a progress file
+            mid-run -- unlike a stateful line-offset reader, which double-counts
+            records across such a rewrite and reports more videos than were
+            processed. The caller assigns the result; it must not accumulate.
+            """
+            records = aggregate_worker_progress(output_path)
             success = 0
             failed = 0
             total_clips = 0
-            for pf in output_path.glob("progress_worker_*.jsonl"):
-                try:
-                    wid = int(pf.stem.split("_")[-1])
-                except ValueError:
-                    continue
-                start_line = progress_lines_read.get(wid, 0)
-                try:
-                    with open(pf) as f:
-                        all_lines = f.readlines()
-                except Exception:
-                    continue
-                for jline in all_lines[start_line:]:
-                    jline = jline.strip()
-                    if not jline:
-                        continue
-                    try:
-                        rec = json.loads(jline)
-                    except json.JSONDecodeError:
-                        continue
-                    vid_name = Path(rec.get("video", "")).name
-                    status = rec.get("status", "unknown")
+            for vid, rec in records.items():
+                status = rec.get("status", "unknown")
+                clips = rec.get("n_clips", 0)
+                if status == "success":
+                    success += 1
+                    total_clips += clips
+                else:
+                    failed += 1
+                if vid not in logged_video_ids:
+                    logged_video_ids.add(vid)
+                    wid = rec.get("worker_id", 0)
+                    vid_name = Path(rec.get("video", "")).name or vid
                     elapsed_s = rec.get("elapsed_s", 0)
-                    clips = rec.get("n_clips", 0)
                     if status == "success":
-                        success += 1
-                        total_clips += clips
                         logs.append(
                             f"  [Worker {wid}] {vid_name}: {clips} clips ({elapsed_s:.1f}s)"
                         )
                     else:
-                        failed += 1
                         err = rec.get("error", "")
                         logs.append(f"  [Worker {wid}] {vid_name}: FAILED - {err}")
-                progress_lines_read[wid] = len(all_lines)
             return success, failed, total_clips
 
         # Stream subprocess output + progress summaries
@@ -353,11 +350,8 @@ def create_ingestion_tab(services: dict[str, Any], config: AppConfig) -> dict[st
             if now - last_poll > 2.0:
                 last_poll = now
 
-                # `_read_worker_progress()` returns deltas — accumulate, don't assign.
-                d_done, d_failed, d_clips = _read_worker_progress()
-                done_videos += d_done
-                failed_videos += d_failed
-                total_clips += d_clips
+                # Absolute totals, deduped by video_id — assign, don't accumulate.
+                done_videos, failed_videos, total_clips = _read_worker_progress()
 
                 elapsed = now - t_start
                 desc = (
@@ -384,11 +378,8 @@ def create_ingestion_tab(services: dict[str, Any], config: AppConfig) -> dict[st
             if not line:
                 time.sleep(0.5)
 
-        # Final delta read — accumulate the same way the poll loop does.
-        d_done, d_failed, d_clips = _read_worker_progress()
-        done_videos += d_done
-        failed_videos += d_failed
-        total_clips += d_clips
+        # Final read — absolute totals, same as the poll loop.
+        done_videos, failed_videos, total_clips = _read_worker_progress()
         elapsed = time.time() - t_start
 
         progress(1.0, desc="Batch ingestion complete")

--- a/video_ingestion_agent/tests/test_sharding.py
+++ b/video_ingestion_agent/tests/test_sharding.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: CC-BY-4.0 AND Apache-2.0
+"""Tests for batch-ingestion sharding utilities.
+
+Focus: ``aggregate_worker_progress``, which the webapp Ingest tab uses to count
+processed videos from ``progress_worker_*.jsonl``. It must dedup by ``video_id``
+so a stale/duplicated/orphaned record never inflates the count above the number
+of distinct videos actually processed.
+"""
+
+import json
+from pathlib import Path
+
+from video_ingestion_agent.utils.sharding import aggregate_worker_progress
+
+
+def _write_progress(path: Path, records: list[dict]) -> None:
+    path.write_text("".join(json.dumps(r) + "\n" for r in records))
+
+
+def _rec(video_id: str, *, status: str = "success", n_clips: int = 3) -> dict:
+    return {
+        "video": f"data/test_videos/{video_id}.mp4",
+        "video_id": video_id,
+        "status": status,
+        "elapsed_s": 49.7,
+        "n_clips": n_clips,
+        "error": None,
+    }
+
+
+def test_empty_dir_returns_no_records(tmp_path):
+    assert aggregate_worker_progress(tmp_path) == {}
+
+
+def test_counts_distinct_videos(tmp_path):
+    _write_progress(
+        tmp_path / "progress_worker_0.jsonl",
+        [_rec("test_1"), _rec("test_2")],
+    )
+    records = aggregate_worker_progress(tmp_path)
+    assert set(records) == {"test_1", "test_2"}
+    success = sum(1 for r in records.values() if r["status"] == "success")
+    assert success == 2
+    assert sum(r["n_clips"] for r in records.values()) == 6
+
+
+def test_stale_and_new_lines_for_same_video_count_once(tmp_path):
+    """Reproduces the reported bug: a truncate/recreate race left a file
+    containing a stale record plus the two real records of this run. A
+    line-summing reader reported 3 videos / 9 clips; deduping by video_id
+    must report 2 distinct videos / 6 clips."""
+    _write_progress(
+        tmp_path / "progress_worker_0.jsonl",
+        [_rec("test_1"), _rec("test_2"), _rec("test_2")],  # test_2 appears twice
+    )
+    records = aggregate_worker_progress(tmp_path)
+    assert set(records) == {"test_1", "test_2"}
+    success = sum(1 for r in records.values() if r["status"] == "success")
+    assert success == 2
+    assert sum(r["n_clips"] for r in records.values()) == 6
+
+
+def test_latest_record_wins_for_duplicate_video_id(tmp_path):
+    """A re-processed video appends a second line; the latest status wins."""
+    _write_progress(
+        tmp_path / "progress_worker_0.jsonl",
+        [
+            _rec("test_1", status="error", n_clips=0),
+            _rec("test_1", status="success", n_clips=4),
+        ],
+    )
+    records = aggregate_worker_progress(tmp_path)
+    assert records["test_1"]["status"] == "success"
+    assert records["test_1"]["n_clips"] == 4
+
+
+def test_orphan_worker_file_from_higher_shard_count_deduped(tmp_path):
+    """A prior run used 2 shards; this run used 1. The orphan
+    progress_worker_1.jsonl must not double-count a video already in
+    progress_worker_0.jsonl."""
+    _write_progress(
+        tmp_path / "progress_worker_0.jsonl",
+        [_rec("test_1"), _rec("test_2")],
+    )
+    _write_progress(
+        tmp_path / "progress_worker_1.jsonl",
+        [_rec("test_2")],  # orphan duplicate of test_2 from the old 2-shard run
+    )
+    records = aggregate_worker_progress(tmp_path)
+    assert set(records) == {"test_1", "test_2"}
+
+
+def test_ignores_blank_and_malformed_lines(tmp_path):
+    path = tmp_path / "progress_worker_0.jsonl"
+    path.write_text(
+        json.dumps(_rec("test_1"))
+        + "\n\n"  # blank line
+        + "{not valid json\n"  # malformed
+        + json.dumps(_rec("test_2"))
+        + "\n"
+    )
+    records = aggregate_worker_progress(tmp_path)
+    assert set(records) == {"test_1", "test_2"}
+
+
+def test_video_id_falls_back_to_stem(tmp_path):
+    _write_progress(
+        tmp_path / "progress_worker_0.jsonl",
+        [{"video": "data/test_videos/clip_a.mp4", "status": "success", "n_clips": 1}],
+    )
+    records = aggregate_worker_progress(tmp_path)
+    assert set(records) == {"clip_a"}
+
+
+def test_records_carry_worker_id(tmp_path):
+    _write_progress(tmp_path / "progress_worker_3.jsonl", [_rec("test_1")])
+    records = aggregate_worker_progress(tmp_path)
+    assert records["test_1"]["worker_id"] == 3
+
+
+def test_non_integer_worker_suffix_skipped(tmp_path):
+    _write_progress(tmp_path / "progress_worker_main.jsonl", [_rec("test_1")])
+    _write_progress(tmp_path / "progress_worker_0.jsonl", [_rec("test_2")])
+    records = aggregate_worker_progress(tmp_path)
+    assert set(records) == {"test_2"}


### PR DESCRIPTION
…t raw lines

The Ingest tab's Log Output over-reported processed videos when reusing an output directory: a 2-video run was shown as "3 / 9 clips" while the worker log correctly reported 2 videos / 6 clips. Re-clicking Start showed the right value "for a moment", the signature of a race rather than stale-data summing.

Root cause: `_read_worker_progress()` used stateful line-offset accounting (`progress_lines_read[wid]`) that assumed `progress_worker_*.jsonl` only ever grows. Commit 78322a34 made the file shrink (unlink + rewrite at the start of a non-resume run). The webapp polls the file every 2s concurrently with the worker subprocess, so a poll firing before truncation read the prior run's stale lines, after which the now-invalid offset re-counted a freshly written line against the shorter file -> an inflated count. The same offset reader also double-counted on resume runs (file never truncated) and across orphan `progress_worker_N.jsonl` files left by a run that used more shards.

Fix: make the reader stateless and idempotent instead of patching truncation timing. New pure helper `aggregate_worker_progress()` in sharding.py reads every progress file and returns one record per `video_id` (last line wins), deduping across stale entries, mid-run rewrites, and orphan shard files. The webapp now recomputes absolute totals from this mapping each poll and assigns (no longer accumulates deltas), so the displayed count can never exceed the number of distinct videos actually processed.

Add tests/test_sharding.py covering the reported 3-lines/2-videos case, orphan shard files, re-processed "latest wins", and malformed/blank lines.