### PR TITLE
[video_ingestion] ingestion: drop failed chunks instead of fabricatin…

### DIFF
--- a/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/segmenter.py
+++ b/video_ingestion_agent/src/video_ingestion_agent/ingestion/segmentation/segmenter.py
@@ -313,20 +313,19 @@ class HybridSegmenter:
 
             logger.error(traceback.format_exc())
 
-            # Fallback: return entire chunk as single segment
-            clip_id = f"{Path(video_path).stem}_clip_{global_clip_idx + 1:04d}"
-            return [
-                ClipContext(
-                    clip_id=clip_id,
-                    video_path=video_path,
-                    start_t=chunk_start,
-                    end_t=chunk_end,
-                    object="unknown",
-                    action="manipulation",
-                    description="Video segment (segmentation failed)",
-                    metadata={"fps": fps, "confidence": 0.3},
-                )
-            ]
+            # Drop this chunk's contribution instead of fabricating a segment.
+            # Previously this returned a synthetic "manipulation" clip spanning
+            # the whole chunk, which injected fake action_segments + frame
+            # embeddings into the (shared) databases that downstream retrieval
+            # then treated as real. A failed chunk must yield no segments, never
+            # a placeholder. The API backend already retries with backoff before
+            # an exception reaches here, so this path means the chunk is
+            # genuinely unrecoverable, not a transient blip.
+            logger.warning(
+                f"  Dropping chunk [{chunk_start:.1f}s-{chunk_end:.1f}s]: "
+                f"no segments produced due to error"
+            )
+            return []
 
         finally:
             # Clean up temp chunk

--- a/video_ingestion_agent/tests/test_ingestion.py
+++ b/video_ingestion_agent/tests/test_ingestion.py
@@ -985,3 +985,52 @@ class TestValidClipsFilter:
         verifications = [self._make_verification("a", False)]
         state = {"clips": clips, "verifications": verifications}
         assert _valid_clips(state) == []
+
+
+# ========================================================================
+# 15. Segmenter failure handling (no fabricated placeholder segments)
+# ========================================================================
+
+
+class TestSegmenterFailureHandling:
+    """A failed chunk must drop its contribution, not fabricate a segment.
+
+    Regression: a backend error (e.g. a 401 after retries are exhausted) used
+    to return a synthetic "manipulation" clip spanning the whole chunk. That
+    placeholder polluted the shared databases with fake action_segments and
+    frame embeddings that downstream retrieval treated as real, while the run
+    still exited 0 and rendered a normal-looking success report.
+    """
+
+    def test_segment_chunk_failure_returns_empty(self):
+        from unittest.mock import MagicMock
+
+        from video_ingestion_agent.ingestion.config import PipelineConfig
+        from video_ingestion_agent.ingestion.segmentation.segmenter import HybridSegmenter
+
+        config = PipelineConfig()
+        segmenter = HybridSegmenter(config)
+
+        # Inject a model that fails the way the API backend surfaces a 401
+        # once its internal retry/backoff loop is exhausted. Seeding the
+        # private cache makes _get_model() return it without touching the
+        # ModelManager (no GPU / network).
+        failing_model = MagicMock()
+        failing_model.generate_from_video.side_effect = RuntimeError(
+            "API request failed after 5 attempts: 401 Client Error: Unauthorized"
+        )
+        segmenter._model = failing_model
+
+        # chunk_end == video_duration -> no temp-chunk extraction, so the path
+        # reaches the VLM call directly without needing a real file or ffmpeg.
+        clips = segmenter._segment_chunk(
+            video_path="/nonexistent/video.mp4",
+            chunk_start=0.0,
+            chunk_end=10.0,
+            video_duration=10.0,
+            fps=30.0,
+            global_clip_idx=0,
+        )
+
+        assert clips == []
+        failing_model.generate_from_video.assert_called_once()


### PR DESCRIPTION
…g placeholder segments

A backend error during segmentation (e.g. a 401 surfaced after the API backend retry/backoff loop is exhausted) was caught by a blanket except in _segment_chunk, which returned a synthetic "manipulation" clip spanning the whole chunk. That placeholder propagated into the shared databases: a fake action_segments row (success=1 while its own evidence read "segmentation failed", quality_score=0.3) plus frame embeddings that downstream retrieval treated as real, while the run still exited 0 and rendered a normal-looking success report. In a batch over a shared outputs/ directory, every failed video polluted the graph.

Fix: drop the chunk contribution on failure (return []) instead of fabricating a segment. Total failure (all chunks fail) writes 0 segments and 0 embeddings; partial failure keeps the good chunks with no placeholder. An empty/failed chunk was already reachable (parse failures return []), and every downstream node handles 0 clips, so the change is contained.

Loud-exit on total failure, the dangling video_metadata row, batch skip-vs-abort policy, and making success reflect outcome are tracked separately for the next release.

Adds a regression test asserting a failing chunk yields no clips.