### PR TITLE
[codex] Add CHORD arXiv link

### DIFF
--- a/docs/chord/index.html
+++ b/docs/chord/index.html
@@ -63,10 +63,10 @@
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6 2h9l5 5v13a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2zm8 1.5V8h4.5L14 3.5z"/></svg>
           Paper
         </a>
-        <span style="display:inline-flex; align-items:center; gap:8px; padding:11px 22px; border-radius:4px; background:rgba(255,255,255,.1); border:1px solid rgba(255,255,255,.2); color:rgba(255,255,255,.62); font-weight:600; font-size:1rem; cursor:not-allowed;">
+        <a href="https://arxiv.org/abs/2607.00033" target="_blank" rel="noopener noreferrer" style="display:inline-flex; align-items:center; gap:8px; padding:11px 22px; border-radius:4px; background:rgba(255,255,255,.12); border:1px solid rgba(255,255,255,.35); color:#fff; font-weight:600; font-size:1rem; text-decoration:none;">
           <img src="assets/pics/arxiv.svg" alt="" aria-hidden="true" style="height:20px; width:auto; display:block;">
-          arXiv <span style="font-size:.74em; font-weight:600; opacity:.85;">soon</span>
-        </span>
+          arXiv
+        </a>
         <span style="display:inline-flex; align-items:center; gap:8px; padding:11px 22px; border-radius:4px; background:rgba(255,255,255,.1); border:1px solid rgba(255,255,255,.2); color:rgba(255,255,255,.62); font-weight:600; font-size:1rem; cursor:not-allowed;">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.85 9.73.5.1.68-.22.68-.49l-.01-1.7c-2.78.62-3.37-1.37-3.37-1.37-.46-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.37-2.22-.26-4.55-1.14-4.55-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.02 10.02 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>
           Code <span style="font-size:.74em; font-weight:600; opacity:.85;">soon</span>
@@ -553,7 +553,7 @@
     <div style="width:min(100%,1100px); margin:0 auto; display:flex; flex-wrap:wrap; align-items:center; justify-content:center; gap:24px;">
       <div style="display:flex; flex-wrap:wrap; gap:10px;">
         <a href="chord.pdf" target="_blank" rel="noopener noreferrer" style="display:inline-flex; align-items:center; gap:7px; text-decoration:none; padding:9px 16px; border-radius:4px; background:var(--nv-green); color:var(--nv-black); font-weight:600; font-size:.9rem;">Paper</a>
-        <span style="display:inline-flex; align-items:center; gap:6px; padding:9px 16px; border-radius:4px; border:1px solid rgba(255,255,255,.2); color:rgba(255,255,255,.55); font-weight:600; font-size:.9rem; cursor:not-allowed;"><img src="assets/pics/arxiv.svg" alt="" aria-hidden="true" style="height:16px; width:auto; display:block;"> arXiv <span style="font-size:.74em;">soon</span></span>
+        <a href="https://arxiv.org/abs/2607.00033" target="_blank" rel="noopener noreferrer" style="display:inline-flex; align-items:center; gap:6px; padding:9px 16px; border-radius:4px; border:1px solid rgba(255,255,255,.35); color:#fff; font-weight:600; font-size:.9rem; text-decoration:none;"><img src="assets/pics/arxiv.svg" alt="" aria-hidden="true" style="height:16px; width:auto; display:block;"> arXiv</a>
         <span style="display:inline-flex; align-items:center; gap:6px; padding:9px 16px; border-radius:4px; border:1px solid rgba(255,255,255,.2); color:rgba(255,255,255,.55); font-weight:600; font-size:.9rem; cursor:not-allowed;">Code <span style="font-size:.74em;">soon</span></span>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Link the CHORD page arXiv buttons to https://arxiv.org/abs/2607.00033.
- Remove the disabled `soon` state from the hero and footer arXiv controls.

## Impact
Visitors can now open the CHORD arXiv abstract directly from the project page while the local PDF and Code placeholders remain unchanged.

## Validation
- Ran `git diff --check`.
- Confirmed both arXiv links are present in `docs/chord/index.html`.