### PR TITLE
[codex] Add documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Monorepo for **Video to Data (V2D)** — an end-to-end pipeline that converts human demonstration videos into simulation-ready assets and physics-grounded robot training data.
 
+Documentation is available at [nvidia-isaac.github.io/video_to_data](https://nvidia-isaac.github.io/video_to_data/).
+
 ## End-to-End Workflow
 
 ```


### PR DESCRIPTION
## Summary

- Add the published Video to Data documentation link near the top of the README.

## Impact

- Makes the hosted documentation easier to discover from the repository landing page.

## Validation

- Ran `git diff --check`.
- Verified `https://nvidia-isaac.github.io/video_to_data/` returns HTTP 200.