### PR TITLE
chore: remove stale TODO comments and internal handle

### DIFF
--- a/robotic_grounding/source/robotic_grounding/config/extension.toml
+++ b/robotic_grounding/source/robotic_grounding/config/extension.toml
@@ -24,12 +24,3 @@ keywords = ["Video to Policy", "RL", "isaaclab"]
 
 [[python.module]]
 name = "robotic_grounding"
-
-[isaaclab_settings]
-# TODO: Uncomment and list any apt dependencies here.
-#       If none, leave it commented out.
-# apt_deps = ["example_package"]
-# TODO: Uncomment and provide path to a ros_ws
-#       with rosdeps to be installed. If none,
-#       leave it commented out.
-# ros_ws = "path/from/extension_root/to/ros_ws"

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/retarget/hand_kinematics.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/retarget/hand_kinematics.py
@@ -284,7 +284,6 @@ class HandKinematics:
                 source_target_joint_pos,
                 source_target_joint_wxyz,
             )
-            # TODO: Implement relative frame tasks
             self.relative_frame_tasks[
                 task_name
             ].transform_target_to_world.translation = source_root_p_target.copy()

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/apply_scene_config.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/scene_utils/apply_scene_config.py
@@ -78,9 +78,7 @@ def _spawn_articulated(
                 stiffness={".*": 0.0},
                 damping={".*": 0.0},
                 armature={".*": 0.01},
-                friction={
-                    ".*": 0.1
-                },  # TODO: @zeol confirm joint friction is appropriate
+                friction={".*": 0.1},
             ),
         },
     )


### PR DESCRIPTION
Drop leftover scaffolding/placeholder TODOs ahead of public release:
- extension.toml: commented-out isaaclab_settings TODO block
- hand_kinematics.py: stale "implement relative frame tasks" TODO
- apply_scene_config.py: internal "@zeol confirm joint friction" note

Comment-only; no behavior change.