### PR TITLE
Add airplane example video datacard to release

### DIFF
--- a/reconstruction/assets/airplane_datacard.md
+++ b/reconstruction/assets/airplane_datacard.md
@@ -1,0 +1,65 @@
+---
+license: cc-by-4.0
+task_categories:
+  - robotics
+tags:
+  - video
+  - hands
+  - manipulation
+  - dexterous-manipulation
+  - egocentric
+  - demonstration
+size_categories:
+  - n<1K
+---
+
+# Hands Manipulation Video
+
+## Dataset Description:
+This dataset consists of a single video clip (`airplane.mp4`) showing a pair of human hands manipulating a toy airplane. The footage is framed on the hands and the object only — no faces or other personally identifiable features are visible. It is intended as a lightweight visual example of dexterous hand–object interaction for use in demonstrations and pipeline examples.
+
+## Dataset Owner(s):
+NVIDIA Corporation <br>
+
+## Dataset Creation Date:
+May 2026 <br>
+
+## Version:
+v0.1.0 <br>
+
+## License/Terms of Use:
+[Creative Commons Attribution 4.0 International (CC BY-4.0)](https://creativecommons.org/licenses/by/4.0/) <br>
+
+## Intended Usage:
+This dataset is intended for demonstration purposes — for example, as sample input when illustrating video-processing, hand-tracking, or hand–object manipulation workflows. It is not intended for training production models or for deployment in physical systems. <br>
+
+## Dataset Characterization
+**Data Collection Method:** <br>
+* Human — The video was recorded with a physical camera capturing a person's hands manipulating an object. <br>
+
+**Labeling Method:** <br>
+* Not Applicable — The dataset contains the raw video only; no annotations, tags, or labels are included. <br>
+
+## Dataset Format:
+Video. A single MP4 (H.264) file (`airplane.mp4`). <br>
+
+| Property | Value |
+|----------|-------|
+| Container / codec | MP4 / H.264 |
+| Resolution | 1280×800 |
+| Frame rate | 30 fps |
+| Duration | 0:26 (780 frames) |
+| Audio | None |
+
+## Dataset Quantification:
+* Record Count: 1 video file <br>
+* Feature Count: 0 (unlabeled raw video) <br>
+* Total Data Storage: ~25 MB <br>
+
+## Reference(s):
+Not Applicable — no associated paper or public repository. <br>
+
+## Ethical Considerations:
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. Developers should work with their internal developer teams to ensure this dataset meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>


### PR DESCRIPTION
Cherry-picks 3b405ef1 from main, adding reconstruction/assets/airplane_datacard.md for the airplane example video.