### PR TITLE
feat(loader)+docs: improve instructions for running data processing locally

### DIFF
--- a/reconstruction/modules/v2d_task_library_loader/docker/run_loader.py
+++ b/reconstruction/modules/v2d_task_library_loader/docker/run_loader.py
@@ -18,6 +18,7 @@ def run_loader(
     output_dir: str,
     mano_model_dir: str,
     human_motion_data_dir: str,
+    object_assets_dir: str | None = None,
     device: str = "cuda:0",
     save: bool = True,
     sequence_pattern: str | None = None,
@@ -27,26 +28,40 @@ def run_loader(
     num_shards: int | None = None,
     dev: bool = False,
 ) -> None:
+    extra_volumes = [
+        f"{os.path.abspath(human_motion_data_dir)}:/data/human_motion_data"
+    ]
+    extra_args: dict[str, object] = {
+        "dataset": dataset,
+        "device": device,
+        "save": save,
+        "sequence_pattern": sequence_pattern,
+        "sequence_id": sequence_id,
+        "max_sequences": max_sequences,
+        "shard_id": shard_id,
+        "num_shards": num_shards,
+    }
+
+    # Object assets (rigid URDFs + meshes). Mount the root containing
+    # `urdfs/<dataset>/` and `meshes/<dataset>/` as ONE volume so the URDFs'
+    # relative `../../meshes/<dataset>/…` refs resolve (MuJoCo loads arctic's
+    # articulated URDF by path and follows those refs).
+    if object_assets_dir is not None:
+        extra_volumes.append(
+            f"{os.path.abspath(object_assets_dir)}:/data/object_assets"
+        )
+        extra_args["object_model_root"] = f"/data/object_assets/urdfs/{dataset}"
+        extra_args["mesh_dir"] = f"/data/object_assets/meshes/{dataset}"
+
     run_in_container(
         image=IMAGE_NAME,
         module="v2d.task_library_loader.lib.run_loader",
         inputs={"mano_model_dir": mano_model_dir},
         outputs={"output_dir": output_dir},
-        extra_args={
-            "dataset": dataset,
-            "device": device,
-            "save": save,
-            "sequence_pattern": sequence_pattern,
-            "sequence_id": sequence_id,
-            "max_sequences": max_sequences,
-            "shard_id": shard_id,
-            "num_shards": num_shards,
-        },
+        extra_args=extra_args,
         # The loaders read raw inputs from $HUMAN_MOTION_DATA_DIR/<dataset>/...
         env={"HUMAN_MOTION_DATA_DIR": "/data/human_motion_data"},
-        extra_volumes=[
-            f"{os.path.abspath(human_motion_data_dir)}:/data/human_motion_data"
-        ],
+        extra_volumes=extra_volumes,
         dev=dev,
         modules_dir=MODULES_DIR,
         gpus=True,
@@ -61,6 +76,12 @@ if __name__ == "__main__":
     parser.add_argument("--output_dir", required=True)
     parser.add_argument("--mano_model_dir", required=True)
     parser.add_argument("--human_motion_data_dir", required=True)
+    parser.add_argument(
+        "--object_assets_dir",
+        default=None,
+        help="Root holding urdfs/<dataset>/ + meshes/<dataset>/ (mounted as one "
+        "volume so URDF '../../meshes/...' refs resolve). Omit for h2o/grab/dexycb.",
+    )
     parser.add_argument("--device", default="cuda:0")
     parser.add_argument("--save", action="store_true", default=True)
     parser.add_argument("--sequence_pattern", default=None)
@@ -75,6 +96,7 @@ if __name__ == "__main__":
         output_dir=args.output_dir,
         mano_model_dir=args.mano_model_dir,
         human_motion_data_dir=args.human_motion_data_dir,
+        object_assets_dir=args.object_assets_dir,
         device=args.device,
         save=args.save,
         sequence_pattern=args.sequence_pattern,

--- a/robotic_grounding/workflow/data_pipeline.md
+++ b/robotic_grounding/workflow/data_pipeline.md
@@ -81,16 +81,35 @@ The loader also handles dataset-specific preprocessing:
 **Output:** `human_motion_data/{dataset}/{dataset}_loaded/` partitioned by
 `sequence_id` and `robot_name`.
 
-**Command** (run from the `reconstruction` repo / loader image, not here):
+**In-container command** (what runs inside the loader image):
 ```bash
 python -m v2d.task_library_loader.lib.run_loader \
   --dataset <name> \
   --dataset_root <raw_dataset_dir> \
+  --object_model_root <dir with the dataset's *.urdf> \
+  --mesh_dir <dir with the dataset's object meshes> \
   --mano_model_dir <dir with models/MANO_{LEFT,RIGHT}.pkl> \
   --output_dir <path> \
   --device cuda:0 --save
 ```
-or submit `reconstruction/workflows/task_library_load/osmo/load.yaml` on OSMO.
+
+**Run it locally** (host wrapper — mounts the inputs and runs the in-container
+command above). Raw data lives under `<human_motion_data_dir>/<dataset>/dataset/`;
+`--object_assets_dir` is the root holding `urdfs/<dataset>/` + `meshes/<dataset>/`:
+
+```bash
+python -m v2d.task_library_loader.docker.run_loader \
+  --dataset arctic \
+  --human_motion_data_dir <dir containing arctic/dataset/...> \
+  --object_assets_dir <dir containing urdfs/arctic + meshes/arctic> \
+  --mano_model_dir <dir with models/MANO_{LEFT,RIGHT}.pkl> \
+  --output_dir <out> \
+  --max_sequences 2 --save
+```
+
+Omit `--object_assets_dir` for h2o/grab/dexycb (meshes come from the raw dataset).
+
+Or submit `reconstruction/workflows/task_library_load/osmo/load.yaml` on OSMO.
 
 ## Stage 1.5: Generate Rigid URDFs
 
@@ -139,14 +158,29 @@ frames) to the existing Parquet alongside the original MANO and object data.
 **Output:** `human_motion_data/{dataset}/{dataset}_processed/` (same partition
 structure, now includes SHARPA robot fields).
 
-**Command:**
+**Command** (in-container — robotic_grounding image):
 ```bash
 python scripts/retarget/run_retarget.py \
-  --dataset <name> \
+  --dataset <name> --robot sharpa_wave \
   --input_dir <loaded_dir> \
   --output_dir <processed_dir> \
   --device cuda:0 --save
 ```
+
+**Run it locally** (override the image's Isaac Sim entrypoint — retarget is
+pinocchio IK, no sim):
+
+```bash
+docker run --rm --gpus all --entrypoint /bin/bash \
+  -v "$PWD/..:/workspace/video_to_data" \
+  -v <loaded_dir>:/data/loaded -v <processed_dir>:/data/processed \
+  -w /workspace/video_to_data/robotic_grounding \
+  robotic-grounding:<tag> \
+  -c "python scripts/retarget/run_retarget.py --dataset <name> --robot sharpa_wave \
+       --input_dir /data/loaded --output_dir /data/processed --device cuda:0 --save"
+```
+
+(Or `./workflow/run.sh start` then run the in-container command.)
 
 ## Stage 3: Reconstruct Support Surfaces (optional)
 


### PR DESCRIPTION
Changes:
- run_loader.py (host wrapper): add `object_assets_dir` — mounts urdfs/<dataset>/
  + meshes/<dataset>/ as ONE volume and passes --object_model_root/--mesh_dir, so the URDFs' ../../meshes/... refs resolve (MuJoCo loads arctic's articulated URDF by path). Optional; omit for h2o/grab/dexycb (meshes from raw).
- data_pipeline.md Stage 1: in-container command + --object_model_root/--mesh_dir, sequence_id-prefix caveat, and a local host-wrapper run command.
- data_pipeline.md Stage 2: in-container command (+ --robot) and a local docker run that overrides the image's Isaac Sim entrypoint (retarget is pinocchio-only).

Validated locally on arctic (2 seqs): load output bit-identical to a direct docker run; retarget populates the robot IK fields.