### PR TITLE
[object_reconstruction] Add toy airplane GLB mesh assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 
 # 3D mesh formats
 *.obj filter=lfs diff=lfs merge=lfs -text
+*.glb filter=lfs diff=lfs merge=lfs -text
 *.stl filter=lfs diff=lfs merge=lfs -text
 *.STL filter=lfs diff=lfs merge=lfs -text
 *.mtl filter=lfs diff=lfs merge=lfs -text

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/objects/toy_airplane/bundlesdf/output_aligned.glb
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/objects/toy_airplane/bundlesdf/output_aligned.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7894d5a17025c1793fe89feea65d9207a6f6e8f309726238f5b82bfe36e4054
+size 3982884

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/objects/toy_airplane/einstar/output_aligned.glb
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/objects/toy_airplane/einstar/output_aligned.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1442cafb45689a1725e2541dcbf42592e4ea914b6d0fa4a5d38fd4b6e9014438
+size 11197504

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/objects/toy_airplane/sam3d/airplane.glb
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/objects/toy_airplane/sam3d/airplane.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5c3e885ad74bbfd4d4a07119efd00420862cc49e3ebd61aed60e03a86b23091
+size 13337960


### PR DESCRIPTION
## Summary
- Add toy airplane GLB mesh assets from swift://pdx.s8k.io/AUTH_team-isaac/recordings/v2d/mesh/toy_airplane/.
- Preserve the downstream-compatible method layout for BundleSDF and Einstar: bundlesdf/output_aligned.glb and einstar/output_aligned.glb.
- Include the available SAM3D mesh as sam3d/airplane.glb; the source folder does not include a SAM3D output_aligned.glb.
- Add *.glb to the repo-level Git LFS rules so these meshes are stored in LFS.

## Notes
- Raw non-aligned BundleSDF/Einstar GLBs are intentionally omitted.

## Validation
- osmo data list --recursive swift://pdx.s8k.io/AUTH_team-isaac/recordings/v2d/mesh/toy_airplane/
- osmo data download swift://pdx.s8k.io/AUTH_team-isaac/recordings/v2d/mesh/toy_airplane/ /tmp/toy_airplane_mesh --processes 4 --threads 8
- git lfs status
- git diff --check origin/main..HEAD
