### PR TITLE
[robotic_grounding] enable object orientation tracking for ReconBody

### DIFF
--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2d_whole_body/config/sonic/g1/g1_sonic_env_cfg.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2d_whole_body/config/sonic/g1/g1_sonic_env_cfg.py
@@ -543,6 +543,11 @@ class G1SonicReconBodyRewardsCfg(G1SonicRewardsCfg):
         weight=1.0,
         params={"command_name": "motion", "std": 0.2},
     )
+    motion_object_orientation_error_exp = RewTerm(
+        func=tracking_rewards.motion_object_orientation_error_exp,
+        weight=1.0,
+        params={"command_name": "motion", "std": 0.4},
+    )
     motion_progress = RewTerm(
         func=tracking_rewards.motion_progress,
         weight=1.0,

--- a/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2d_whole_body/tests/test_sonic_g1_env.py
+++ b/robotic_grounding/source/robotic_grounding/robotic_grounding/tasks/v2d_whole_body/tests/test_sonic_g1_env.py
@@ -11,7 +11,11 @@ from robotic_grounding.tests.utils import APP_IS_READY
 if APP_IS_READY:
     from isaaclab.envs import ManagerBasedRLEnv
     from robotic_grounding.assets import WHOLE_BODY_EXAMPLE_MOTION
-    from robotic_grounding.tasks.v2d_whole_body import G1SonicEnvCfg
+    from robotic_grounding.tasks.v2d_whole_body import (
+        G1SonicEnvCfg,
+        G1SonicReconBodyEnvCfg,
+    )
+    from robotic_grounding.tasks.v2d_whole_body.mdp.rewards import tracking_rewards
 
 
 @unittest.skipIf(not APP_IS_READY, "App is not ready")
@@ -114,6 +118,53 @@ class TestSonicG1Env(unittest.TestCase):
         self.assertEqual(
             truncated.shape[0], self.env.num_envs, "Truncated should match num_envs"
         )
+
+
+@unittest.skipIf(not APP_IS_READY, "App is not ready")
+class TestSonicG1ReconBodyRewards(unittest.TestCase):
+    """Test the ReconBody object-pose reward composition."""
+
+    env: Any
+    cfg: Any
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Create a ReconBody environment for reward-manager checks."""
+        cls.cfg = G1SonicReconBodyEnvCfg(scene_config_path=WHOLE_BODY_EXAMPLE_MOTION)
+        cls.cfg.scene.num_envs = 1
+        cls.env = ManagerBasedRLEnv(cfg=cls.cfg)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Clean up the environment after all tests."""
+        cls.env.close()
+
+    def test_object_pose_reward_composition(self) -> None:
+        """Test separate position and orientation tracking terms are configured."""
+        position_term = self.cfg.rewards.motion_object_position_error_exp
+        orientation_term = self.cfg.rewards.motion_object_orientation_error_exp
+        self.assertIsNot(position_term, orientation_term)
+
+        self.assertIs(
+            position_term.func, tracking_rewards.motion_object_position_error_exp
+        )
+        self.assertEqual(position_term.weight, 1.0)
+        self.assertEqual(position_term.params, {"command_name": "motion", "std": 0.2})
+
+        self.assertIs(
+            orientation_term.func,
+            tracking_rewards.motion_object_orientation_error_exp,
+        )
+        self.assertEqual(orientation_term.weight, 1.0)
+        self.assertEqual(
+            orientation_term.params, {"command_name": "motion", "std": 0.4}
+        )
+
+    def test_object_pose_rewards_are_active(self) -> None:
+        """Test both object-pose terms reach the runtime reward manager."""
+        active_terms = self.env.reward_manager.active_terms
+        self.assertIn("motion_object_position_error_exp", active_terms)
+        self.assertIn("motion_object_orientation_error_exp", active_terms)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- PR title: [robotic_grounding] enable object orientation tracking for ReconBody -->

## Summary

- Enable the existing `motion_object_orientation_error_exp` primitive in `G1SonicReconBodyRewardsCfg`.
- Add a focused regression test for the position/orientation composition and active runtime reward manager.
- Keep the existing object-position reward unchanged.

## Rationale

ReconBody already tracks object position, while the repository's existing object-orientation primitive is not included in its reward composition. The CHORD paper describes the task objective as tracking object pose in `SE(3)`.

This change uses two independent exponential kernels:

`exp(-||delta_position||^2 / 0.2^2) + exp(-theta^2 / 0.4^2)`.

It therefore aligns ReconBody with the paper's object-pose objective, but it is not a formula-level reproduction of the paper's single joint `SE(3)` exponential kernel.

Adding the proposed `weight = 1.0` term raises the maximum object-pose reward contribution from `1.0` to `2.0` when both errors are zero. The paper does not specify this weight or `std = 0.4`: the weight is proposed for consistency with the existing position and orientation-tracking term weights, and the standard deviation is inferred from the existing ReconBody anchor and end-effector orientation kernels. Maintainer confirmation of both values is requested.

## Scope

- Keeps `motion_object_position_error_exp` with its existing function, `weight = 1.0`, and `std = 0.2`.
- Reuses the existing official orientation primitive without changing its mathematics.
- Does not change observations, actions, resets, curriculum, VOC, terminations, or any other reward.
- Adds no dependency, private task, private path, data, asset, checkpoint, generated output, or object/task-specific special case.
- This is a general ReconBody configuration fix.

## Test plan

- [x] `robotic_grounding/**` component pre-commit passed.
- [x] Changed-file pre-commit passed.
- [x] `git diff --check` passed.
- [x] `python3 -m compileall -q robotic_grounding/source` passed.
- [x] Static composition assertions passed.

## Checklist

- [x] Commit is signed off under the configured contributor identity.
- [x] Tests were added for the behavior change.
- [x] No documentation change is needed because the existing primitive reward table already documents object-orientation tracking; this PR only enables its ReconBody composition.
