### PR TITLE
docs: note training time and accelerated release timeline

### DIFF
--- a/robotic_grounding/README.md
+++ b/robotic_grounding/README.md
@@ -423,6 +423,8 @@ Whole-body ReconHand — the three-stage retarget → plan → train recipe
 (warm-up → contact grounding → finetune), documented per sequence in
 [`v2d_whole_body/EXAMPLE_SEQUENCES.md`](source/robotic_grounding/robotic_grounding/tasks/v2d_whole_body/EXAMPLE_SEQUENCES.md).
 
+> The current release uses Isaac Lab and PPO for simulation and RL and may require longer training to converge. The accelerated implementation reported in the paper, which achieves approximately two-hour training times, is currently under internal review and targeted for release in September 2026.
+
 ## RL Tasks
 - `Sharpa-V2D-v0-Play`
 - `Sharpa-V2D-v0`


### PR DESCRIPTION
## Summary

Ports the note from #151 to `release/0.2.0`.

Adds a callout to `robotic_grounding/README.md` clarifying that the current release uses Isaac Lab + PPO and may require longer training to converge, and that the accelerated implementation reported in the paper (~two-hour training) is under internal review with a targeted September 2026 release.

## Changes

- `robotic_grounding/README.md`: one callout added to the Whole-body ReconHand section, above `## RL Tasks`.

## Test plan

Documentation-only change; no code paths affected.