### PR TITLE
Add recon hand mdp training for rigid, articulated, and multi-object sequences

### DIFF
--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/apply_scene_config.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/apply_scene_config.py
@@ -57,6 +57,7 @@ def _spawn_articulated(
     obj_rot = (
         tuple(float(r) for r in obj.init_rot) if obj.init_rot else (1.0, 0.0, 0.0, 0.0)
     )
+    joint_pos = float(obj.init_joint_pos) if obj.init_joint_pos is not None else 0.0
     return ARTICULATED_OBJECT_CFG.replace(
         prim_path=prim_path,
         spawn=ARTICULATED_OBJECT_CFG.spawn.replace(
@@ -66,7 +67,7 @@ def _spawn_articulated(
         init_state=ArticulationCfg.InitialStateCfg(
             pos=obj_pos,
             rot=obj_rot,
-            joint_pos={".*": 0.0},
+            joint_pos={".*": joint_pos},
             joint_vel={".*": 0.0},
         ),
         actuators={
@@ -444,8 +445,15 @@ def apply_scene_config(
         if object_attr_names:
             env_cfg.commands.motion.object_name = object_attr_names[0]
             env_cfg.commands.motion.object_body_names = object_attr_names
+        whole_body_step_dt = float(env_cfg.sim.dt) * int(env_cfg.decimation)
+        reset_freeze_steps = int(
+            getattr(env_cfg.commands.motion, "reset_freeze_steps", 0)
+        )
+        whole_body_episode_length_s = (
+            scene_config.episode_length_s + reset_freeze_steps * whole_body_step_dt
+        )
         env_cfg.episode_length_s = min(
-            env_cfg.episode_length_s, scene_config.episode_length_s
+            env_cfg.episode_length_s, whole_body_episode_length_s
         )
 
         # Contact sensors for whole-body

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/scene_config.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/scene_config.py
@@ -399,7 +399,7 @@ class SceneConfig:
     def _build_episode_length_s(data: dict) -> float:
         """Build the episode length from the parquet data."""
         try:
-            timesteps = len(data.get("object_articulation", [[]])[0])
+            timesteps = len(data.get("object_body_position", [[]])[0])
             fps = data.get("fps", [30.0])[0]
             episode_length_s = float(timesteps / fps)
         except Exception:
@@ -439,11 +439,14 @@ def _load_articulated_poses(data: dict, obj: ArticulatedObjectConfig) -> None:
         obj.body_init_positions = [
             [p + o for p, o in zip(bp, offset, strict=True)] for bp in frame0
         ]
+        body0_pos = list(frame0[0])
+        obj.init_pos = [p + o for p, o in zip(body0_pos, offset, strict=True)]
 
     body_rot = data.get("object_body_wxyz")
     if body_rot and body_rot[0]:
         frame0 = body_rot[0][0]
         obj.body_init_rotations = [list(bw) for bw in frame0]
+        obj.init_rot = list(frame0[0])
 
     art = data.get("object_articulation")
     if art and art[0]:

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/config/sonic/g1/g1_sonic_env_cfg.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/config/sonic/g1/g1_sonic_env_cfg.py
@@ -3,6 +3,7 @@
 import isaaclab.envs.mdp as il_mdp
 from isaaclab.envs.mdp import observations
 from isaaclab.managers import CurriculumTermCfg as CurrTerm
+from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import RewardTermCfg as RewTerm
@@ -15,9 +16,11 @@ from robotic_grounding.assets import POLICY_ASSET_DIR
 from robotic_grounding.assets.g1 import (
     G1_CYLINDER_MODEL_12_HANDS_DEX_DELAYED_CFG,
     G1_DEX_CONTACT_BODIES,
+    G1_HAND_JOINT_NAMES,
     G1_MODEL_12_ACTION_SCALE,
 )
-from robotic_grounding.tasks.v2p_whole_body.base_env_cfg import V2PEnvCfg
+from robotic_grounding.tasks.v2p.mdp.events import configure_collision_groups
+from robotic_grounding.tasks.v2p_whole_body.base_env_cfg import BaseEventsCfg, V2PEnvCfg
 from robotic_grounding.tasks.v2p_whole_body.mdp import observations as obs
 from robotic_grounding.tasks.v2p_whole_body.mdp.actions import (
     SONICActionCfg,
@@ -35,6 +38,7 @@ from robotic_grounding.tasks.v2p_whole_body.mdp.terminations import (
     anchor_quat_error,
     ee_position_error,
     ee_quat_error,
+    hand_wrist_away_from_trajectory,
     object_pos_error,
     object_quat_error,
     timestep_termination,
@@ -170,7 +174,7 @@ class G1PolicyCfg(ObsGroup):
     """Unified policy observations for whole-body tracking.
 
     Egocentric (body frame) for hand/object state, 6D rotation throughout,
-    delta-based for future frames.
+    and legacy absolute anchor positions for checkpoint compatibility.
     """
 
     wrist_position_b = ObsTerm(
@@ -218,7 +222,11 @@ class G1PolicyCfg(ObsGroup):
     )
     motion_anchor_pos_b = ObsTerm(
         func=obs.motion_anchor_pos_b,
-        params={"command_name": "motion", "num_future_frames": 3},
+        params={
+            "command_name": "motion",
+            "num_future_frames": 3,
+            "frame": "absolute",
+        },
     )
     motion_anchor_ori_b = ObsTerm(
         func=obs.motion_anchor_ori_b,
@@ -264,6 +272,126 @@ class G1SonicObservationsCfg:
     sonic_tokenizer: G1SONICEncoderCfg = G1SONICEncoderCfg()
     sonic_policy: G1SONICDecoderCfg = G1SONICDecoderCfg()
     hand_policy: G1HandPolicyCfg = G1HandPolicyCfg()
+
+
+# ---------------------------------------------------------------------------
+# ReconHand observations
+# ---------------------------------------------------------------------------
+
+
+@configclass
+class G1ReconHandPolicyCfg(ObsGroup):
+    """Policy (actor) observations for the hand-recon whole-body task.
+
+    Shape: 385 for single-body objects, plus 14 dims per additional object body.
+    """
+
+    wrist_velocity_b = ObsTerm(
+        func=obs.wrist_velocity_full_b,
+        params={"command_name": "motion"},
+        noise=Unoise(n_min=-0.01, n_max=0.01),
+    )
+    joint_pos_rel = ObsTerm(
+        func=obs.joint_pos_rel,
+        params={
+            "asset_cfg": SceneEntityCfg("robot"),
+            "sonic_joints_only": False,
+            "action_name": "joint_pos",
+        },
+        noise=Unoise(n_min=-0.01, n_max=0.01),
+    )
+    joint_vel_rel = ObsTerm(
+        func=obs.joint_vel_rel,
+        params={
+            "asset_cfg": SceneEntityCfg("robot"),
+            "sonic_joints_only": False,
+            "action_name": "joint_pos",
+        },
+        noise=Unoise(n_min=-0.01, n_max=0.01),
+    )
+    motion_anchor_pos_b = ObsTerm(
+        func=obs.motion_anchor_pos_b,
+        params={
+            "command_name": "motion",
+            "num_future_frames": 3,
+            "frame": "relative",
+        },
+    )
+    motion_anchor_ori_b = ObsTerm(
+        func=obs.motion_anchor_ori_b,
+        params={"command_name": "motion", "num_future_frames": 3},
+    )
+    motion_joint_pos_delta = ObsTerm(
+        func=obs.motion_joint_pos_delta,
+        params={"command_name": "motion", "num_future_frames": 3},
+    )
+    motion_ee_pos_delta = ObsTerm(
+        func=obs.motion_ee_pos_delta,
+        params={"command_name": "motion", "num_future_frames": 3},
+    )
+    motion_ee_quat_delta = ObsTerm(
+        func=obs.motion_ee_quat_delta,
+        params={"command_name": "motion", "num_future_frames": 3},
+    )
+    left_hand_object_transform = ObsTerm(
+        func=obs.hand_object_reference_transform,
+        params={
+            "side": "left",
+            "command_name": "motion",
+            "threshold": 10.0,
+        },
+    )
+    right_hand_object_transform = ObsTerm(
+        func=obs.hand_object_reference_transform,
+        params={
+            "side": "right",
+            "command_name": "motion",
+            "threshold": 10.0,
+        },
+    )
+    object_pose_delta = ObsTerm(
+        func=obs.object_pose_delta,
+        params={"command_name": "motion"},
+    )
+    trajectory_progress = ObsTerm(func=obs.command_trajectory_progress)
+    base_ang_vel = ObsTerm(
+        func=observations.base_ang_vel,
+        params={"asset_cfg": SceneEntityCfg("robot")},
+    )
+    actions = ObsTerm(
+        func=obs.last_action,
+        params={"action_name": "joint_pos", "sonic_joints_only": False},
+    )
+    wrist_position_e = ObsTerm(
+        func=obs.wrist_position_e,
+        params={"command_name": "motion"},
+        noise=Unoise(n_min=-0.01, n_max=0.01),
+    )
+    wrist_wxyz_e = ObsTerm(
+        func=obs.wrist_wxyz_e,
+        params={"command_name": "motion"},
+        noise=Unoise(n_min=-0.01, n_max=0.01),
+    )
+    object_position_e = ObsTerm(
+        func=obs.object_position_e,
+        params={"command_name": "motion"},
+        noise=Unoise(n_min=-0.01, n_max=0.01),
+    )
+    object_wxyz_e = ObsTerm(
+        func=obs.object_wxyz_e,
+        params={"command_name": "motion"},
+        noise=Unoise(n_min=-0.01, n_max=0.01),
+    )
+    concatenate_terms = True
+
+
+@configclass
+class G1SonicReconHandObservationsCfg:
+    """Observation config for the hand-recon whole-body task."""
+
+    policy: G1ReconHandPolicyCfg = G1ReconHandPolicyCfg()
+    sonic_tokenizer: G1SONICEncoderCfg = G1SONICEncoderCfg()
+    sonic_policy: G1SONICDecoderCfg = G1SONICDecoderCfg()
 
 
 # ---------------------------------------------------------------------------
@@ -485,8 +613,9 @@ class G1SonicReconBodyEnvCfg(G1SonicEnvCfg):
 
 @configclass
 class G1SonicReconHandRewardsCfg(G1SonicRewardsCfg):
-    """Rewards for hand-accurate references (from exp201)."""
+    """Rewards for the hand-recon whole-body task."""
 
+    termination_penalty = RewTerm(func=il_mdp.is_terminated, weight=-100.0)
     motion_hand_keypoints_gaussian_exp = RewTerm(
         func=tracking_rewards.motion_hand_keypoints_gaussian_exp,
         weight=1.0,
@@ -497,12 +626,140 @@ class G1SonicReconHandRewardsCfg(G1SonicRewardsCfg):
         weight=1.0,
         params={"command_name": "motion", "std": 1.0},
     )
+    motion_object_keypoints_tracking_exp = RewTerm(
+        func=tracking_rewards.motion_object_keypoints_tracking_exp,
+        weight=0.0,
+        params={"command_name": "motion", "var": 0.1},
+    )
+    motion_contact_tracking_gaussian_exp = RewTerm(
+        func=tracking_rewards.motion_contact_tracking_gaussian_exp,
+        weight=0.0,
+        params={"command_name": "motion", "std": 0.05},
+    )
+    contact_wrench_support_reward = RewTerm(
+        func=contact_rewards.contact_wrench_support_reward,
+        weight=0.0,
+        params={"command_name": "motion", "tolerance": 0.1, "var": 0.1},
+    )
+    unintended_contact_penalty = RewTerm(
+        func=contact_rewards.unintended_contact_penalty,
+        weight=0.0,
+        params={"command_name": "motion"},
+    )
+    missed_contact_penalty = RewTerm(
+        func=contact_rewards.missed_contact_penalty,
+        weight=0.0,
+        params={"command_name": "motion"},
+    )
     action_rate = RewTerm(func=il_mdp.action_rate_l2, weight=-0.001)
     action_l2 = RewTerm(func=il_mdp.action_l2, weight=-0.0001)
+    joint_pos_limit = RewTerm(
+        func=il_mdp.joint_pos_limits,
+        weight=0.0,
+        params={"asset_cfg": SceneEntityCfg("robot", joint_names=[".*"])},
+    )
+
+
+@configclass
+class G1SonicReconHandCurriculumCfg:
+    """ReconHand curriculum hooks.
+
+    Defaults to no-op. Experiment configs can enable fixed VOC schedules by
+    overriding `timestep_schedule` and `virtual_object_control_scale_factor`.
+    """
+
+    voc_curriculum = CurrTerm(
+        func=WholeBodyFixedTimestepVOCCurriculum,
+        params={
+            "command_name": "motion",
+            "num_steps_per_env": 24,
+            # Single disabled stage (VOC target 0.0). Experiments override these two
+            # equal-length lists to enable a PPO-update VOC decay schedule.
+            "timestep_schedule": [0],
+            "virtual_object_control_scale_factor": [0.0],
+        },
+    )
+
+
+@configclass
+class G1SonicReconHandTerminationsCfg:
+    """Termination config for the hand-recon task.
+
+    Drops EE pos/quat terminations (redundant: the reference EE depends on the
+    current object pose, covered by hand_wrist_away_from_trajectory) and adds the
+    hand-away termination. Object terminations are effectively disabled.
+    """
+
+    timeout = DoneTerm(
+        func=timestep_termination,
+        time_out=True,
+        params={"command_name": "motion"},
+    )
+    anchor_pos_error = DoneTerm(
+        func=anchor_pos_error,
+        params={"command_name": "motion", "threshold": 0.70},
+    )
+    anchor_quat_error = DoneTerm(
+        func=anchor_quat_error,
+        params={"command_name": "motion", "threshold": 1.50},
+    )
+    hand_wrist_away = DoneTerm(
+        func=hand_wrist_away_from_trajectory,
+        params={"command_name": "motion", "threshold": 0.15},
+    )
+    object_pos_error = DoneTerm(
+        func=object_pos_error,
+        params={"command_name": "motion", "threshold": 100.0},
+    )
+    object_quat_error = DoneTerm(
+        func=object_quat_error,
+        params={"command_name": "motion", "threshold": 100.0},
+    )
+
+
+@configclass
+class G1SonicReconHandEventsCfg(BaseEventsCfg):
+    """Events for hand-recon scene collision grouping."""
+
+    setup_collision_groups = EventTerm(
+        func=configure_collision_groups,
+        mode="prestartup",
+        params={
+            "robot_names": ["Robot"],
+            "object_names": [],
+            "fixed_object_names": [],
+            "disable_robot_to_object_collisions": False,
+            "disable_robot_to_fixed_object_collisions": False,
+        },
+    )
 
 
 @configclass
 class G1SonicReconHandEnvCfg(G1SonicEnvCfg):
     """Hand-accurate reference env (planner pipeline)."""
 
+    # Hand-recon actor observations; overrides the inherited generic obs config.
+    events: G1SonicReconHandEventsCfg = G1SonicReconHandEventsCfg()  # type: ignore[assignment]
+    observations: G1SonicReconHandObservationsCfg = G1SonicReconHandObservationsCfg()  # type: ignore[assignment]
     rewards: G1SonicReconHandRewardsCfg = G1SonicReconHandRewardsCfg()
+    terminations: G1SonicReconHandTerminationsCfg = G1SonicReconHandTerminationsCfg()  # type: ignore[assignment]
+    curriculum: G1SonicReconHandCurriculumCfg = G1SonicReconHandCurriculumCfg()  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        """Configure Dex3 hand tracking: EE links, fingertips, VOC, freeze."""
+        super().__post_init__()
+        self.scene.replicate_physics = False
+        self.scene.filter_collisions = False
+        self.commands.motion.ee_link_names = [
+            "left_hand_palm_link",
+            "right_hand_palm_link",
+        ]
+        self.commands.motion.fingertip_body_name = ".*_(thumb_2|index_1|middle_1)_link"
+        self.commands.motion.finger_joint_names = G1_HAND_JOINT_NAMES
+        self.commands.motion.reset_freeze_steps = 50
+        self.commands.motion.initial_virtual_object_control_curriculum_scale = 1.0
+        self.commands.motion.reset_shoulder_spread = 0.5
+        self.commands.motion.voc_decay_steps = 10
+        self.commands.motion.voc_reset_scale = 1.0
+        # Upper bound; apply_scene_config() clips this down to the trajectory length.
+        self.episode_length_s = 70.0

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/commands/tracking_command.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/commands/tracking_command.py
@@ -27,6 +27,10 @@ from robotic_grounding.tasks.v2p.mdp.utils import (
     compute_wrench_space_support_function,
     sample_wrench_space_basis_scaled,
 )
+from robotic_grounding.tasks.v2p.mdp.utils_jit import (
+    wrench_preprocess_jit,
+    wrench_support_one_body_jit,
+)
 
 from .tracking_utils import load_motion_data
 
@@ -138,6 +142,22 @@ class TrackingCommand(CommandTerm):
             cfg.object_pos_offset, device=self.device
         )
         self._object_quat_w = motion_data.object_quat_w.float()
+        # Multi-body reference object trajectories (E, T, B, *) for the command
+        # target. Used by the multi-object command-frame observations/metrics.
+        self._object_body_pos_w = (
+            motion_data.object_body_position.float()
+            + torch.tensor(cfg.object_pos_offset, device=self.device)
+        )
+        self._object_body_quat_w = motion_data.object_body_wxyz.float()
+        if motion_data.object_articulation is not None:
+            self.retargeted_object_articulation = (
+                motion_data.object_articulation.float()
+            )
+        else:
+            self.retargeted_object_articulation = torch.zeros(
+                self._object_body_pos_w.shape[0], 0, device=self.device
+            )
+        self.retargeted_object_body_names = motion_data.object_body_names
         self.num_timesteps = self.root_pos_w.shape[0]
 
         # EE data
@@ -209,6 +229,12 @@ class TrackingCommand(CommandTerm):
         self.reset_timestep = torch.zeros(
             self.num_envs, dtype=torch.int32, device=self.device
         )
+        self.trajectory_end_timestep = torch.full(
+            (self.num_envs,),
+            self.num_timesteps - 1,
+            dtype=torch.int32,
+            device=self.device,
+        )
         self.steps_since_last_reset = torch.zeros(
             self.num_envs, dtype=torch.int32, device=self.device
         )
@@ -244,10 +270,32 @@ class TrackingCommand(CommandTerm):
 
         self.all_env_ids = torch.arange(self.num_envs, device=self.device)
         self.num_bodies = self.object_position_e.shape[1]
-        self.KEYPOINT_VECS = torch.tensor(
-            [[1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0], [0, 0, 1], [0, 0, -1]],
-            dtype=torch.float32,
-            device=self.device,
+        if (
+            self.retargeted_object_body_names is None
+            or len(self.retargeted_object_body_names) != self.num_bodies
+        ):
+            self.retargeted_object_body_names = list(self.object.data.body_names)
+        assert len(self.retargeted_object_body_names) == self.num_bodies, (
+            "The number of body names in the motion file and the object do not match. "
+            f"Find {len(self.retargeted_object_body_names)} in motion file, "
+            f"but {self.num_bodies} in the object."
+        )
+        self.KEYPOINT_VECS = (
+            torch.tensor(
+                [
+                    [1.0, 0.0, 0.0],
+                    [-1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [0.0, -1.0, 0.0],
+                    [0.0, 0.0, 1.0],
+                    [0.0, 0.0, -1.0],
+                ],
+                dtype=torch.float32,
+                device=self.device,
+            )
+            .unsqueeze(0)
+            .unsqueeze(1)
+            .expand(self.num_envs, self.num_bodies, -1, -1)
         )
 
     def _init_metrics(self) -> None:
@@ -297,19 +345,19 @@ class TrackingCommand(CommandTerm):
                 if "right" in n.lower()
             ]
 
-        # Finger joint IDs (from cfg, robot-level)
+        # Finger joint IDs (from cfg, robot-level). Track names alongside IDs so
+        # parquet finger joint values can be reordered to IsaacLab's joint order.
+        self._left_finger_joint_names: list[str] = []
+        self._right_finger_joint_names: list[str] = []
         if cfg.finger_joint_names:
             all_fj_ids, all_fj_names = self.robot.find_joints(cfg.finger_joint_names)
-            self._left_finger_joint_ids = [
-                i
-                for i, n in zip(all_fj_ids, all_fj_names, strict=False)
-                if "left" in n.lower()
-            ]
-            self._right_finger_joint_ids = [
-                i
-                for i, n in zip(all_fj_ids, all_fj_names, strict=False)
-                if "right" in n.lower()
-            ]
+            for i, n in zip(all_fj_ids, all_fj_names, strict=False):
+                if "left" in n.lower():
+                    self._left_finger_joint_ids.append(i)
+                    self._left_finger_joint_names.append(n)
+                elif "right" in n.lower():
+                    self._right_finger_joint_ids.append(i)
+                    self._right_finger_joint_names.append(n)
 
         # Retargeted hand data (from parquet, may be None)
         self.retargeted_left_wrist_position = md.left_wrist_position  # (T, 3)
@@ -338,8 +386,17 @@ class TrackingCommand(CommandTerm):
                 torch.tensor(indices, dtype=torch.long, device=self.device),
             )
 
-        self.retargeted_left_finger_joints = md.left_finger_joints  # (T, J)
-        self.retargeted_right_finger_joints = md.right_finger_joints
+        for side in ("left", "right"):
+            parquet_vals = getattr(md, f"{side}_finger_joints")
+            parquet_names = getattr(md, f"{side}_finger_joint_names")
+            sim_names = getattr(self, f"_{side}_finger_joint_names")
+            if parquet_vals is not None and parquet_names and sim_names:
+                reorder = [parquet_names.index(n) for n in sim_names]
+                setattr(
+                    self, f"retargeted_{side}_finger_joints", parquet_vals[:, reorder]
+                )
+            else:
+                setattr(self, f"retargeted_{side}_finger_joints", parquet_vals)
 
         # Binary per-frame contact labels.
         # If a side is absent on disk, we substitute an all-zero mask of length
@@ -395,9 +452,6 @@ class TrackingCommand(CommandTerm):
             part_ids = getattr(md, f"{side}_object_contact_part_ids")  # (T, N) or None
 
             if link_contacts is not None:
-                is_valid = link_contacts[..., :3].abs().sum(dim=-1) > 1e-5
-                has_contact = is_valid.any(dim=-1)
-
                 # Normalize link contact normals
                 if link_normals is not None:
                     norms = (
@@ -407,8 +461,14 @@ class TrackingCommand(CommandTerm):
                     link_normals[..., :3] = link_normals[..., :3] / norms
 
                 # Extract part IDs from 4th column if not separately provided
-                if part_ids is None:
+                if part_ids is None and link_contacts.shape[-1] > 3:
                     part_ids = link_contacts[..., 3].long()
+                is_valid = (
+                    part_ids > 0
+                    if part_ids is not None
+                    else link_contacts[..., :3].abs().sum(dim=-1) > 1e-5
+                )
+                has_contact = is_valid.any(dim=-1)
 
                 setattr(
                     self, f"retargeted_{side}_link_contact_positions_e", link_contacts
@@ -440,82 +500,188 @@ class TrackingCommand(CommandTerm):
                 setattr(self, f"num_retargeted_contacts_{side}", 0)
 
     def _precompute_hand_keypoints_in_object_frame(self) -> None:
-        """Express hand frames and wrist poses in the object's local frame.
+        """Express hand frames and wrist poses in the contacted object's local frame.
 
         Stored as object-frame tensors so they can be quickly transformed
         to env frame each step using the current object pose.
         """
-        obj_pos = self._object_pos_w  # (T, 3)
-        obj_quat = self._object_quat_w  # (T, 4)
+        horizon = self._object_body_pos_w.shape[0]
+        horizon_ids = torch.arange(horizon, device=self.device)
 
         for side in ("left", "right"):
             frames = getattr(self, f"retargeted_{side}_hand_frames")
             wrist_pos = getattr(self, f"retargeted_{side}_wrist_position")
             wrist_wxyz = getattr(self, f"retargeted_{side}_wrist_wxyz")
+            part_ids = getattr(self, f"retargeted_{side}_object_contact_part_ids", None)
+
+            part_ids_per_hand = torch.ones(
+                horizon, dtype=torch.int64, device=self.device
+            )
+            if part_ids is not None:
+                T_ids = min(horizon, part_ids.shape[0])
+                last_contact_part_id = torch.ones(
+                    (), dtype=torch.int64, device=self.device
+                )
+                for horizon_idx in range(T_ids - 1, -1, -1):
+                    hand_contact_part_id = part_ids[horizon_idx].mode().values
+                    part_ids_per_hand[horizon_idx] = (
+                        hand_contact_part_id
+                        if hand_contact_part_id > 0
+                        else last_contact_part_id
+                    )
+                    last_contact_part_id = part_ids_per_hand[horizon_idx]
+            part_ids_per_hand = part_ids_per_hand.clamp(min=1, max=self.num_bodies)
+            setattr(
+                self,
+                f"retargeted_{side}_object_contact_part_ids_per_hand",
+                part_ids_per_hand,
+            )
+
+            contact_body_position = self._object_body_pos_w[
+                horizon_ids, part_ids_per_hand - 1
+            ]
+            contact_body_wxyz = self._object_body_quat_w[
+                horizon_ids, part_ids_per_hand - 1
+            ]
 
             if frames is not None and wrist_pos is not None:
-                T_frames = min(frames.shape[0], obj_pos.shape[0])
+                T_frames = min(frames.shape[0], horizon)
 
                 # Hand frame positions → object frame
                 frame_pos = frames[:T_frames, :, :3]  # (T, K, 3)
-                obj_pos_exp = obj_pos[:T_frames].unsqueeze(1)  # (T, 1, 3)
-                obj_quat_exp = obj_quat[:T_frames].unsqueeze(1)  # (T, 1, 4)
-                frame_pos_o = math_utils.quat_rotate_inverse(
+                obj_pos_exp = contact_body_position[:T_frames].unsqueeze(1)
+                obj_quat_exp = contact_body_wxyz[:T_frames].unsqueeze(1)
+                frame_pos_o = math_utils.quat_apply_inverse(
                     obj_quat_exp.expand_as(frame_pos[..., :1].expand(-1, -1, 4)),
                     frame_pos - obj_pos_exp,
                 )
                 setattr(self, f"retargeted_{side}_hand_frame_positions_o", frame_pos_o)
 
+                if frames.shape[-1] >= 7:
+                    frame_wxyz_o = math_utils.quat_mul(
+                        math_utils.quat_conjugate(
+                            obj_quat_exp.expand(-1, frame_pos.shape[1], -1)
+                        ),
+                        frames[:T_frames, :, 3:7],
+                    )
+                    setattr(
+                        self,
+                        f"retargeted_{side}_hand_frame_wxyz_o",
+                        frame_wxyz_o,
+                    )
+
                 # Wrist pose → object frame
-                wrist_pos_o = math_utils.quat_rotate_inverse(
-                    obj_quat[:T_frames], wrist_pos[:T_frames] - obj_pos[:T_frames]
+                T_wrist = min(wrist_pos.shape[0], horizon)
+                wrist_pos_o = math_utils.quat_apply_inverse(
+                    contact_body_wxyz[:T_wrist],
+                    wrist_pos[:T_wrist] - contact_body_position[:T_wrist],
                 )
                 wrist_wxyz_o = math_utils.quat_mul(
-                    math_utils.quat_conjugate(obj_quat[:T_frames]),
-                    wrist_wxyz[:T_frames],
+                    math_utils.quat_conjugate(contact_body_wxyz[:T_wrist]),
+                    wrist_wxyz[:T_wrist],
                 )
                 setattr(self, f"retargeted_{side}_wrist_position_o", wrist_pos_o)
                 setattr(self, f"retargeted_{side}_wrist_wxyz_o", wrist_wxyz_o)
 
     def _precompute_contact_positions_in_object_frame(self) -> None:
-        """Transform contact positions and normals into object-local (COM) frame."""
-        obj_pos = self._object_pos_w
-        obj_quat = self._object_quat_w
+        """Transform contact positions and normals into per-body object/COM frames."""
+        object_o_t_com = torch.cat(
+            [obj.data.body_com_pose_b for obj in self.objects], dim=1
+        ).float()
+        object_o_p_com = object_o_t_com[..., :3].mean(dim=0)
+        object_o_q_com = object_o_t_com[0, :, 3:7]
 
         for side in ("left", "right"):
             obj_contacts = getattr(
                 self, f"retargeted_{side}_object_contact_positions_e"
             )
             link_normals = getattr(self, f"retargeted_{side}_link_contact_normals_e")
+            contact_part_ids = getattr(
+                self, f"retargeted_{side}_object_contact_part_ids", None
+            )
 
             if obj_contacts is not None:
-                T_c = min(obj_contacts.shape[0], obj_pos.shape[0])
+                T_c = min(obj_contacts.shape[0], self._object_body_pos_w.shape[0])
                 contact_pos = obj_contacts[:T_c, :, :3]
-                obj_pos_exp = obj_pos[:T_c].unsqueeze(1)
-                obj_quat_exp = (
-                    obj_quat[:T_c].unsqueeze(1).expand(-1, contact_pos.shape[1], -1)
-                )
+                horizon_ids = torch.arange(T_c, device=self.device)
+                if contact_part_ids is None:
+                    if obj_contacts.shape[-1] > 3:
+                        contact_part_ids = obj_contacts[..., 3].long()
+                    else:
+                        contact_part_ids = torch.ones(
+                            obj_contacts.shape[:2],
+                            dtype=torch.long,
+                            device=self.device,
+                        )
+                is_valid = getattr(self, f"retargeted_{side}_object_contact_is_valid")[
+                    :T_c
+                ]
 
-                contact_pos_com = math_utils.quat_rotate_inverse(
-                    obj_quat_exp, contact_pos - obj_pos_exp
-                )
+                contact_pos_o = torch.zeros_like(contact_pos)
+                contact_pos_com = torch.zeros_like(contact_pos)
+                normals_o = None
+                normals_com = None
+                if link_normals is not None:
+                    normals = link_normals[:T_c, :, :3]
+                    normals_o = torch.zeros_like(normals)
+                    normals_com = torch.zeros_like(normals)
+
+                for link_idx in range(contact_pos.shape[1]):
+                    part_id = (contact_part_ids[:T_c, link_idx] - 1).clamp(
+                        min=0, max=self.num_bodies - 1
+                    )
+                    object_e_p_o = self._object_body_pos_w[horizon_ids, part_id]
+                    object_e_q_o = self._object_body_quat_w[horizon_ids, part_id]
+
+                    contact_pos_o[:, link_idx] = math_utils.quat_apply_inverse(
+                        object_e_q_o,
+                        contact_pos[:, link_idx] - object_e_p_o,
+                    )
+
+                    _object_o_p_com = object_o_p_com[part_id]
+                    _object_o_q_com = object_o_q_com[part_id]
+                    contact_pos_com[:, link_idx], _ = (
+                        math_utils.subtract_frame_transforms(
+                            _object_o_p_com,
+                            _object_o_q_com,
+                            contact_pos_o[:, link_idx],
+                            q02=None,
+                        )
+                    )
+
+                    if normals_o is not None and normals_com is not None:
+                        normals_o[:, link_idx] = math_utils.quat_apply_inverse(
+                            object_e_q_o,
+                            normals[:, link_idx],
+                        )
+                        normals_com[:, link_idx], _ = (
+                            math_utils.subtract_frame_transforms(
+                                torch.zeros_like(_object_o_p_com),
+                                _object_o_q_com,
+                                normals_o[:, link_idx],
+                                q02=None,
+                            )
+                        )
+
+                contact_pos_o.masked_fill_(~is_valid.unsqueeze(-1), 0.0)
+                contact_pos_com.masked_fill_(~is_valid.unsqueeze(-1), 0.0)
                 setattr(
                     self,
                     f"retargeted_{side}_object_contact_positions_com",
                     contact_pos_com,
                 )
-
-                # Also store as _o for backward compat with simple rewards
                 setattr(
                     self,
                     f"retargeted_{side}_object_contact_positions_o",
-                    contact_pos_com,
+                    contact_pos_o,
                 )
 
-                # Normals in object frame
-                if link_normals is not None:
-                    normals = link_normals[:T_c, :, :3]
-                    normals_com = math_utils.quat_rotate_inverse(obj_quat_exp, normals)
+                if normals_o is not None and normals_com is not None:
+                    normals_o.masked_fill_(~is_valid.unsqueeze(-1), 0.0)
+                    normals_com.masked_fill_(~is_valid.unsqueeze(-1), 0.0)
+                    setattr(
+                        self, f"retargeted_{side}_link_contact_normals_o", normals_o
+                    )
                     setattr(
                         self, f"retargeted_{side}_link_contact_normals_com", normals_com
                     )
@@ -523,9 +689,14 @@ class TrackingCommand(CommandTerm):
     def _init_wrench_data(self, cfg: TrackingCommandCfg) -> None:
         """Set up wrench computation buffers: basis, friction cone, mesh radius."""
         md = self._motion_data
-        self.object_mesh_radius = md.object_mesh_radius or [0.05]  # fallback
+        self.object_mesh_radius = list(md.object_mesh_radius or [0.05])
+        self.object_mesh_radius = self.object_mesh_radius[: self.num_bodies]
+        if len(self.object_mesh_radius) < self.num_bodies:
+            self.object_mesh_radius = self.object_mesh_radius + [
+                self.object_mesh_radius[-1]
+            ] * (self.num_bodies - len(self.object_mesh_radius))
         self.retargeted_horizon = min(
-            self._object_pos_w.shape[0],
+            self._object_body_pos_w.shape[0],
             (
                 getattr(
                     self, "retargeted_left_link_contact_positions_e", torch.empty(0)
@@ -565,6 +736,7 @@ class TrackingCommand(CommandTerm):
             cfg.num_wrench_space_basis_samples,
             device=self.device,
         )
+        self._tensors_dirty = True
 
     def _precompute_contact_wrench_support_values(self) -> None:
         """Precompute wrench supports for all timesteps from retargeted contacts."""
@@ -707,11 +879,12 @@ class TrackingCommand(CommandTerm):
     @property
     def future_timesteps(self) -> torch.Tensor:
         """Clamped future frame indices per env. (E, num_future_frames)."""
-        return torch.clamp(
+        future_timesteps = torch.clamp(
             self.timestep[:, None] + self._future_frame_offsets[None, :],
             0,
             self.num_timesteps - 1,
         )
+        return torch.minimum(future_timesteps, self.trajectory_end_timestep[:, None])
 
     def update_action_history(self, actions: torch.Tensor) -> None:
         """Push current processed actions into the history buffer."""
@@ -902,6 +1075,39 @@ class TrackingCommand(CommandTerm):
         return torch.zeros(self.num_envs, 3, device=self.device)
 
     @property
+    def left_hand_wrist_wxyz_e(self) -> torch.Tensor:
+        """(E, 4) current left wrist quaternion."""
+        if self._left_wrist_body_id is not None:
+            return math_utils.quat_unique(
+                self.robot.data.body_quat_w[:, self._left_wrist_body_id]
+            )
+        quat = torch.zeros(self.num_envs, 4, device=self.device)
+        quat[:, 0] = 1.0
+        return quat
+
+    @property
+    def right_hand_wrist_wxyz_e(self) -> torch.Tensor:
+        """(E, 4) current right wrist quaternion."""
+        if self._right_wrist_body_id is not None:
+            return math_utils.quat_unique(
+                self.robot.data.body_quat_w[:, self._right_wrist_body_id]
+            )
+        quat = torch.zeros(self.num_envs, 4, device=self.device)
+        quat[:, 0] = 1.0
+        return quat
+
+    def get_command_contact_object_position_orientation(
+        self, side: str
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Get the current contacted object body pose for a hand side."""
+        contact_part_id = self.get_command_contact_part_id(side)
+        object_position = self.object_position_e[self.all_env_ids, contact_part_id]
+        object_orientation = self.object_orientation_e[
+            self.all_env_ids, contact_part_id
+        ]
+        return object_position, object_orientation
+
+    @property
     def left_hand_fingertip_position_command_e(self) -> torch.Tensor:
         """(E, K, 3) left fingertip command positions in env frame."""
         return self._fingertip_command_e("left")
@@ -979,39 +1185,40 @@ class TrackingCommand(CommandTerm):
 
     @property
     def object_position_e(self) -> torch.Tensor:
-        """Object position in env frame. (E, 1, 3)."""
-        return (self.object.data.root_pos_w - self._env_origins).unsqueeze(1)
+        """Object body positions in env frame. (E, B, 3) over all object bodies."""
+        object_position_w = torch.cat(
+            [obj.data.body_link_pos_w for obj in self.objects], dim=1
+        )
+        return (object_position_w - self._env_origins.unsqueeze(1)).float()
 
     @property
     def object_orientation_e(self) -> torch.Tensor:
-        """Object quaternion in env frame. (E, 1, 4)."""
-        return self.object.data.root_quat_w.unsqueeze(1)
+        """Object body quaternions in env frame. (E, B, 4) over all object bodies."""
+        return torch.cat(
+            [obj.data.body_link_quat_w for obj in self.objects], dim=1
+        ).float()
 
     @property
     def object_body_position_command_e(self) -> torch.Tensor:
         """(E, B, 3) command object body positions in env frame."""
-        pos = self._object_pos_w[self.timestep]  # (E, 3)
-        if pos.ndim == 2:
-            pos = pos.unsqueeze(1)  # (E, 1, 3)
-        return pos
+        return self._object_body_pos_w[self.timestep]
 
     @property
     def object_body_wxyz_command_e(self) -> torch.Tensor:
         """(E, B, 4) command object body quaternions in env frame."""
-        quat = math_utils.quat_unique(self._object_quat_w[self.timestep])  # (E, 4)
-        if quat.ndim == 2:
-            quat = quat.unsqueeze(1)  # (E, 1, 4)
-        return quat
+        return math_utils.quat_unique(self._object_body_quat_w[self.timestep])
 
     @property
     def object_body_ids(self) -> torch.Tensor:
-        """Object body indices (single rigid body). (1,)."""
-        return torch.tensor([0], device=self.device)
+        """Object body indices. (B,)."""
+        return torch.arange(self.num_bodies, device=self.device)
 
     @property
     def object_com_position_and_wxyz_w(self) -> torch.Tensor:
         """(E, num_bodies, 7) object COM state."""
-        return self.object.data.body_com_state_w[..., :7].float()
+        return torch.cat(
+            [obj.data.body_com_state_w[..., :7] for obj in self.objects], dim=1
+        ).float()
 
     # ------------------------------------------------------------------
     # Properties: finger joints
@@ -1065,6 +1272,13 @@ class TrackingCommand(CommandTerm):
 
     def get_command_contact_part_id(self, side: str) -> torch.Tensor:
         """Get dominant contact body index per env. (E,) — 0-indexed."""
+        per_hand = getattr(
+            self, f"retargeted_{side}_object_contact_part_ids_per_hand", None
+        )
+        if per_hand is not None:
+            t = self.timestep.clamp(max=per_hand.shape[0] - 1)
+            return (per_hand[t] - 1).clamp(min=0, max=self.num_bodies - 1)
+
         part_ids = getattr(self, f"retargeted_{side}_object_contact_part_ids")
         if part_ids is not None:
             t = self.timestep.clamp(max=part_ids.shape[0] - 1)
@@ -1109,12 +1323,14 @@ class TrackingCommand(CommandTerm):
     @property
     def left_hand_contact_wrench_supports(self) -> torch.Tensor:
         """(E, num_bodies, num_basis) live wrench supports from sim contacts."""
-        return self._compute_live_wrench_supports("left")
+        self.refresh_tensors()
+        return self.left_contact_wrench_supports
 
     @property
     def right_hand_contact_wrench_supports(self) -> torch.Tensor:
         """(E, num_bodies, num_basis) live right hand wrench supports from sim."""
-        return self._compute_live_wrench_supports("right")
+        self.refresh_tensors()
+        return self.right_contact_wrench_supports
 
     @property
     def left_hand_contact_active_command(self) -> torch.Tensor:
@@ -1150,6 +1366,8 @@ class TrackingCommand(CommandTerm):
             )
         if self._action_history is not None:
             self._action_history[env_ids] = 0.0
+        if hasattr(self, "_tensors_dirty"):
+            self._tensors_dirty = True
 
     def _update_command(self) -> None:
         """Advance timestep and decay VOC."""
@@ -1178,6 +1396,9 @@ class TrackingCommand(CommandTerm):
         else:
             self.timestep += 1
         self.timestep.clamp_(0, self.num_timesteps - 1)
+        self.timestep.copy_(torch.minimum(self.timestep, self.trajectory_end_timestep))
+        if hasattr(self, "_tensors_dirty"):
+            self._tensors_dirty = True
 
     def _update_metrics(self) -> None:
         """Track per-step errors for logging."""
@@ -1341,13 +1562,12 @@ class TrackingCommand(CommandTerm):
             return torch.zeros(self.num_envs, 7, device=self.device)
 
         t = self.timestep.clamp(max=wrist_pos_o.shape[0] - 1)
-        obj_pos = self.object.data.root_pos_w - self._env_origins  # (E, 3)
-        obj_quat = self.object.data.root_quat_w  # (E, 4)
+        obj_pos, obj_quat = self.get_command_contact_object_position_orientation(side)
 
         pos_o = wrist_pos_o[t]  # (E, 3)
         wxyz_o = wrist_wxyz_o[t]  # (E, 4)
 
-        pos_e = math_utils.quat_rotate(obj_quat, pos_o) + obj_pos
+        pos_e = math_utils.quat_apply(obj_quat, pos_o) + obj_pos
         wxyz_e = math_utils.quat_mul(obj_quat, wxyz_o)
         return torch.cat([pos_e, wxyz_e], dim=-1)
 
@@ -1361,11 +1581,10 @@ class TrackingCommand(CommandTerm):
         t = self.timestep.clamp(max=frame_pos_o.shape[0] - 1)
         tips_o = frame_pos_o[t][:, tip_indices]  # (E, K, 3)
 
-        obj_pos = (self.object.data.root_pos_w - self._env_origins).unsqueeze(1)
-        obj_quat = self.object.data.root_quat_w.unsqueeze(1).expand_as(
-            tips_o[..., :1].expand(-1, -1, 4)
-        )
-        return math_utils.quat_rotate(obj_quat, tips_o) + obj_pos
+        obj_pos, obj_quat = self.get_command_contact_object_position_orientation(side)
+        obj_pos = obj_pos.unsqueeze(1)
+        obj_quat = obj_quat.unsqueeze(1).expand_as(tips_o[..., :1].expand(-1, -1, 4))
+        return math_utils.quat_apply(obj_quat, tips_o) + obj_pos
 
     def _contact_command_e(self, side: str) -> torch.Tensor:
         """Contact command positions in env frame."""
@@ -1377,11 +1596,39 @@ class TrackingCommand(CommandTerm):
         t = self.timestep.clamp(max=contact_o.shape[0] - 1)
         contacts = contact_o[t]  # (E, N, 3)
 
-        obj_pos = (self.object.data.root_pos_w - self._env_origins).unsqueeze(1)
-        obj_quat = self.object.data.root_quat_w.unsqueeze(1).expand(
-            -1, contacts.shape[1], -1
+        object_position, object_orientation = self._contact_object_pose_e(
+            side, contacts.shape[1]
         )
-        return math_utils.quat_rotate(obj_quat, contacts) + obj_pos
+        pos_e = math_utils.quat_apply(object_orientation, contacts) + object_position
+        valid = getattr(self, f"retargeted_{side}_object_contact_is_valid", None)
+        if valid is not None:
+            valid_t = valid[t]
+            pos_e.masked_fill_(~valid_t.unsqueeze(-1), 0.0)
+        return pos_e
+
+    def _contact_object_pose_e(
+        self, side: str, num_contacts: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Current object body poses for each contact link. Shapes: (E, N, 3/4)."""
+        part_ids = getattr(self, f"retargeted_{side}_object_contact_part_ids", None)
+        if part_ids is not None:
+            t = self.timestep.clamp(max=part_ids.shape[0] - 1)
+            contact_part_id = (part_ids[t] - 1).clamp(min=0, max=self.num_bodies - 1)
+        else:
+            contact_part_id = torch.zeros(
+                self.num_envs, num_contacts, dtype=torch.long, device=self.device
+            )
+        object_position = torch.gather(
+            self.object_position_e,
+            dim=1,
+            index=contact_part_id.unsqueeze(-1).expand(-1, -1, 3),
+        )
+        object_orientation = torch.gather(
+            self.object_orientation_e,
+            dim=1,
+            index=contact_part_id.unsqueeze(-1).expand(-1, -1, 4),
+        )
+        return object_position, object_orientation
 
     def _live_contact_positions_w(self, side: str) -> torch.Tensor:
         """(E, B, N, 3) contact positions from per-body sensors."""
@@ -1422,68 +1669,96 @@ class TrackingCommand(CommandTerm):
             return torch.zeros(self.num_envs, n, 6, device=self.device)
 
         t = self.timestep.clamp(max=contact_o.shape[0] - 1)
-        obj_pos = (self.object.data.root_pos_w - self._env_origins).unsqueeze(1)
-        obj_quat = self.object.data.root_quat_w.unsqueeze(1).expand(
-            -1, contact_o.shape[1], -1
+        object_position, object_orientation = self._contact_object_pose_e(
+            side, contact_o.shape[1]
         )
 
-        pos_e = math_utils.quat_rotate(obj_quat, contact_o[t]) + obj_pos
+        pos_e = (
+            math_utils.quat_apply(object_orientation, contact_o[t]) + object_position
+        )
         if normals_com is not None:
-            normals_e = math_utils.quat_rotate(obj_quat, normals_com[t])
+            normals_e = math_utils.quat_apply(object_orientation, normals_com[t])
         else:
             normals_e = torch.zeros_like(pos_e)
+        valid = getattr(self, f"retargeted_{side}_object_contact_is_valid", None)
+        if valid is not None:
+            valid_t = valid[t]
+            pos_e.masked_fill_(~valid_t.unsqueeze(-1), 0.0)
+            normals_e.masked_fill_(~valid_t.unsqueeze(-1), 0.0)
         return torch.cat([pos_e, normals_e], dim=-1)
 
-    def _compute_live_wrench_supports(self, side: str) -> torch.Tensor:
-        """Compute wrench supports from live sim contacts. Matches floating hand env pattern."""
+    def refresh_tensors(self) -> None:
+        """Refresh shared contact/wrench tensors once per sim step."""
+        if not self._tensors_dirty:
+            return
+        self._tensors_dirty = False
+
+        self._compute_contact_wrench_supports("right")
+        self._compute_contact_wrench_supports("left")
+
+        self._cached_right_wrench_cmd_supports = (
+            self.right_hand_contact_wrench_supports_command
+        )
+        self._cached_left_wrench_cmd_supports = (
+            self.left_hand_contact_wrench_supports_command
+        )
+        self._cached_right_wrench_cmd_active = (
+            self._cached_right_wrench_cmd_supports > 1e-3
+        )
+        self._cached_left_wrench_cmd_active = (
+            self._cached_left_wrench_cmd_supports > 1e-3
+        )
+        self._cached_right_wrench_cur_active = self.right_contact_wrench_supports > 1e-3
+        self._cached_left_wrench_cur_active = self.left_contact_wrench_supports > 1e-3
+        self._cached_right_wrench_cmd_active_per_body = (
+            self._cached_right_wrench_cmd_active.any(dim=-1)
+        )
+        self._cached_left_wrench_cmd_active_per_body = (
+            self._cached_left_wrench_cmd_active.any(dim=-1)
+        )
+        self._cached_right_wrench_cur_active_per_body = (
+            self._cached_right_wrench_cur_active.any(dim=-1)
+        )
+        self._cached_left_wrench_cur_active_per_body = (
+            self._cached_left_wrench_cur_active.any(dim=-1)
+        )
+
+    def _compute_contact_wrench_supports(self, side: str) -> None:
+        """Fill live wrench supports in place for one hand."""
         sensors = getattr(self, f"object_to_{side}_hand_contact_sensors", [])
+        supports = getattr(self, f"{side}_contact_wrench_supports")
+        supports.zero_()
         if not sensors or not hasattr(self, "wrench_space_bases"):
-            return torch.zeros(
-                self.num_envs,
-                self.num_bodies,
-                self.cfg.num_wrench_space_basis_samples,
-                device=self.device,
-            )
+            return
 
         num_contacts = getattr(self, f"num_robot_contacts_{side}", 0)
+        if num_contacts == 0:
+            return
+
         contact_pos_w = self._live_contact_positions_w(side)  # (E, B, N, 3)
         contact_forces_w = self._live_contact_forces_w(side)  # (E, H, B, N, 3)
 
-        active = contact_pos_w.norm(dim=-1) > 1e-3  # (E, B, N)
-
-        # COM state per body, expanded to contact dim
         obj_com = self.object_com_position_and_wxyz_w  # (E, B, 7)
-        obj_com_expanded = obj_com.unsqueeze(2).expand(-1, -1, num_contacts, -1)
-        obj_com_pos = obj_com_expanded[..., :3]
-        obj_com_quat = obj_com_expanded[..., 3:7]
+        object_com_position_w = obj_com[..., :3].unsqueeze(2)
+        object_com_orientation_w = obj_com[..., 3:7].unsqueeze(2)
 
-        # Contact positions in COM frame
-        pos_com, _ = math_utils.subtract_frame_transforms(
-            obj_com_pos, obj_com_quat, contact_pos_w, q02=None
+        contact_positions_com, contact_normals_com = wrench_preprocess_jit(
+            contact_positions_w=contact_pos_w,
+            contact_forces_first_hist_w=contact_forces_w[:, 0],
+            object_com_position_w=object_com_position_w,
+            object_com_orientation_w=object_com_orientation_w,
+            num_envs=self.num_envs,
+            num_bodies=self.num_bodies,
+            num_robot_contacts=num_contacts,
         )
-        pos_com *= active.unsqueeze(-1)
-
-        # Normals from force direction
-        normals_w = contact_forces_w[:, 0]  # (E, B, N, 3)
-        normals_w = normals_w / normals_w.norm(dim=-1, keepdim=True).clamp(min=1e-5)
-        normals_com, _ = math_utils.subtract_frame_transforms(
-            torch.zeros_like(obj_com_pos), obj_com_quat, normals_w, q02=None
-        )
-        normals_com *= active.unsqueeze(-1)
-
-        # Wrench space per body
-        supports = getattr(self, f"{side}_contact_wrench_supports")
+        friction_coefficients = float(self.cfg.friction_coefficients)
         for body_idx, body_radius in enumerate(self.object_mesh_radius):
-            wrench_space = compute_wrench_space(
-                contact_points=pos_com[:, body_idx],
-                contact_normals=normals_com[:, body_idx],
+            supports[:, body_idx] = wrench_support_one_body_jit(
+                contact_points=contact_positions_com[:, body_idx],
+                contact_normals=contact_normals_com[:, body_idx],
                 cos_t=self.friction_cone_edge_cosines,
                 sin_t=self.friction_cone_edge_sines,
-                rc=body_radius,
-                friction_coefficients=self.cfg.friction_coefficients,
-            )
-            supports[:, body_idx] = compute_wrench_space_support_function(
-                wrench_space=wrench_space,
                 basis=self.wrench_space_bases[body_idx],
+                rc=float(body_radius),
+                friction_coefficients=friction_coefficients,
             )
-        return supports

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/events/events.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/events/events.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import torch
-from isaaclab.assets import Articulation, RigidObject
+from isaaclab.assets import Articulation
 from isaaclab.envs import ManagerBasedRLEnv
 from isaaclab.managers import SceneEntityCfg
 
@@ -17,9 +17,11 @@ def reset_robot_to_trajectory_start(
 ) -> None:
     """Reset robot and object to a frame in the motion trajectory.
 
-    Frame selection:
-    - always_reset_to_first_frame: force frame 0 (eval mode)
-    - Otherwise: random within trajectory_time_index range
+    Frame-window selection:
+    - trajectory_time_index is the inclusive command window [start, end].
+    - always_reset_to_first_frame: reset to the window start.
+    - Otherwise: random reset inside the window.
+    - The timestep termination ends the episode at the window end.
 
     Post-processing (all configurable on TrackingCommandCfg):
     - Optional root Z clamp (reset_root_height_min)
@@ -32,14 +34,17 @@ def reset_robot_to_trajectory_start(
     robot: Articulation = env.scene[asset_cfg.name]
 
     # --- Frame selection ---
+    low = max(0, int(trajectory_time_index[0]))
+    high = min(command.num_timesteps - 1, int(trajectory_time_index[1]))
+    high = max(low, high)
     if command.cfg.always_reset_to_first_frame:
-        reset_ts = torch.zeros(len(env_ids), dtype=torch.int32, device=env.device)
+        reset_ts = torch.full(
+            (len(env_ids),), low, dtype=torch.int32, device=env.device
+        )
     else:
-        low = max(0, trajectory_time_index[0])
-        high = min(command.num_timesteps - 1, trajectory_time_index[1])
         reset_ts = torch.randint(
             low,
-            max(low + 1, high),
+            high + 1,
             (len(env_ids),),
             dtype=torch.int32,
             device=env.device,
@@ -47,6 +52,8 @@ def reset_robot_to_trajectory_start(
 
     command.timestep[env_ids] = reset_ts
     command.reset_timestep[env_ids] = reset_ts
+    command.trajectory_end_timestep[env_ids] = high
+    command.tracking_lengths[env_ids] = (high - reset_ts + 1).clamp(min=1)
 
     # --- Read trajectory frame ---
     initial_root_pos = command.root_pos_w[reset_ts].clone()
@@ -112,15 +119,43 @@ def reset_robot_to_trajectory_start(
         env_ids=env_ids,
     )
 
-    # --- Reset object ---
-    scene_object = env.scene[command.cfg.object_name]
-    if isinstance(scene_object, RigidObject):
-        obj_pos = command._object_pos_w[reset_ts] + env.scene.env_origins[env_ids]
-        obj_quat = command._object_quat_w[reset_ts]
-        scene_object.write_root_pose_to_sim(
-            torch.cat([obj_pos, obj_quat], dim=-1), env_ids=env_ids
-        )
+    # --- Reset objects ---
+    scene_objects = getattr(command, "objects", None) or [
+        env.scene[command.cfg.object_name]
+    ]
+    object_pose = torch.cat(
+        [
+            command._object_body_pos_w[reset_ts] + env.scene.env_origins[env_ids, None],
+            command._object_body_quat_w[reset_ts],
+        ],
+        dim=-1,
+    )
+    object_velocity = torch.zeros(
+        object_pose.shape[0],
+        object_pose.shape[1],
+        6,
+        device=object_pose.device,
+        dtype=object_pose.dtype,
+    )
+    object_joint_pos = None
+    if command.retargeted_object_articulation.numel() > 0:
+        object_joint_pos = command.retargeted_object_articulation[reset_ts]
+        if object_joint_pos.dim() == 1:
+            object_joint_pos = object_joint_pos.unsqueeze(-1)
+
+    for object_idx, scene_object in enumerate(scene_objects):
+        scene_object.write_root_pose_to_sim(object_pose[:, object_idx], env_ids=env_ids)
         scene_object.write_root_velocity_to_sim(
-            torch.zeros_like(scene_object.data.root_vel_w[env_ids]), env_ids=env_ids
+            object_velocity[:, object_idx], env_ids=env_ids
         )
-    # TODO: generalize for ArticulatedObject (Arctic multi-body)
+        if isinstance(scene_object, Articulation) and object_joint_pos is not None:
+            if len(scene_objects) > 1:
+                raise NotImplementedError(
+                    "Multi-object trajectory reset currently supports separate "
+                    "RigidObject assets or a single Articulation asset."
+                )
+            scene_object.write_joint_state_to_sim(
+                object_joint_pos,
+                torch.zeros_like(scene_object.data.joint_vel[env_ids]),
+                env_ids=env_ids,
+            )

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/observations/policy_observations.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/observations/policy_observations.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 from isaaclab.utils.math import (
     matrix_from_quat,
+    quat_apply_inverse,
     quat_inv,
     quat_mul,
     subtract_frame_transforms,
@@ -21,7 +22,10 @@ from robotic_grounding.tasks.v2p_whole_body.mdp.commands import TrackingCommand
 
 
 def motion_anchor_pos_b(
-    env: ManagerBasedRLEnv, command_name: str = "motion", num_future_frames: int = 10
+    env: ManagerBasedRLEnv,
+    command_name: str = "motion",
+    num_future_frames: int = 10,
+    frame: str = "absolute",
 ) -> torch.Tensor:
     """Get future anchor positions.
 
@@ -29,13 +33,28 @@ def motion_anchor_pos_b(
         env: The environment instance
         command_name: Name of the tracking command term
         num_future_frames: Number of future frames to include (default: 10)
+        frame: ``"absolute"`` returns legacy world-frame positions. ``"relative"``
+            returns deltas in the current anchor frame.
 
     Returns:
-        Future anchor positions (num_envs, num_future_frames * 3) - flattened 3D position
+        Future anchor positions or deltas (num_envs, num_future_frames * 3).
     """
+    if frame not in ("absolute", "relative"):
+        raise ValueError(
+            "motion_anchor_pos_b frame must be 'absolute' or 'relative', "
+            f"got {frame!r}."
+        )
+
     command: TrackingCommand = env.command_manager.get_term(command_name)
-    anchor_pos = command.command_anchor_pos_w_multi_future
-    return anchor_pos[:, :num_future_frames, :].reshape(env.num_envs, -1)
+    future_pos_w = command.command_anchor_pos_w_multi_future[:, :num_future_frames, :]
+    if frame == "absolute":
+        return future_pos_w.reshape(env.num_envs, -1)
+
+    delta_w = future_pos_w - command.robot_anchor_pos_w.unsqueeze(1)
+    num_frames = future_pos_w.shape[1]
+    anchor_quat_w = command.robot_anchor_quat_w.unsqueeze(1).expand(-1, num_frames, -1)
+    delta_b = quat_apply_inverse(anchor_quat_w, delta_w)
+    return delta_b.reshape(env.num_envs, -1)
 
 
 def motion_joint_pos_delta(
@@ -157,15 +176,22 @@ def command_trajectory_progress(
 def object_pose_delta(
     env: ManagerBasedRLEnv, command_name: str = "motion"
 ) -> torch.Tensor:
-    """Object pose delta (pos + quat) in current object frame. Shape: (num_envs, 7)."""
+    """Object body pose deltas in each current body frame. (num_envs, 7 * num_object_bodies)."""
     command: TrackingCommand = env.command_manager.get_term(command_name)
+    num_bodies = command.object_position_e.shape[1]
     pos_delta, quat_delta = subtract_frame_transforms(
-        command.object_pos_w,
-        command.object_quat_w,
-        command.command_object_pos_w,
-        command.command_object_quat_w,
+        command.object_position_e.reshape(-1, 3),
+        command.object_orientation_e.reshape(-1, 4),
+        command.object_body_position_command_e.reshape(-1, 3),
+        command.object_body_wxyz_command_e.reshape(-1, 4),
     )
-    return torch.cat([pos_delta, quat_delta], dim=-1)
+    return torch.cat(
+        [
+            pos_delta.reshape(env.num_envs, num_bodies, 3),
+            quat_delta.reshape(env.num_envs, num_bodies, 4),
+        ],
+        dim=-1,
+    ).reshape(env.num_envs, -1)
 
 
 def wrist_position_b(
@@ -230,6 +256,29 @@ def wrist_velocity_b(
     right_vel_b = torch.bmm(rot, right_vel_w.unsqueeze(-1)).squeeze(-1)
     left_vel_b = torch.bmm(rot, left_vel_w.unsqueeze(-1)).squeeze(-1)
     return torch.cat([right_vel_b, left_vel_b], dim=-1)
+
+
+def wrist_velocity_full_b(
+    env: ManagerBasedRLEnv, command_name: str = "motion"
+) -> torch.Tensor:
+    """Wrist linear+angular velocities in each wrist's own frame. (num_envs, 12) = [right(6), left(6)]."""
+    command: TrackingCommand = env.command_manager.get_term(command_name)
+    robot = command.robot
+    left_id = getattr(command, "_left_wrist_body_id", None)
+    right_id = getattr(command, "_right_wrist_body_id", None)
+
+    def _per_wrist(body_id: int | None) -> torch.Tensor:
+        if body_id is None:
+            return torch.zeros(env.num_envs, 6, device=env.device)
+        quat = robot.data.body_quat_w[:, body_id]
+        lin_w = robot.data.body_lin_vel_w[:, body_id]
+        ang_w = robot.data.body_ang_vel_w[:, body_id]
+        return torch.cat(
+            [quat_apply_inverse(quat, lin_w), quat_apply_inverse(quat, ang_w)],
+            dim=-1,
+        )
+
+    return torch.cat([_per_wrist(right_id), _per_wrist(left_id)], dim=-1).float()
 
 
 def object_position_b(
@@ -313,3 +362,79 @@ def contact_desired_positions_e(
     return torch.cat(
         [left.reshape(env.num_envs, -1), right.reshape(env.num_envs, -1)], dim=-1
     )
+
+
+def hand_object_reference_transform(
+    env: ManagerBasedRLEnv,
+    side: str,
+    command_name: str = "motion",
+    threshold: float = 10.0,
+) -> torch.Tensor:
+    """Wrist pose expressed in the frame of the object body this hand tracks.
+
+    Picks the commanded object body for this side when the scene has several
+    object bodies; reduces to the single object body otherwise. Zeroed when the
+    wrist is farther than ``threshold`` from that object.
+    """
+    command: TrackingCommand = env.command_manager.get_term(command_name)
+    if side == "left":
+        wrist_pos_e = command.left_hand_wrist_position_e
+        wrist_wxyz_e = command.left_hand_wrist_wxyz_e
+    elif side == "right":
+        wrist_pos_e = command.right_hand_wrist_position_e
+        wrist_wxyz_e = command.right_hand_wrist_wxyz_e
+    else:
+        raise ValueError(f"Unknown hand side: {side}")
+
+    obj_pos_e, obj_wxyz_e = command.get_command_contact_object_position_orientation(
+        side
+    )
+    pos_o, wxyz_o = subtract_frame_transforms(
+        obj_pos_e,
+        obj_wxyz_e,
+        wrist_pos_e,
+        wrist_wxyz_e,
+    )
+    transform = torch.cat([pos_o, wxyz_o], dim=-1)
+    mask = (torch.norm(pos_o, dim=-1, keepdim=True) < threshold).expand_as(transform)
+    return torch.where(mask, transform, torch.zeros_like(transform))
+
+
+def wrist_position_e(
+    env: ManagerBasedRLEnv, command_name: str = "motion"
+) -> torch.Tensor:
+    """Wrist positions in env frame. (num_envs, 6) = [right(3), left(3)]."""
+    command: TrackingCommand = env.command_manager.get_term(command_name)
+    return torch.cat(
+        [
+            command.right_hand_wrist_position_e,
+            command.left_hand_wrist_position_e,
+        ],
+        dim=-1,
+    )
+
+
+def wrist_wxyz_e(env: ManagerBasedRLEnv, command_name: str = "motion") -> torch.Tensor:
+    """Wrist quaternions in env frame. (num_envs, 8) = [right(4), left(4)]."""
+    command: TrackingCommand = env.command_manager.get_term(command_name)
+    return torch.cat(
+        [
+            command.right_hand_wrist_wxyz_e,
+            command.left_hand_wrist_wxyz_e,
+        ],
+        dim=-1,
+    )
+
+
+def object_position_e(
+    env: ManagerBasedRLEnv, command_name: str = "motion"
+) -> torch.Tensor:
+    """Object body positions in env frame. (num_envs, 3 * num_object_bodies)."""
+    command: TrackingCommand = env.command_manager.get_term(command_name)
+    return command.object_position_e.reshape(env.num_envs, -1)
+
+
+def object_wxyz_e(env: ManagerBasedRLEnv, command_name: str = "motion") -> torch.Tensor:
+    """Object body quaternions in env frame. (num_envs, 4 * num_object_bodies)."""
+    command: TrackingCommand = env.command_manager.get_term(command_name)
+    return command.object_orientation_e.reshape(env.num_envs, -1)

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/rewards/contact_rewards.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/rewards/contact_rewards.py
@@ -13,6 +13,12 @@ are in tasks.v2p.mdp.utils.
 import torch
 from isaaclab.envs import ManagerBasedEnv
 
+from robotic_grounding.tasks.v2p.mdp.utils_jit import (
+    contact_wrench_support_reward_jit,
+    missed_contact_penalty_jit,
+    unintended_contact_penalty_jit,
+)
+
 
 def contact_wrench_support_reward(
     env: ManagerBasedEnv,
@@ -29,40 +35,21 @@ def contact_wrench_support_reward(
     Returns continuous value in [0, 1].
     """
     command = env.command_manager.get_term(command_name)
-
-    def _hand_reward(
-        cmd: torch.Tensor, cur: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        cmd_active = cmd > 1e-3  # (E, B, M)
-        cur_active = cur > 1e-3
-        n_cmd_per_body = cmd_active.sum(dim=-1).clamp(min=1)  # (E, B)
-
-        # Tolerance band violations per direction
-        lower = ((1.0 - tolerance) * cmd - cur).clamp(min=0.0)
-        upper = (cur - (1.0 + tolerance) * cmd).clamp(min=0.0)
-        loss = lower.square() + upper.square()  # (E, B, M)
-
-        # Per-direction reward, gated by both command and sim having support
-        per_dir_reward = (cmd_active & cur_active) * torch.exp(-loss / var)
-        per_body_reward = per_dir_reward.sum(dim=-1) / n_cmd_per_body  # (E, B)
-
-        # Average over bodies with command contact
-        body_has_contact = cmd_active.any(dim=-1)  # (E, B)
-        n_bodies = body_has_contact.sum(dim=-1).clamp(min=1)
-        hand_reward = (per_body_reward * body_has_contact).sum(dim=-1) / n_bodies
-        return hand_reward, body_has_contact.any(dim=-1)
-
-    right_reward, right_any = _hand_reward(
-        command.right_hand_contact_wrench_supports_command,
-        command.right_hand_contact_wrench_supports,
+    command.refresh_tensors()
+    return contact_wrench_support_reward_jit(
+        right_cmd_active=command._cached_right_wrench_cmd_active,
+        right_cur_active=command._cached_right_wrench_cur_active,
+        left_cmd_active=command._cached_left_wrench_cmd_active,
+        left_cur_active=command._cached_left_wrench_cur_active,
+        right_cmd_active_per_body=command._cached_right_wrench_cmd_active_per_body,
+        left_cmd_active_per_body=command._cached_left_wrench_cmd_active_per_body,
+        right_cmd_supports=command._cached_right_wrench_cmd_supports,
+        right_cur_supports=command.right_contact_wrench_supports,
+        left_cmd_supports=command._cached_left_wrench_cmd_supports,
+        left_cur_supports=command.left_contact_wrench_supports,
+        tolerance=tolerance,
+        var=var,
     )
-    left_reward, left_any = _hand_reward(
-        command.left_hand_contact_wrench_supports_command,
-        command.left_hand_contact_wrench_supports,
-    )
-
-    n_hands = (right_any.float() + left_any.float()).clamp(min=1)
-    return (right_reward + left_reward) / n_hands
 
 
 def unintended_contact_penalty(
@@ -75,33 +62,15 @@ def unintended_contact_penalty(
     penalty proportional to the unintended wrench support magnitude.
     """
     command = env.command_manager.get_term(command_name)
-
-    def _hand_penalty(
-        cmd_supports: torch.Tensor, cur_supports: torch.Tensor
-    ) -> torch.Tensor:
-        cmd_has = cmd_supports.amax(dim=-1) > 1e-3  # (E, B)
-        cur_has = cur_supports.amax(dim=-1) > 1e-3
-        n_cmd = cmd_has.sum(dim=-1)  # (E,)
-        num_bodies = cmd_supports.shape[1]
-
-        # Binary: contact where not expected
-        unintended = (~cmd_has) & cur_has  # (E, B)
-        binary = unintended.float().mean(dim=-1)
-
-        # Continuous: wrench magnitude where not expected
-        continuous = (~cmd_has).float() * cur_supports.clamp(min=0.0).square().mean(
-            dim=-1
-        )
-        continuous = continuous.sum(dim=-1) / (num_bodies - n_cmd).clamp(min=1e-3)
-
-        return binary + continuous
-
-    return _hand_penalty(
-        command.right_hand_contact_wrench_supports_command,
-        command.right_hand_contact_wrench_supports,
-    ) + _hand_penalty(
-        command.left_hand_contact_wrench_supports_command,
-        command.left_hand_contact_wrench_supports,
+    command.refresh_tensors()
+    return unintended_contact_penalty_jit(
+        right_cmd_active_per_body=command._cached_right_wrench_cmd_active_per_body,
+        right_cur_active_per_body=command._cached_right_wrench_cur_active_per_body,
+        left_cmd_active_per_body=command._cached_left_wrench_cmd_active_per_body,
+        left_cur_active_per_body=command._cached_left_wrench_cur_active_per_body,
+        right_cur_supports=command.right_contact_wrench_supports,
+        left_cur_supports=command.left_contact_wrench_supports,
+        num_bodies=command.num_bodies,
     )
 
 
@@ -117,36 +86,17 @@ def missed_contact_penalty(
     Returns continuous value in [0, 1]. Zero when no contact expected.
     """
     command = env.command_manager.get_term(command_name)
-
-    def _hand_penalty(cmd: torch.Tensor, cur: torch.Tensor) -> torch.Tensor:
-        cmd_active = cmd > 1e-3  # (E, B, M)
-        cur_active = cur > 1e-3
-        missed = cmd_active & ~cur_active
-        n_expected = cmd_active.sum(dim=-1)  # (E, B)
-        n_missed = missed.sum(dim=-1)
-        frac = n_missed / n_expected.clamp(min=1)  # (E, B)
-
-        body_has_contact = n_expected > 0  # (E, B)
-        n_bodies = body_has_contact.sum(dim=-1).clamp(min=1)
-        return (frac * body_has_contact).sum(dim=-1) / n_bodies
-
-    right_cmd = command.right_hand_contact_wrench_supports_command
-    right_cur = command.right_hand_contact_wrench_supports
-    left_cmd = command.left_hand_contact_wrench_supports_command
-    left_cur = command.left_hand_contact_wrench_supports
-
-    right_any = (right_cmd > 1e-3).any(dim=-1).any(dim=-1)
-    left_any = (left_cmd > 1e-3).any(dim=-1).any(dim=-1)
-    n_hands = (right_any.float() + left_any.float()).clamp(min=1)
-
-    return (
-        _hand_penalty(right_cmd, right_cur) + _hand_penalty(left_cmd, left_cur)
-    ) / n_hands
+    command.refresh_tensors()
+    return missed_contact_penalty_jit(
+        right_cmd_active=command._cached_right_wrench_cmd_active,
+        right_cur_active=command._cached_right_wrench_cur_active,
+        left_cmd_active=command._cached_left_wrench_cmd_active,
+        left_cur_active=command._cached_left_wrench_cur_active,
+        right_cmd_active_per_body=command._cached_right_wrench_cmd_active_per_body,
+        left_cmd_active_per_body=command._cached_left_wrench_cmd_active_per_body,
+    )
 
 
-# TODO: force closure should be explicitly evaluated (this is a proxy lower bound).
-# TODO: combine both hands' contacts into a single wrench space per body for
-# bimanual grasps, rather than evaluating per-hand independently.
 def force_closure_reward(
     env: ManagerBasedEnv,
     command_name: str = "motion",
@@ -156,6 +106,8 @@ def force_closure_reward(
 
     When contact is expected, rewards fraction of wrench basis directions
     with sim support above min_support. Averaged over active hands.
+    This is a proxy lower bound: support is evaluated per hand rather than by
+    combining both hands' contacts into a single wrench space per body.
     """
     command = env.command_manager.get_term(command_name)
 

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/rewards/tracking_rewards.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/rewards/tracking_rewards.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+import isaaclab.utils.math as math_utils
 import torch
 from isaaclab.envs import ManagerBasedEnv
 from isaaclab.managers import ManagerTermBase
@@ -324,14 +325,18 @@ def motion_contact_tracking_gaussian_exp(
 
     for side in ("right", "left"):
         pos_e = getattr(command, f"{side}_hand_object_contact_positions_e")
-        valid = (
-            getattr(command, f"{side}_hand_object_contact_positions_w").sum(dim=-1)
-            > 1e-5
-        )
+        pos_w = getattr(command, f"{side}_hand_object_contact_positions_w")
         cmd_e = getattr(command, f"{side}_hand_object_contact_command_positions_e")
         cmd_valid = getattr(command, f"retargeted_{side}_object_contact_is_valid")[
             command.timestep_counter
         ]
+
+        # Articulated objects expose one contact sensor per object body. Chamfer
+        # matching is hand-level, so flatten object bodies into one point cloud.
+        pos_e = pos_e.reshape(pos_e.shape[0], -1, 3)
+        valid = pos_w.reshape(pos_w.shape[0], -1, 3).norm(dim=-1) > 1e-5
+        cmd_e = cmd_e.reshape(cmd_e.shape[0], -1, 3)
+        cmd_valid = cmd_valid.reshape(cmd_valid.shape[0], -1)
 
         dist = chamfer_distance(pos_e, cmd_e, valid, cmd_valid)
         rew = torch.exp(-(dist**2) / std**2)
@@ -363,3 +368,35 @@ def motion_contact_force_gaussian_exp(
         total_contacts += in_contact.sum(dim=-1)
 
     return torch.nan_to_num(total_rew / total_contacts, nan=0.0)
+
+
+def motion_object_keypoints_tracking_exp(
+    env: ManagerBasedEnv,
+    command_name: str,
+    var: float,
+) -> torch.Tensor:
+    """Object keypoint tracking over all object bodies."""
+    command = env.command_manager.get_term(command_name)
+
+    object_pos = command.object_position_e.unsqueeze(2).expand(-1, -1, 6, -1)
+    object_quat = command.object_orientation_e.unsqueeze(2).expand(-1, -1, 6, -1)
+    object_keypoints, _ = math_utils.combine_frame_transforms(
+        object_pos,
+        object_quat,
+        command.KEYPOINT_VECS,
+        q12=None,
+    )
+
+    command_pos = command.object_body_position_command_e.unsqueeze(2).expand(
+        -1, -1, 6, -1
+    )
+    command_quat = command.object_body_wxyz_command_e.unsqueeze(2).expand(-1, -1, 6, -1)
+    command_keypoints, _ = math_utils.combine_frame_transforms(
+        command_pos,
+        command_quat,
+        command.KEYPOINT_VECS,
+        q12=None,
+    )
+
+    error = torch.sum(torch.square(object_keypoints - command_keypoints), dim=-1)
+    return torch.exp(-error / var).mean(dim=(-2, -1))

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/terminations/terminations.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2p_whole_body/mdp/terminations/terminations.py
@@ -8,6 +8,10 @@ import torch
 from isaaclab.envs import ManagerBasedRLEnv
 from isaaclab.utils.math import quat_error_magnitude
 
+from robotic_grounding.tasks.v2p.mdp.terminations import (
+    hand_wrist_away_from_trajectory as _v2p_hand_wrist_away_from_trajectory,
+)
+
 
 def _mask_freeze(command: Any, terminated: torch.Tensor) -> torch.Tensor:
     """Suppress termination during the post-reset freeze period."""
@@ -24,7 +28,10 @@ def timestep_termination(
 ) -> torch.Tensor:
     """Terminate when the trajectory is completed."""
     command = env.command_manager.get_term(command_name)
-    return command.timestep >= command.num_timesteps - 1
+    end_timestep = getattr(
+        command, "trajectory_end_timestep", command.num_timesteps - 1
+    )
+    return command.timestep >= end_timestep
 
 
 def anchor_pos_error(
@@ -99,10 +106,19 @@ def object_pos_error(
     command_name: str,
     threshold: float = 0.1,
 ) -> torch.Tensor:
-    """Terminate when the object position is too far from the command. Freeze-aware."""
+    """Terminate when any object body position is too far from the command."""
     command = env.command_manager.get_term(command_name)
-    error = torch.norm(command.object_pos_w - command.command_object_pos_w, dim=-1)
-    terminated = error > threshold
+    if hasattr(command, "object_body_position_command_e") and hasattr(
+        command, "object_position_e"
+    ):
+        error = torch.norm(
+            command.object_position_e - command.object_body_position_command_e,
+            dim=-1,
+        )
+        terminated = (error > threshold).any(dim=-1)
+    else:
+        error = torch.norm(command.object_pos_w - command.command_object_pos_w, dim=-1)
+        terminated = error > threshold
     return _mask_freeze(command, terminated)
 
 
@@ -111,8 +127,34 @@ def object_quat_error(
     command_name: str,
     threshold: float = 0.5,
 ) -> torch.Tensor:
-    """Terminate when the object orientation is too far from the command. Freeze-aware."""
+    """Terminate when any object body orientation is too far from the command."""
     command = env.command_manager.get_term(command_name)
-    error = quat_error_magnitude(command.object_quat_w, command.command_object_quat_w)
-    terminated = error > threshold
+    if hasattr(command, "object_body_wxyz_command_e") and hasattr(
+        command, "object_orientation_e"
+    ):
+        error = quat_error_magnitude(
+            command.object_orientation_e.reshape(-1, 4),
+            command.object_body_wxyz_command_e.reshape(-1, 4),
+        ).reshape(command.num_envs, -1)
+        terminated = (error > threshold).any(dim=-1)
+    else:
+        error = quat_error_magnitude(
+            command.object_quat_w, command.command_object_quat_w
+        )
+        terminated = error > threshold
+    return _mask_freeze(command, terminated)
+
+
+def hand_wrist_away_from_trajectory(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    threshold: float,
+) -> torch.Tensor:
+    """V2P hands hand-away termination with whole-body reset-freeze masking."""
+    command = env.command_manager.get_term(command_name)
+    terminated = _v2p_hand_wrist_away_from_trajectory(
+        env,
+        command_name=command_name,
+        threshold=threshold,
+    )
     return _mask_freeze(command, terminated)


### PR DESCRIPTION
## Summary

This PR adds the ReconHand MDP/runtime code needed to train and evaluate rigid, articulated, and multi-object hand-object sequences.

Scope is intentionally code-only. It does not ship the companion motion parquets, reconstructed support USDAs, experiment YAML/workflow files, policies, checkpoints, or generated output artifacts from the broader task branch.

## Module changes

### Robot assets

`assets/g1.py` now exposes the Dex3 finger joint names used by the ReconHand environment config. This keeps the hand joint list centralized with the robot asset definition instead of hard-coding it inside the task config.

### Scene loading and spawning

`tasks/scene_utils/scene_config.py` now derives motion horizon length from available motion data and initializes articulated object roots from the first object body pose in `motion_v1` data. `apply_scene_config.py` uses articulated object initial joint positions when spawning and caps whole-body episode length from the motion horizon plus reset-freeze steps. The clean branch does not add dataset-specific support-surface alignment behavior.

### Whole-body environment config

`tasks/v2p_whole_body/base_env_cfg.py` adds collision group setup as a pre-startup event and configures scene replication/collision filtering so multi-object sequences can be handled consistently.

`tasks/v2p_whole_body/config/sonic/g1/g1_sonic_env_cfg.py` adds the ReconHand observation, reward, curriculum, termination, and action configuration. It keeps the existing generic wrist-velocity observation path intact while using the fuller wrist-frame velocity signal for the ReconHand policy.

### Tracking command

`tasks/v2p_whole_body/mdp/commands/tracking_command.py` now handles multi-body object references and optional object articulation from motion data. It validates/reorders per-hand finger joints, tracks contacted object part IDs, computes wrist/fingertip/contact targets in the relevant object-body frame, clamps future command timesteps to the active trajectory window, and caches refreshed tensors for the support/contact wrench reward path.

### Reset events

`tasks/v2p_whole_body/mdp/events/events.py` makes trajectory reset window-aware and resets all command objects, not only the first rigid object. It also writes articulated object joint state when the scene object is an articulation.

### Observations

`tasks/v2p_whole_body/mdp/observations/policy_observations.py` adds future anchor deltas in the current anchor frame and multi-body object pose deltas. It restores the generic 6D pelvis-frame wrist velocity observation and adds a separate 12D wrist-frame linear/angular velocity observation for ReconHand.

### Rewards

`tasks/v2p_whole_body/mdp/rewards/contact_rewards.py` uses refreshed/cached command tensors for contact wrench support, unintended contact, and missed contact rewards.

`tasks/v2p_whole_body/mdp/rewards/tracking_rewards.py` evaluates object keypoint tracking across multiple object bodies and flattens object bodies into the hand-contact point cloud where needed.

### Terminations

`tasks/v2p_whole_body/mdp/terminations/terminations.py` uses the active trajectory end timestep, evaluates object position/orientation termination across all object bodies, and preserves reset-freeze masking for the hand-wrist-away termination wrapper.

## Verification

Functional eval coverage was run on the comprehensive task branch that this clean PR was split from, using the same ReconHand code plus the companion data/support assets intentionally excluded here:

- `taco_empty_cup_bowl`: stable success rate `0.97775`, trials `[0.959, 0.975, 0.986, 0.991]`.
- `mixer_use_s02`: stable success rate `0.96675`, trials `[0.970, 0.970, 0.967, 0.960]`.
- `espresso_grab_s01`: first two observed trials were `1.000` success

## Future work

- Normalize license headers in the touched ReconHand source files.
- Find an appropriate place to host the companion task-set motion parquets and support USDAs.
- Add flagship experiment YAML/workflow files once the flagship task set is decided.
