### PR TITLE
Hhz/remove internal links

### DIFF
--- a/robotic_grounding/experiments/experiment_config.yaml
+++ b/robotic_grounding/experiments/experiment_config.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# TODO(public-release): Remove this file prior to release.
+
+wandb_entity: nvidia-isaac
+
+osmo:
+  default_pool: isaac-dev-l40s-04
+  runner_default_pool: isaac-dev-l40-03
+  image_repo: nvcr.io/nvstaging/isaac-amr/robotic-grounding
+  image_latest: nvcr.io/nvstaging/isaac-amr/robotic-grounding:latest
+  omni_server: omniverse://isaac-dev.ov.nvidia.com
+
+experiments:
+  recon_body_apple:
+    osmo:
+      image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple
+  recon_body_bottle_pick_transfer:
+    osmo:
+      image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple
+  recon_body_snack_box_pick_and_place_01:
+    osmo:
+      image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple
+  recon_body_blue_trash_can_drag_007:
+    osmo:
+      image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple
+  recon_body_corn_can_right_left_handover_01:
+    osmo:
+      image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple

--- a/robotic_grounding/experiments/recon_body_apple_pick/config.yaml
+++ b/robotic_grounding/experiments/recon_body_apple_pick/config.yaml
@@ -23,7 +23,3 @@ train_overrides:
 
 osmo:
   build_image: false
-  # Pin the pre-built image that contains the v2p_whole_body tasks so submits don't
-  # fall back to :latest (which predates this branch). Rebuild via --build-image when
-  # you change source code the image depends on.
-  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple

--- a/robotic_grounding/experiments/recon_body_blue_trash_can_drag_007/config.yaml
+++ b/robotic_grounding/experiments/recon_body_blue_trash_can_drag_007/config.yaml
@@ -33,5 +33,3 @@ train_overrides:
 
 osmo:
   build_image: false
-  # Reuse the current whole-body training image so submits don't fall back to :latest.
-  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple

--- a/robotic_grounding/experiments/recon_body_bottle_pick_transfer/config.yaml
+++ b/robotic_grounding/experiments/recon_body_bottle_pick_transfer/config.yaml
@@ -23,5 +23,3 @@ train_overrides:
 
 osmo:
   build_image: false
-  # Reuse the current whole-body training image so submits don't fall back to :latest.
-  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple

--- a/robotic_grounding/experiments/recon_body_corn_can_right_left_handover_01/config.yaml
+++ b/robotic_grounding/experiments/recon_body_corn_can_right_left_handover_01/config.yaml
@@ -24,4 +24,3 @@ train_overrides:
   env.commands.motion.reset_shoulder_spread: 0.2
 osmo:
   build_image: false
-  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple

--- a/robotic_grounding/experiments/recon_body_snack_box_pick_and_place_01/config.yaml
+++ b/robotic_grounding/experiments/recon_body_snack_box_pick_and_place_01/config.yaml
@@ -32,5 +32,3 @@ train_overrides:
 
 osmo:
   build_image: false
-  # Reuse the current whole-body training image so submits don't fall back to :latest.
-  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple

--- a/robotic_grounding/experiments/run_experiment.py
+++ b/robotic_grounding/experiments/run_experiment.py
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 Usage:
   python scripts/run_experiment.py exp5              # defaults to --osmo
   python scripts/run_experiment.py exp5 --local
-  python scripts/run_experiment.py exp5 --osmo --pool isaac-dev-l40s-04 --build-image
+  python scripts/run_experiment.py exp5 --osmo --pool <pool> --build-image
   python scripts/run_experiment.py exp6 --wandb-sweep-create   # Create wandb sweep, print agent command
   python scripts/run_experiment.py exp7 --osmo                # Submit OSMO curriculum sweep
   python scripts/run_experiment.py --list                    # List all experiments
@@ -41,8 +41,10 @@ from experiments.utils import (  # noqa: E402
     DEFAULT_WANDB_ENTITY,
     build_eval_command,
     build_train_command,
+    get_internal_config_value,
     make_entry_script,
     overrides_to_cli,
+    require_internal_config_value,
 )
 
 
@@ -65,6 +67,33 @@ def load_registry() -> dict[str, str]:
     return registry
 
 
+def _deep_merge_dict(base: dict, overrides: dict) -> dict:
+    """Return base recursively overlaid with overrides."""
+    merged = dict(base)
+    for key, value in overrides.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge_dict(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _merge_internal_experiment_config(exp_id: str, config: dict) -> dict:
+    """Overlay optional internal per-experiment settings by id."""
+    internal_experiments = get_internal_config_value("experiments", default={})
+    if not isinstance(internal_experiments, dict):
+        return config
+
+    merged = config
+    for key in dict.fromkeys((exp_id, config.get("id"))):
+        if not key:
+            continue
+        internal_config = internal_experiments.get(key)
+        if isinstance(internal_config, dict):
+            merged = _deep_merge_dict(merged, internal_config)
+    return merged
+
+
 def load_experiment_config(exp_id: str) -> tuple[Path, dict]:
     """Load config for experiment. Returns (config_path, config dict)."""
     registry = load_registry()
@@ -80,6 +109,7 @@ def load_experiment_config(exp_id: str) -> tuple[Path, dict]:
         config = yaml.safe_load(f)
     if not config:
         raise SystemExit(f"Empty or invalid config: {config_path}")
+    config = _merge_internal_experiment_config(exp_id, config)
     return config_path, config
 
 
@@ -357,9 +387,13 @@ def generate_single_task_workflow(
         print(
             "[WARNING] WANDB_API_KEY not set in local environment — wandb will fail in the container"
         )
-    # Default to the shared NVIDIA team entity so OSMO runs don't land in a submitter's
-    # personal workspace. Individual experiments can override via config `wandb_entity`.
-    wandb_entity = config.get("wandb_entity", DEFAULT_WANDB_ENTITY)
+    wandb_entity = config.get("wandb_entity") or DEFAULT_WANDB_ENTITY
+    if wandb_entity is None:
+        wandb_entity = require_internal_config_value("wandb_entity")
+    omni_server = require_internal_config_value("osmo", "omni_server")
+    image_latest = DEFAULT_OSMO_IMAGE_LATEST or require_internal_config_value(
+        "osmo", "image_latest"
+    )
     return f"""# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # Generated from experiments/ for {exp_id}
@@ -381,7 +415,7 @@ workflow:
     args: [/tmp/entry.sh]
     environment:
       ACCEPT_EULA: Y
-      OMNI_SERVER: omniverse://isaac-dev.ov.nvidia.com
+      OMNI_SERVER: {omni_server}
       WANDB_API_KEY: {wandb_api_key}
       WANDB_ENTITY: {wandb_entity}
 {inputs_block}    files:
@@ -391,7 +425,7 @@ workflow:
 
 default-values:
   workflow_name: robotic_grounding_{exp_id}
-  image: {DEFAULT_OSMO_IMAGE_LATEST}
+  image: {image_latest}
 """
 
 
@@ -433,6 +467,13 @@ def generate_multi_sequence_workflow(
         print(
             "[WARNING] WANDB_API_KEY not set in local environment — wandb will fail in the container"
         )
+    wandb_entity = config.get("wandb_entity") or DEFAULT_WANDB_ENTITY
+    if wandb_entity is None:
+        wandb_entity = require_internal_config_value("wandb_entity")
+    omni_server = require_internal_config_value("osmo", "omni_server")
+    image_latest = DEFAULT_OSMO_IMAGE_LATEST or require_internal_config_value(
+        "osmo", "image_latest"
+    )
 
     tasks = []
     for seq_id in sequences:
@@ -490,8 +531,9 @@ def generate_multi_sequence_workflow(
             f"    args: [/tmp/entry.sh]\n"
             f"    environment:\n"
             f"      ACCEPT_EULA: Y\n"
-            f"      OMNI_SERVER: omniverse://isaac-dev.ov.nvidia.com\n"
+            f"      OMNI_SERVER: {omni_server}\n"
             f"      WANDB_API_KEY: {wandb_api_key}\n"
+            f"      WANDB_ENTITY: {wandb_entity}\n"
             f"{inputs_block}"
             f"    files:\n"
             f"    - path: /tmp/entry.sh\n"
@@ -519,7 +561,7 @@ def generate_multi_sequence_workflow(
         f"\n"
         f"default-values:\n"
         f"  workflow_name: robotic_grounding_{exp_id}{'_' + workflow_label if workflow_label else ''}\n"
-        f"  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:latest\n"
+        f"  image: {image_latest}\n"
     )
 
 
@@ -608,7 +650,7 @@ def _check_osmo_login() -> None:
 def run_osmo(
     exp_id: str,
     config: dict,
-    pool: str = "isaac-dev-l40s-04",
+    pool: str | None = None,
     build_image: bool = False,
     image: str | None = None,
     priority: str = "NORMAL",
@@ -618,6 +660,8 @@ def run_osmo(
     """Generate workflow YAML and submit to OSMO via run_osmo.py."""
     if not dry_run:
         _check_osmo_login()
+    if pool is None:
+        pool = require_internal_config_value("osmo", "default_pool")
 
     # When the user asks to build but doesn't pin an explicit image tag, derive one from
     # exp_id so the tag produced by run_osmo.py matches the tag baked into the workflow
@@ -625,7 +669,10 @@ def run_osmo(
     # the submitted workflow still references :latest, which causes OSMO to run a stale
     # image and e.g. miss newly-registered gym task IDs (see SonicG1-ReconBody-v0).
     if build_image and image is None:
-        image = f"{DEFAULT_OSMO_IMAGE_REPO}:{exp_id}"
+        image_repo = DEFAULT_OSMO_IMAGE_REPO or require_internal_config_value(
+            "osmo", "image_repo"
+        )
+        image = f"{image_repo}:{exp_id}"
         print(f"[INFO] --build-image without --image: pinning to {image}")
 
     if "osmo_multi_task" in config:
@@ -655,7 +702,7 @@ def run_osmo(
         mode="w",
         suffix=".yaml",
         delete=False,
-        dir=REPO_ROOT,
+        dir=RG_ROOT,
     ) as f:
         f.write(workflow_content)
         workflow_path = Path(f.name)
@@ -690,7 +737,7 @@ def run_osmo(
         cmd.extend(["--priority", priority])
         if dry_run:
             cmd.append("--dry-run")
-        result = subprocess.run(cmd, cwd=REPO_ROOT, check=False)
+        result = subprocess.run(cmd, cwd=RG_ROOT, check=False)
         sys.exit(result.returncode)
     finally:
         workflow_path.unlink(missing_ok=True)
@@ -786,7 +833,7 @@ def main() -> None:
     parser.add_argument(
         "--pool",
         default=None,
-        help="OSMO pool (default: from config osmo.pool, or isaac-dev-l40s-04)",
+        help="OSMO pool (default: config osmo.pool, then internal experiment_config.yaml)",
     )
     parser.add_argument(
         "--build-image", action="store_true", help="Build and push image before OSMO"
@@ -924,7 +971,11 @@ def main() -> None:
         # Image precedence: CLI --image > config osmo.image > (auto-derived from exp_id
         # when --build-image and nothing else is set, see run_osmo) > workflow YAML default.
         image = args.image or osmo_cfg.get("image")
-        pool = args.pool or osmo_cfg.get("pool", "isaac-dev-l40s-04")
+        pool = (
+            args.pool
+            or osmo_cfg.get("pool")
+            or get_internal_config_value("osmo", "default_pool")
+        )
         priority = args.priority or osmo_cfg.get("priority", "NORMAL")
         run_osmo(
             args.exp_id,

--- a/robotic_grounding/experiments/utils.py
+++ b/robotic_grounding/experiments/utils.py
@@ -7,21 +7,55 @@ Used by run_experiment.py and experiment-specific workflow.py modules.
 
 from __future__ import annotations
 
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent
+EXPERIMENT_CONFIG_PATH = Path(__file__).resolve().parent / "experiment_config.yaml"
 
-# Default W&B team entity for all OSMO-submitted runs. Overridable per experiment via
-# `wandb_entity:` in config.yaml.
-DEFAULT_WANDB_ENTITY = "nvidia-isaac"
 
-# Container registry repo for the robotic-grounding Docker image. Individual experiments
-# pin a specific tag via `osmo.image` in their config.yaml; this constant is used when
-# deriving tags (e.g. `<repo>:<exp_id>` when --build-image is passed without --image)
-# and as the default ":latest" fallback for generated OSMO workflow YAMLs.
-DEFAULT_OSMO_IMAGE_REPO = "nvcr.io/nvstaging/isaac-amr/robotic-grounding"
-DEFAULT_OSMO_IMAGE_LATEST = f"{DEFAULT_OSMO_IMAGE_REPO}:latest"
+@lru_cache(maxsize=1)
+def load_internal_experiment_config() -> dict[str, Any]:
+    """Load optional internal launch settings removed from release builds."""
+    if not EXPERIMENT_CONFIG_PATH.exists():
+        return {}
+    with open(EXPERIMENT_CONFIG_PATH, encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Invalid internal experiment config: {EXPERIMENT_CONFIG_PATH}"
+        )
+    return data
+
+
+def get_internal_config_value(*keys: str, default: Any = None) -> Any:
+    """Return a nested value from experiment_config.yaml when present."""
+    value: Any = load_internal_experiment_config()
+    for key in keys:
+        if not isinstance(value, dict) or key not in value:
+            return default
+        value = value[key]
+    return value
+
+
+def require_internal_config_value(*keys: str) -> Any:
+    """Return a required internal value or fail with release-safe guidance."""
+    value = get_internal_config_value(*keys)
+    if value is None:
+        dotted = ".".join(keys)
+        raise RuntimeError(
+            f"Missing internal experiment config value: {dotted}. "
+            f"Create {EXPERIMENT_CONFIG_PATH} or pass an explicit override."
+        )
+    return value
+
+
+DEFAULT_WANDB_ENTITY = get_internal_config_value("wandb_entity")
+DEFAULT_OSMO_IMAGE_REPO = get_internal_config_value("osmo", "image_repo")
+DEFAULT_OSMO_IMAGE_LATEST = get_internal_config_value("osmo", "image_latest")
 
 
 def sequence_to_object(sequence_id: str) -> str:

--- a/robotic_grounding/scripts/retarget/create_soma_task.py
+++ b/robotic_grounding/scripts/retarget/create_soma_task.py
@@ -130,8 +130,6 @@ def render_config_yaml(
         "\n"
         "osmo:\n"
         "  build_image: false\n"
-        "  # Reuse the current whole-body training image so submits don't fall back to :latest.\n"
-        "  image: nvcr.io/nvstaging/isaac-amr/robotic-grounding:recon_body_apple\n"
     )
 
 

--- a/robotic_grounding/scripts/rsl_rl/download_from_wandb.py
+++ b/robotic_grounding/scripts/rsl_rl/download_from_wandb.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Download a run from wandb")
     parser.add_argument(
-        "run_id", help="Wandb run ID (e.g. nvidia-isaac/xzhu_v2p_hands/y5y535hn)"
+        "run_id", help="Wandb run ID (e.g. <entity>/<project>/<run_id>)"
     )
     parser.add_argument(
         "--checkpoint",

--- a/robotic_grounding/scripts/run_osmo.py
+++ b/robotic_grounding/scripts/run_osmo.py
@@ -16,6 +16,17 @@ import subprocess
 import sys
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from experiments.utils import (  # noqa: E402
+    DEFAULT_OSMO_IMAGE_LATEST,
+    DEFAULT_OSMO_IMAGE_REPO,
+    get_internal_config_value,
+    require_internal_config_value,
+)
+
 
 def run_command(cmd: str, check: bool = True) -> subprocess.CompletedProcess:
     """Run a shell command and return the result."""
@@ -48,8 +59,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--pool",
-        default="isaac-dev-l40-03",
-        help="OSMO pool to use for workflow execution (default: isaac-dev-l40-03)",
+        default=None,
+        help="OSMO pool to use for workflow execution (default: internal experiment_config.yaml)",
     )
     parser.add_argument(
         "--build-image",
@@ -75,8 +86,13 @@ def main() -> None:
     args = parser.parse_args()
 
     # Get the repository root directory (assuming script is in scripts/)
-    repo_root = Path(__file__).parent.parent
-    os.chdir(repo_root)
+    os.chdir(REPO_ROOT)
+    pool = args.pool or get_internal_config_value("osmo", "runner_default_pool")
+    if pool is None:
+        raise SystemExit(
+            "OSMO pool is required. Pass --pool or provide osmo.runner_default_pool "
+            "in experiments/experiment_config.yaml."
+        )
 
     # Determine image to use
     if args.build_image:
@@ -86,9 +102,10 @@ def main() -> None:
             image_version = image_name.split(":")[-1]
         else:
             image_version = args.experiment_name
-            image_name = (
-                f"nvcr.io/nvstaging/isaac-amr/robotic-grounding:{image_version}"
+            image_repo = DEFAULT_OSMO_IMAGE_REPO or require_internal_config_value(
+                "osmo", "image_repo"
             )
+            image_name = f"{image_repo}:{image_version}"
 
         print(f"\nBuilding Docker image: {image_name} ...")
         build_cmd = f"./workflow/run.sh build {image_version}"
@@ -115,7 +132,9 @@ def main() -> None:
         image_name = args.image
         print(f"Using existing Docker image: {image_name}")
     else:
-        image_name = "nvcr.io/nvstaging/isaac-amr/robotic-grounding:latest"
+        image_name = DEFAULT_OSMO_IMAGE_LATEST or require_internal_config_value(
+            "osmo", "image_latest"
+        )
         print(f"Using default Docker image: {image_name}")
 
     # Use provided image
@@ -140,7 +159,7 @@ def main() -> None:
     osmo_cmd = (
         f"osmo workflow submit {args.workflow_yaml} "
         f"--set {set_str} "
-        f"--pool {args.pool} "
+        f"--pool {pool} "
         f"--priority {args.priority}"
     )
 

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=apple_pick_optimized/object/apple_collision.obj
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=apple_pick_optimized/object/apple_collision.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c6c65338a190e0f536d8068e0f95f10c744c2c980e97242302ce285ca5c92ca
+size 131549

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=apple_pick_optimized/object/apple_rigid.urdf
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=apple_pick_optimized/object/apple_rigid.urdf
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<robot name="apple">
+  <material name="red">
+    <color rgba="0.8 0.1 0.1 1.0"/>
+  </material>
+  <link name="object">
+    <visual>
+      <geometry>
+        <mesh filename="apple_collision.obj" scale="1.0 1.0 1.0"/>
+      </geometry>
+      <material name="red"/>
+    </visual>
+    <collision>
+      <geometry>
+        <mesh filename="apple_collision.obj" scale="1.0 1.0 1.0"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <mass value="0.15"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+</robot>

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=apple_pick_optimized/object/apple_simple.usda
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=apple_pick_optimized/object/apple_simple.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b75bc085fd70fceb5f76654e5a0b7ef944c0ad30ae21dc88f7a349974e765f7
+size 1732

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=apple_pick_optimized/robot_name=g1/data.parquet
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/assets/human_motion_data/whole_body/soma/sequence_id=apple_pick_optimized/robot_name=g1/data.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d6e358d829be45c97ea0f4f8fb4257761ed08ed8c7bed96bf48b7340711ec87
-size 130060
+oid sha256:80db3cb4ff18e185a21f22f02132935535838d617f3f6b78f4f45df7d4c9ac1b
+size 123258


### PR DESCRIPTION
### Summary

Two release-prep cleanups landed together:
1. Move NVIDIA-internal defaults (OSMO pool, image tags, W&B entity, omni server) out of public-facing code into a local `experiments/experiment_config.yaml` that's stripped at release time.
2. Restore the apple object assets that PR #121 deleted but the `apple_pick_optimized` SOMA parquet still references.

### Changes

**Internal-config extraction**
- `experiments/utils.py` + `run_experiment.py` + `scripts/run_osmo.py`: read OSMO/W&B defaults from the internal config; raise a clear error when missing.
- `experiments/recon_body_*/config.yaml` (5 files): drop hardcoded `osmo.image` pins; supplied by per-experiment overlay.
- `release/`: new directory with `remove_internal.py` (walks `internal.yaml` markers + `# internal-begin/end` line markers, removes submodules) and README.

**Apple asset restore**
- Restore (from `0fabc6a3~1`) under `whole_body/soma/sequence_id=apple_pick_optimized/object/`:
  - `apple_rigid.urdf`, `apple_collision.obj`, `apple_simple.usda`
- Rewrite `data.parquet`'s `object_mesh_paths` / `object_urdf_paths` to point at the new location.

### Testing

- `--osmo --dry-run` renders the right image + pool for `recon_body_apple` and `recon_body_bottle_pick_transfer`.
- Fresh clone without the internal config fails fast with `RuntimeError: Missing internal experiment config value: ...`.
- Apple files on disk; USDA is real content (LFS resolved); parquet read-back returns the new paths.
- OSMO end-to-end: `recon_body_apple-24` was the failing baseline; `recon_body_apple-25` rebuilt with `--build-image` is RUNNING with both fixes baked in.  [apple pick](https://us-west-2-aws.osmo.nvidia.com/workflows/robotic_grounding_recon_body_apple-25), [bottle pick](https://us-west-2-aws.osmo.nvidia.com/workflows/robotic_grounding_recon_body_bottle_pick_transfer-2)